### PR TITLE
ci: drop aarch64-linux release target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,12 +94,11 @@ jobs:
       (startsWith(github.ref, 'refs/tags/') || needs.bump.result == 'success')
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
             arch: x86_64
-          - target: aarch64-unknown-linux-gnu
-            arch: aarch64
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -113,16 +112,8 @@ jobs:
         with:
           key: release-${{ matrix.target }}
 
-      # protoc runs on the host (build-time tool), so the host package serves both targets.
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-
-      - name: Install cross-compilation tools
-        if: matrix.arch == 'aarch64'
-        run: |
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-          echo '[target.aarch64-unknown-linux-gnu]' >> ~/.cargo/config.toml
-          echo 'linker = "aarch64-linux-gnu-gcc"' >> ~/.cargo/config.toml
 
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}

--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ Prebuilt binaries are on [GitHub Releases](https://github.com/huggingface/funes/
 | Platform | Binary |
 | --- | --- |
 | Linux x86_64 | `funes-x86_64-linux` |
-| Linux aarch64 | `funes-aarch64-linux` |
 | macOS Apple Silicon | `funes-arm64-apple-darwin` |
 
 ```bash


### PR DESCRIPTION
The `v0.1.0` release run failed: `openssl-sys` (pulled transitively via `native-tls` from `hf-hub` and `reqwest`) can't cross-compile to `aarch64-unknown-linux-gnu` without a target OpenSSL sysroot.

Rather than vendor OpenSSL, drop the aarch64-linux target. Releases now ship **x86_64-linux + macOS arm64**. Also adds `fail-fast: false` so one target failing no longer cancels the others (which is what masked this as two Linux failures).

aarch64-linux can be re-added later via vendored OpenSSL (`openssl-sys/vendored`) or by moving the TLS stack to rustls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)