### PR TITLE
ci: cancellable builds, mold linker, timeouts, and path filters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,12 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    paths:
+      - "src/**"
+      - "tests/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/ci.yml"
   push:
     branches: [main]
 
@@ -15,11 +21,13 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: "1"
 
 jobs:
   lint-test:
     name: Lint & Unit Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
@@ -35,6 +43,9 @@ jobs:
           components: clippy
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      # Faster, lower-memory linker — keeps the heavy lance/onnxruntime link in budget.
+      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
 
       # lance-encoding (via lancedb) compiles protobuf in its build script.
       - name: Install protoc
@@ -55,12 +66,15 @@ jobs:
     name: Integration Test (real embedder)
     runs-on: ubuntu-latest
     needs: lint-test
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
 
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
     name: Build Linux (${{ matrix.arch }})
     needs: [compute]
     if: |
-      always() &&
+      !cancelled() &&
       (startsWith(github.ref, 'refs/tags/') || needs.compute.result == 'success'
         || github.event_name == 'pull_request')
     # 24.04 (glibc 2.39): the prebuilt onnxruntime pulled by ort_sys/fastembed needs the
@@ -138,7 +138,7 @@ jobs:
     name: Build macOS (arm64)
     needs: [compute]
     if: |
-      always() &&
+      !cancelled() &&
       (startsWith(github.ref, 'refs/tags/') || needs.compute.result == 'success'
         || github.event_name == 'pull_request')
     runs-on: macos-14
@@ -181,7 +181,7 @@ jobs:
     name: Publish Release
     needs: [compute, build-linux, build-macos]
     if: |
-      always() &&
+      !cancelled() &&
       needs.build-linux.result == 'success' &&
       needs.build-macos.result == 'success' &&
       (startsWith(github.ref, 'refs/tags/') || needs.compute.result == 'success')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,12 @@ on:
     tags: ["v*"]
   pull_request:
     branches: [main]
+    paths:
+      - "src/**"
+      - "tests/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/release.yml"
   workflow_dispatch:
     inputs:
       bump:
@@ -29,6 +35,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: "1"
 
 jobs:
   # Dispatch-only: work out the next version. Nothing is written or pushed here — the
@@ -38,6 +45,7 @@ jobs:
   compute:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     outputs:
       version: ${{ steps.version.outputs.new }}
       tag: ${{ steps.version.outputs.tag }}
@@ -94,6 +102,7 @@ jobs:
     # 24.04 (glibc 2.39): the prebuilt onnxruntime pulled by ort_sys/fastembed needs the
     # glibc 2.38+ __isoc23_* symbols, so linking fails on 22.04.
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -110,6 +119,9 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: release-${{ matrix.target }}
+
+      # Faster, lower-memory linker — keeps the heavy lance/onnxruntime link in budget.
+      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
 
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
@@ -142,6 +154,7 @@ jobs:
       (startsWith(github.ref, 'refs/tags/') || needs.compute.result == 'success'
         || github.event_name == 'pull_request')
     runs-on: macos-14
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
@@ -186,6 +199,7 @@ jobs:
       needs.build-macos.result == 'success' &&
       (startsWith(github.ref, 'refs/tags/') || needs.compute.result == 'success')
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:


### PR DESCRIPTION
A few CI improvements, several borrowed from lancedb.

**`!cancelled()` instead of `always()`** (`release.yml`)
The build/publish jobs need a status-check function in `if:` so they run when the `compute` dependency is skipped (tag/PR builds). `always()` also means "run even when the workflow is cancelled", so cancelling a run didn't stop in-progress builds (verified: a build completed `success` ~7 min after a cancel). `!cancelled()` keeps the skipped-dependency behaviour but lets cancellation actually stop the jobs.

**mold linker** (`ci.yml` + `release.yml`, Linux jobs)
`rui314/setup-mold` — much faster and lower-memory linking, easing the heavy lance/onnxruntime link. macOS keeps its own linker.

**`timeout-minutes` on every job**
So a hung or runaway build can't run for hours (ci 45m, build-linux 60m, build-macos 45m, compute 10m, publish 15m).

**`RUST_BACKTRACE=1`**
Usable backtraces on test failures.

**`pull_request` path filters**
Non-Rust PRs (e.g. README-only) no longer trigger the expensive builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)