### PR TITLE
chore: reset version to 0.1.0 for first release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2211,7 +2211,7 @@ dependencies = [
 
 [[package]]
 name = "funes"
-version = "0.2.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "funes"
-version = "0.2.0"
+version = "0.1.0"
 edition = "2021"
 description = "Recall over your past AI agent sessions — the man who forgets nothing, with discrimination."
 


### PR DESCRIPTION
Two failed release runs each ran the `bump` job, walking `Cargo.toml` `0.0.1 → 0.1.0 → 0.2.0` without ever publishing a release. Reset to `0.1.0` so the first actual release is sensibly numbered.

After this merges, the release will be cut via a **tag push** of `v0.1.0` at the merge commit (skips the `bump` job, no further version churn), and the orphan `v0.2.0` tag (which points at a stale pre-fix commit, no release attached) will be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)