### PR TITLE
build: prebuilt release binaries + protoc setup for source builds

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     name: Lint & Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       # Pin nightly so rustfmt rules don't drift between CI and contributor machines.
       # Bump together with the nightly used for `cargo +nightly fmt` locally.
@@ -30,11 +30,11 @@ jobs:
           toolchain: nightly-2026-04-22
           components: rustfmt
 
-      - uses: dtolnay/rust-toolchain@1.95.0
+      - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
         with:
           components: clippy
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       # lance-encoding (via lancedb) compiles protobuf in its build script.
       - name: Install protoc
@@ -56,11 +56,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint-test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: dtolnay/rust-toolchain@1.95.0
+      - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
@@ -68,7 +68,7 @@ jobs:
       # Cache the embedder/reranker weights so we don't re-download ~hundreds of MB from
       # the Hugging Face Hub every run. fastembed downloads into ./.fastembed_cache.
       - name: Cache fastembed models
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .fastembed_cache
           key: fastembed-models-v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,5 @@
 name: Release
 
-# Build prebuilt binaries and attach them to a GitHub Release. protoc (needed by lance's
-# build scripts) is installed on the runner, so end users download a ready-made binary and
-# never compile lance themselves. Mirrors the release flow of huggingface/hf-mount.
 on:
   push:
     tags: ["v*"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,205 @@
+name: Release
+
+# Build prebuilt binaries and attach them to a GitHub Release. protoc (needed by lance's
+# build scripts) is installed on the runner, so end users download a ready-made binary and
+# never compile lance themselves. Mirrors the release flow of huggingface/hf-mount.
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump type (leave 'auto' to detect from commit messages)"
+        required: true
+        type: choice
+        default: auto
+        options:
+          - auto
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # Manual dispatch path: bump Cargo.toml, commit, tag, push. Downstream jobs run in this
+  # same run (keyed off needs.bump) because a tag pushed with GITHUB_TOKEN doesn't cascade
+  # into a fresh workflow run, so the `push: tags` trigger wouldn't fire.
+  bump:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-22.04
+    outputs:
+      new_tag: ${{ steps.version.outputs.tag }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Detect bump type from commits
+        id: detect
+        run: |
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          RANGE="HEAD"
+          [ -n "$LAST_TAG" ] && RANGE="${LAST_TAG}..HEAD"
+          COMMITS=$(git log --pretty=format:"%s" "$RANGE")
+          BUMP="patch"
+          if echo "$COMMITS" | grep -qiE "^feat(\(.*\))?!:|BREAKING CHANGE"; then
+            BUMP="major"
+          elif echo "$COMMITS" | grep -qiE "^feat(\(.*\))?:"; then
+            BUMP="minor"
+          elif echo "$COMMITS" | grep -qiE "^(fix|perf)(\(.*\))?:"; then
+            BUMP="patch"
+          fi
+          echo "detected=$BUMP" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve bump type
+        id: bump
+        run: |
+          BUMP="${{ inputs.bump }}"
+          [ "$BUMP" = "auto" ] && BUMP="${{ steps.detect.outputs.detected }}"
+          echo "type=$BUMP" >> "$GITHUB_OUTPUT"
+
+      - name: Compute new version
+        id: version
+        run: |
+          CURRENT=$(grep -m1 '^version' Cargo.toml | sed 's/.*"\(.*\)"/\1/')
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+          case "${{ steps.bump.outputs.type }}" in
+            major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+            minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+            patch) PATCH=$((PATCH + 1)) ;;
+          esac
+          NEW="${MAJOR}.${MINOR}.${PATCH}"
+          echo "new=$NEW" >> "$GITHUB_OUTPUT"
+          echo "tag=v${NEW}" >> "$GITHUB_OUTPUT"
+
+      - name: Bump Cargo.toml, commit, tag, push
+        run: |
+          sed -i "0,/^version = \".*\"/s//version = \"${{ steps.version.outputs.new }}\"/" Cargo.toml
+          cargo generate-lockfile
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Cargo.toml Cargo.lock
+          git commit -m "chore: release ${{ steps.version.outputs.tag }}"
+          git tag "${{ steps.version.outputs.tag }}"
+          git push origin HEAD:main --tags
+
+  build-linux:
+    name: Build Linux (${{ matrix.arch }})
+    needs: [bump]
+    if: |
+      always() &&
+      (startsWith(github.ref, 'refs/tags/') || needs.bump.result == 'success')
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            arch: x86_64
+          - target: aarch64-unknown-linux-gnu
+            arch: aarch64
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ needs.bump.outputs.new_tag || github.ref }}
+
+      - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: release-${{ matrix.target }}
+
+      # protoc runs on the host (build-time tool), so the host package serves both targets.
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Install cross-compilation tools
+        if: matrix.arch == 'aarch64'
+        run: |
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+          echo '[target.aarch64-unknown-linux-gnu]' >> ~/.cargo/config.toml
+          echo 'linker = "aarch64-linux-gnu-gcc"' >> ~/.cargo/config.toml
+
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Package
+        run: |
+          mkdir -p dist
+          cp "target/${{ matrix.target }}/release/funes" "dist/funes-${{ matrix.arch }}-linux"
+          chmod +x dist/*
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: linux-${{ matrix.arch }}
+          path: dist/
+
+  build-macos:
+    name: Build macOS (arm64)
+    needs: [bump]
+    if: |
+      always() &&
+      (startsWith(github.ref, 'refs/tags/') || needs.bump.result == 'success')
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ needs.bump.outputs.new_tag || github.ref }}
+
+      - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+        with:
+          targets: aarch64-apple-darwin
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: release-aarch64-apple-darwin
+
+      - name: Install protoc
+        run: brew install protobuf
+
+      - name: Build
+        run: cargo build --release --target aarch64-apple-darwin
+
+      - name: Package
+        run: |
+          mkdir -p dist
+          cp target/aarch64-apple-darwin/release/funes dist/funes-arm64-apple-darwin
+          chmod +x dist/*
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: macos-arm64
+          path: dist/
+
+  release:
+    name: Create Release
+    needs: [bump, build-linux, build-macos]
+    if: |
+      always() &&
+      needs.build-linux.result == 'success' &&
+      needs.build-macos.result == 'success' &&
+      (startsWith(github.ref, 'refs/tags/') || needs.bump.result == 'success')
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: artifacts
+          pattern: "{linux-*,macos-*}"
+          merge-multiple: true
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ needs.bump.outputs.new_tag || github.ref_name }}"
+          gh release create "$TAG" artifacts/* \
+            --repo "${{ github.repository }}" \
+            --title "$TAG" \
+            --generate-notes

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ build/
 
 # fastembed model cache (downloaded ONNX weights)
 .fastembed_cache/
+
+# protoc downloaded by scripts/bootstrap-protoc.sh
+/.tools/

--- a/README.md
+++ b/README.md
@@ -53,8 +53,7 @@ parser to the same shape, not touching the index or query path.
 
 ## Install
 
-Prebuilt binaries are on [GitHub Releases](https://github.com/huggingface/funes/releases) —
-no build step, no `protoc`:
+Prebuilt binaries are on [GitHub Releases](https://github.com/huggingface/funes/releases):
 
 | Platform | Binary |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -51,6 +51,24 @@ into a generic turn/block shape. Everything downstream — chunk → embed → s
 source-agnostic and operates on that shape. Adding another framework means writing one new
 parser to the same shape, not touching the index or query path.
 
+## Install
+
+Prebuilt binaries are on [GitHub Releases](https://github.com/huggingface/funes/releases) —
+no build step, no `protoc`:
+
+| Platform | Binary |
+| --- | --- |
+| Linux x86_64 | `funes-x86_64-linux` |
+| Linux aarch64 | `funes-aarch64-linux` |
+| macOS Apple Silicon | `funes-arm64-apple-darwin` |
+
+```bash
+curl -fsSL https://github.com/huggingface/funes/releases/latest/download/funes-x86_64-linux -o funes
+chmod +x funes && ./funes status
+```
+
+To build it yourself instead, see [Building from source](#building-from-source).
+
 ## Use
 
 > `funes` is a single Rust binary (`lancedb` + `fastembed-rs`, CPU).
@@ -70,6 +88,24 @@ funes mcp                                         # run as an MCP server over st
 `→ get <session_id> <turn_uuid>` line for drilling down into the full surrounding turns. An
 agent consumes funes either by shelling out to the CLI or via the `recall` / `get` MCP tools
 (`funes mcp`).
+
+## Building from source
+
+Needs a Rust toolchain and **`protoc`** — `lance`'s build scripts compile protobuf at
+build time (the finished binary does not need it). Install it one of two ways:
+
+```bash
+# System-wide:
+sudo apt-get install -y protobuf-compiler   # Debian/Ubuntu
+brew install protobuf                        # macOS
+
+# …or repo-local, no sudo (downloads a pinned protoc into .tools/):
+./scripts/bootstrap-protoc.sh
+export PROTOC="$PWD/.tools/protoc/bin/protoc"
+```
+
+Then `cargo build --release` (binary at `target/release/funes`); `cargo test` runs the
+suite. The integration test downloads the embedder/reranker weights on first run.
 
 ## Notes
 

--- a/scripts/bootstrap-protoc.sh
+++ b/scripts/bootstrap-protoc.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Download a pinned protoc into .tools/protoc so funes can be built without a system-wide
+# install. lance's build scripts need protoc at build time; the funes binary does not.
+#
+# Usage:
+#   ./scripts/bootstrap-protoc.sh
+#   export PROTOC="$PWD/.tools/protoc/bin/protoc"
+#   cargo build
+set -euo pipefail
+
+VERSION=28.3
+dest=".tools/protoc"
+
+case "$(uname -s)" in
+  Linux) os=linux ;;
+  Darwin) os=osx ;;
+  *) echo "unsupported OS $(uname -s) — install protoc manually" >&2; exit 1 ;;
+esac
+case "$(uname -m)" in
+  x86_64 | amd64) arch=x86_64 ;;
+  aarch64 | arm64) arch=aarch_64 ;;
+  *) echo "unsupported arch $(uname -m) — install protoc manually" >&2; exit 1 ;;
+esac
+
+zip="protoc-${VERSION}-${os}-${arch}.zip"
+url="https://github.com/protocolbuffers/protobuf/releases/download/v${VERSION}/${zip}"
+
+echo "downloading $url"
+rm -rf "$dest" && mkdir -p "$dest"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+curl -fsSL -o "$tmp/protoc.zip" "$url"
+unzip -q "$tmp/protoc.zip" -d "$dest"
+
+echo
+echo "installed $("$dest/bin/protoc" --version) at $dest"
+echo "now run:  export PROTOC=\"$PWD/$dest/bin/protoc\""


### PR DESCRIPTION
protoc is a build-time-only dependency (lance's build scripts compile protobuf); the finished binary doesn't need it. cargo can't inject PROTOC into a transitive dependency's build script, so it must exist before the build.

- Add a release workflow (modeled on huggingface/hf-mount) that builds binaries for Linux x86_64/aarch64 and macOS arm64 on a version tag or workflow_dispatch, then attaches them to the GitHub Release via the gh CLI. End users download a binary and never compile lance or need protoc.
- Document install (prebuilt) and building from source, with a no-sudo scripts/bootstrap-protoc.sh that downloads a pinned protoc into .tools/.
- Adopt action-hardening convention: pin every GitHub Action to a commit SHA (in release.yml and the existing ci.yml) and add a dependabot github-actions group to keep the pins current.