### PR TITLE
feat: local-first onboarding and a stateful remote store

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
     needs: lint-test
     timeout-minutes: 45
     env:
-      # The sync round-trip test awaits one large combined future (embed + Xet upload + lance);
+      # The push round-trip test awaits one large combined future (embed + Xet upload + lance);
       # it overflows the default ~2 MB test-thread stack under the CI toolchain. Give it headroom.
       RUST_MIN_STACK: "16777216"
     steps:
@@ -89,7 +89,7 @@ jobs:
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
-      # sync's pre-publish secret gate shells out to trufflehog (fail-closed), so the
+      # push's pre-publish secret gate shells out to trufflehog (fail-closed), so the
       # round-trip test below needs the binary on PATH. Pinned to the version used locally.
       - name: Install trufflehog
         run: |
@@ -116,10 +116,10 @@ jobs:
 
       # Gated: create→append→recall→clear against a unique scratch path. Skips without the
       # secret; cleans up the scratch path itself.
-      - name: Sync round-trip test
+      - name: Push round-trip test
         env:
           HF_FUNES_TEST_TOKEN: ${{ secrets.HF_FUNES_TEST_TOKEN }}
-        run: cargo test --profile ci --test sync_round_trip -- --nocapture
+        run: cargo test --profile ci --test push_round_trip -- --nocapture
 
       - name: Save fastembed models
         if: ${{ !cancelled() && github.ref == 'refs/heads/main' && steps.fastembed.outputs.cache-hit != 'true' }}

--- a/README.md
+++ b/README.md
@@ -113,15 +113,27 @@ reaches for prior decisions and rationale without you pasting context. (The repo
 an optional skill at [skills/funes/](skills/funes/) for richer recall-triggering and a
 `/funes` command — optional, since the MCP server already carries when-to-use instructions.)
 
-**4. Share it across machines or a team (optional).** Publish your index to a dataset repo
-you own on the Hugging Face Hub, then read it back over `hf://`:
+**4. Share it across machines or a team (optional).** Attach a dataset repo you own on the
+Hugging Face Hub as your **active store**. From then on `index` publishes to it and `recall`
+reads it — no per-command flags:
 
 ```bash
-funes sync --store hf://datasets/<org>/<repo>           # push local → your HF dataset repo
-funes recall "..." --store hf://datasets/<org>/<repo>   # read from the shared tier
+funes use acme/kb        # attach hf://datasets/acme/kb as the active store (persisted in funes.json)
+funes index              # builds locally, then publishes to the active remote
+funes recall "..."       # reads the active remote
+funes use local          # detach — back to the local index
 ```
 
-You never need the Hub to use funes locally — it's a tier you opt into.
+`funes use` is the one place you name a store; everything else just uses it. To **query a
+different remote for a single call** — say, someone's published memories on a topic — without
+changing your default, pass `--remote`:
+
+```bash
+funes recall "..." --remote other-org/subject-kb
+```
+
+`push` is a manual re-publish to the active remote (`index` already publishes on its own). You
+never need the Hub to use funes locally — it's a tier you opt into.
 
 ## Building from source
 

--- a/README.md
+++ b/README.md
@@ -64,30 +64,64 @@ Prebuilt binaries are on [GitHub Releases](https://github.com/huggingface/funes/
 
 ```bash
 curl -fsSL https://github.com/huggingface/funes/releases/latest/download/funes-x86_64-linux -o funes
-chmod +x funes && ./funes status
+chmod +x funes && ./funes recall "how do I get started with funes"
 ```
+
+funes works the moment it lands: with no index yet, `recall` (and `get` / `list`) answer
+from a small **built-in guide to funes itself**, so you can feel recall before indexing
+anything. `funes status` tells you whether you're reading that built-in guide or your own index.
 
 To build it yourself instead, see [Building from source](#building-from-source).
 
-## Use
+## Getting started
 
-> `funes` is a single Rust binary (`lancedb` + `fastembed-rs`, CPU).
+> `funes` is a single Rust binary (`lance` + `fastembed-rs`, CPU). `index` writes; `recall`
+> / `list` / `get` / `status` read.
+
+**1. Index your own history.**
 
 ```bash
-funes index                                       # index ~/.claude/projects (incremental)
+funes index                                       # parse → chunk → embed ~/.claude/projects → ~/.funes
+```
+
+This replaces the built-in guide with recall over your real sessions. Re-run it to pick up
+new work — it's incremental (only new turns are embedded), so it's cheap to run often.
+
+**2. Recall.**
+
+```bash
 funes recall "how do we parse transcripts"        # hybrid → rerank → recency → neighbors
-funes recall "the lancedb schema" --type tool_use --project <project>
+funes recall "the lance schema" --type tool_use --project <project>
 funes list --project <project>                    # browse indexed sessions
 funes get <session_id> <turn_uuid>                # expand a hit into its full surrounding turns
 funes status
-funes mcp                                         # run as an MCP server over stdio
 ```
 
-`index` writes; `recall` / `list` / `get` / `status` read. `recall` narrows with `--type`
-(`text|thinking|tool_use|tool_result`) and `--project`, and each hit prints a
-`→ get <session_id> <turn_uuid>` line for drilling down into the full surrounding turns. An
-agent consumes funes either by shelling out to the CLI or via the `recall` / `get` MCP tools
-(`funes mcp`).
+`recall` narrows with `--type` (`text|thinking|tool_use|tool_result`) and `--project`, and
+each hit prints a `→ get <session_id> <turn_uuid>` line for drilling into the full
+surrounding turns.
+
+**3. Let your agent recall on its own.** Register funes as an MCP server, so Claude Code (or
+Cursor, …) gets `recall` and `get` as tools:
+
+```bash
+claude mcp add funes -- /path/to/funes mcp        # `funes mcp` runs the stdio server
+```
+
+New sessions then get the tools **plus** instructions on when to use them, so the agent
+reaches for prior decisions and rationale without you pasting context. (The repo also ships
+an optional skill at [skills/funes/](skills/funes/) for richer recall-triggering and a
+`/funes` command — optional, since the MCP server already carries when-to-use instructions.)
+
+**4. Share it across machines or a team (optional).** Publish your index to a dataset repo
+you own on the Hugging Face Hub, then read it back over `hf://`:
+
+```bash
+funes sync --store hf://datasets/<org>/<repo>           # push local → your HF dataset repo
+funes recall "..." --store hf://datasets/<org>/<repo>   # read from the shared tier
+```
+
+You never need the Hub to use funes locally — it's a tier you opt into.
 
 ## Building from source
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,74 @@
+//! The funes config (`funes.json`): the persisted active store. Lives in `$FUNES_HOME` next to the
+//! local index. It holds the remote this host is attached to — its absence means "local only".
+//! This is the stateful replacement for the old `$FUNES_STORE` env var: set once with `funes use`,
+//! honored by every command (read source, push target, the MCP server's recall target).
+
+use crate::dataset;
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct Config {
+    /// The attached remote (`hf://datasets/<org>/<repo>`). `None` ⇒ recall/push use the local index.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote: Option<String>,
+}
+
+/// Path to `funes.json` under funes's home directory.
+pub fn path() -> PathBuf {
+    dataset::funes_dir().join("funes.json")
+}
+
+/// Load the config, defaulting to empty (local) when the file is absent or unreadable.
+pub fn load() -> Config {
+    load_from(&path())
+}
+
+/// Persist the config, creating the parent directory if needed.
+pub fn save(cfg: &Config) -> Result<()> {
+    save_to(&path(), cfg)
+}
+
+/// Pure core of [`load`]: read+parse `p`, or the default (local) when it's absent/unreadable.
+fn load_from(p: &Path) -> Config {
+    std::fs::read_to_string(p)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default()
+}
+
+/// Pure core of [`save`]: write `cfg` to `p`, creating its parent directory.
+fn save_to(p: &Path, cfg: &Config) -> Result<()> {
+    if let Some(dir) = p.parent() {
+        std::fs::create_dir_all(dir)?;
+    }
+    std::fs::write(p, serde_json::to_string_pretty(cfg)?).context("writing funes.json")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn save_then_load_round_trips_the_remote() {
+        let home = tempfile::tempdir().unwrap();
+        let p = home.path().join("funes.json");
+
+        // Absent file → empty (local).
+        assert_eq!(load_from(&p).remote, None);
+
+        save_to(
+            &p,
+            &Config {
+                remote: Some("hf://datasets/acme/kb".into()),
+            },
+        )
+        .unwrap();
+        assert_eq!(load_from(&p).remote.as_deref(), Some("hf://datasets/acme/kb"));
+
+        // Clearing it (back to local).
+        save_to(&p, &Config { remote: None }).unwrap();
+        assert_eq!(load_from(&p).remote, None);
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,5 @@
-//! The funes config (`funes.json`): the persisted active store. Lives in `$FUNES_HOME` next to the
-//! local index. It holds the remote this host is attached to — its absence means "local only".
-//! This is the stateful replacement for the old `$FUNES_STORE` env var: set once with `funes use`,
-//! honored by every command (read source, push target, the MCP server's recall target).
+//! The funes config (`funes.json` in `$FUNES_HOME`): the attached remote, or absent for local-only.
+//! Set with `funes use`; read by recall, push, and the MCP server.
 
 use crate::dataset;
 use anyhow::{Context, Result};

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -21,9 +21,8 @@ use lance_linalg::distance::MetricType;
 /// The table (Lance dataset) name within a store.
 pub const TABLE: &str = "chunks";
 
-/// funes's home directory: `$FUNES_HOME` if set, else `~/.funes`. Holds `funes.json`, the
-/// incremental state, and the local store. The one bootstrap location — the config can't say
-/// where the config lives, so this is set by env (or defaulted), not by config.
+/// funes's home directory: `$FUNES_HOME`, else `~/.funes`. Holds `funes.json`, the incremental
+/// state, and the local store.
 pub fn funes_dir() -> PathBuf {
     if let Ok(d) = std::env::var("FUNES_HOME") {
         return PathBuf::from(d);

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -1,6 +1,6 @@
 //! Shared store helpers: the local store location, opening a dataset, plain scans, and building the
-//! FTS/IVF indexes. The local store lives at `$FUNES_DB`/`~/.funes` → `…/lancedb`, holding the
-//! `chunks` Lance dataset.
+//! FTS/IVF indexes. funes's home is `$FUNES_HOME`/`~/.funes` — it holds the config (`funes.json`),
+//! the incremental state, and the local store at `…/lancedb` (the `chunks` Lance dataset).
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -21,9 +21,11 @@ use lance_linalg::distance::MetricType;
 /// The table (Lance dataset) name within a store.
 pub const TABLE: &str = "chunks";
 
-/// Base directory for the local store: `$FUNES_DB` if set, else `~/.funes`.
+/// funes's home directory: `$FUNES_HOME` if set, else `~/.funes`. Holds `funes.json`, the
+/// incremental state, and the local store. The one bootstrap location — the config can't say
+/// where the config lives, so this is set by env (or defaulted), not by config.
 pub fn funes_dir() -> PathBuf {
-    if let Ok(d) = std::env::var("FUNES_DB") {
+    if let Ok(d) = std::env::var("FUNES_HOME") {
         return PathBuf::from(d);
     }
     let home = std::env::var("HOME").unwrap_or_default();

--- a/src/hello.rs
+++ b/src/hello.rs
@@ -1,7 +1,7 @@
 //! The built-in hello-world corpus: a tiny set of onboarding passages funes can recall before
 //! the user has indexed anything. A fresh install runs the real recall pipeline against this, so
 //! the first `funes recall` returns something useful — and the passages double as the
-//! getting-started guide (how to index, recall, wire into an agent, and optionally sync).
+//! getting-started guide (how to index, recall, wire into an agent, and optionally push).
 //!
 //! It's a read-only fallback: the moment `funes index` builds the local store, recall reads the
 //! user's own history and this corpus steps aside (see [`crate::recall`]).
@@ -65,10 +65,11 @@ pub const PASSAGES: &[(&str, &str)] = &[
     ),
     (
         "assistant",
-        "Optional, and later: share your memory across machines or a team by syncing to the \
-         Hugging Face Hub. `funes sync` publishes your local index to a dataset repo you own; \
-         reads then work over `hf://` via `--store hf://datasets/<org>/<repo>`. You never need the \
-         Hub to use funes locally — it's a tier you opt into.",
+        "Optional, and later: share your memory across machines or a team via the Hugging Face \
+         Hub. `funes use <org>/<repo>` attaches a dataset repo you own as your active store — from \
+         then on `index` publishes to it and recall reads it; `funes use local` detaches. To query \
+         a different store for one call without changing your default, pass `recall --remote \
+         <org>/<repo>`. You never need the Hub to use funes locally — it's a tier you opt into.",
     ),
     (
         "assistant",

--- a/src/hello.rs
+++ b/src/hello.rs
@@ -1,0 +1,121 @@
+//! The built-in hello-world corpus: a tiny set of onboarding passages funes can recall before
+//! the user has indexed anything. A fresh install runs the real recall pipeline against this, so
+//! the first `funes recall` returns something useful — and the passages double as the
+//! getting-started guide (how to index, recall, wire into an agent, and optionally sync).
+//!
+//! It's a read-only fallback: the moment `funes index` builds the local store, recall reads the
+//! user's own history and this corpus steps aside (see [`crate::recall`]).
+
+use crate::chunk::Chunk;
+use crate::index::{self, DIM};
+use anyhow::Result;
+use arrow_array::RecordBatchIterator;
+use fastembed::TextEmbedding;
+use lance::dataset::Dataset;
+use tempfile::TempDir;
+
+/// Synthetic session these passages belong to: they surface as `funes/hello` in recall output and
+/// resolve under `funes get hello <turn>`.
+const SESSION: &str = "hello";
+const PROJECT: &str = "funes";
+
+/// The onboarding passages, in reading order, as `(role, text)`. The first is phrased as the
+/// user's question so `list` has a sensible summary line; the rest are guidance. Edit these
+/// freely — they're plain text, embedded fresh at runtime.
+pub const PASSAGES: &[(&str, &str)] = &[
+    ("user", "What is funes and how do I get started?"),
+    (
+        "assistant",
+        "funes gives an AI agent durable, mid-term memory of your past Claude Code sessions. It \
+         indexes your transcripts locally and serves selective, reranked recall: you ask in \
+         natural language and get back the few relevant passages with exact provenance — not a \
+         flood of detail, and never an LLM-rewritten summary.",
+    ),
+    (
+        "assistant",
+        "Build the index first: run `funes index`. It walks ~/.claude/projects, parses each \
+         session, and embeds the turns into a local store at ~/.funes. It's incremental — \
+         re-running it only adds new turns — so it's cheap to run often.",
+    ),
+    (
+        "assistant",
+        "Recall with `funes recall \"<your question>\"`. The pipeline is hybrid vector + BM25 \
+         search, then a cross-encoder rerank, then recency weighting, then neighbor expansion. \
+         Narrow with `--type text|thinking|tool_use|tool_result` and `--project <name>`; tune \
+         breadth with `--k` (results) and `--candidates` (the rerank pool).",
+    ),
+    (
+        "assistant",
+        "Drill into a hit: every recall result prints a `→ get <session_id> <turn_uuid>` line. Run \
+         `funes get <session_id> <turn_uuid>` to expand that hit into its full surrounding turns. \
+         Try it on this corpus: `funes get hello hello-0005`.",
+    ),
+    (
+        "assistant",
+        "Wire funes into your agent so it can recall on its own: register the MCP server with \
+         `claude mcp add funes -- /path/to/funes mcp`. New sessions then get the `recall` and \
+         `get` tools plus instructions on when to use them, so the agent reaches for prior \
+         decisions and rationale on its own — without you pasting context.",
+    ),
+    (
+        "assistant",
+        "Keep recall fresh. The index only updates when `funes index` runs, so the latest turns of \
+         the current session aren't searchable until you re-run it. Re-run it periodically, or add \
+         a Claude Code Stop hook that runs `funes index` after each session.",
+    ),
+    (
+        "assistant",
+        "Optional, and later: share your memory across machines or a team by syncing to the \
+         Hugging Face Hub. `funes sync` publishes your local index to a dataset repo you own; \
+         reads then work over `hf://` via `--store hf://datasets/<org>/<repo>`. You never need the \
+         Hub to use funes locally — it's a tier you opt into.",
+    ),
+    (
+        "assistant",
+        "funes is local-first and deterministic: no LLM in the ingest path, the embedding model is \
+         pinned (BAAI/bge-small-en-v1.5), and the index is a disposable derived artifact you can \
+         always rebuild from your transcripts. The transcripts are the source of truth.",
+    ),
+];
+
+/// Build the hello-world corpus as an ephemeral lance dataset, returning the temp dir that backs
+/// it — keep it alive for as long as the dataset is read. With an `embedder`, passages get real
+/// vectors so `recall` can search them; without one, vectors are zero (enough for `get`/`list`,
+/// which scan columns but never the vector).
+pub async fn dataset(embedder: Option<&mut TextEmbedding>) -> Result<(TempDir, Dataset)> {
+    let ts = chrono::Utc::now().to_rfc3339();
+    let chunks: Vec<Chunk> = PASSAGES
+        .iter()
+        .enumerate()
+        .map(|(i, (role, text))| Chunk {
+            id: format!("{SESSION}-{i:04}"),
+            text: (*text).to_string(),
+            session_id: SESSION.to_string(),
+            project: PROJECT.to_string(),
+            turn_uuid: format!("{SESSION}-{i:04}"),
+            parent_uuid: (i > 0).then(|| format!("{SESSION}-{:04}", i - 1)),
+            seq: i as i64,
+            ts: ts.clone(),
+            role: (*role).to_string(),
+            block_type: "text".to_string(),
+            tool_name: None,
+            source_path: "built-in".to_string(),
+            block_idx: 0,
+            split_idx: 0,
+        })
+        .collect();
+
+    let texts: Vec<&str> = chunks.iter().map(|c| c.text.as_str()).collect();
+    let vectors: Vec<Vec<f32>> = match embedder {
+        Some(e) => e.embed(texts, None)?,
+        None => vec![vec![0.0; DIM as usize]; chunks.len()],
+    };
+
+    let batch = index::build_batch(&chunks, &vectors)?;
+    let schema = batch.schema();
+    let dir = tempfile::tempdir()?;
+    let uri = crate::dataset::table_uri(&dir.path().to_string_lossy());
+    let reader = RecordBatchIterator::new(vec![Ok(batch)], schema);
+    let ds = Dataset::write(reader, &uri, None).await?;
+    Ok((dir, ds))
+}

--- a/src/hello.rs
+++ b/src/hello.rs
@@ -1,10 +1,5 @@
-//! The built-in hello-world corpus: a tiny set of onboarding passages funes can recall before
-//! the user has indexed anything. A fresh install runs the real recall pipeline against this, so
-//! the first `funes recall` returns something useful — and the passages double as the
-//! getting-started guide (how to index, recall, wire into an agent, and optionally push).
-//!
-//! It's a read-only fallback: the moment `funes index` builds the local store, recall reads the
-//! user's own history and this corpus steps aside (see [`crate::recall`]).
+//! The built-in hello-world corpus: onboarding passages recall falls back to when there's no local
+//! index yet, so a fresh install returns something useful. Superseded once `funes index` runs.
 
 use crate::chunk::Chunk;
 use crate::index::{self, DIM};
@@ -19,9 +14,8 @@ use tempfile::TempDir;
 const SESSION: &str = "hello";
 const PROJECT: &str = "funes";
 
-/// The onboarding passages, in reading order, as `(role, text)`. The first is phrased as the
-/// user's question so `list` has a sensible summary line; the rest are guidance. Edit these
-/// freely — they're plain text, embedded fresh at runtime.
+/// The onboarding passages as `(role, text)`. The first is the user's question (so `list` has a
+/// summary line); the rest are guidance.
 pub const PASSAGES: &[(&str, &str)] = &[
     ("user", "What is funes and how do I get started?"),
     (
@@ -79,10 +73,8 @@ pub const PASSAGES: &[(&str, &str)] = &[
     ),
 ];
 
-/// Build the hello-world corpus as an ephemeral lance dataset, returning the temp dir that backs
-/// it — keep it alive for as long as the dataset is read. With an `embedder`, passages get real
-/// vectors so `recall` can search them; without one, vectors are zero (enough for `get`/`list`,
-/// which scan columns but never the vector).
+/// Build the corpus as an ephemeral lance dataset; the returned temp dir backs it (keep alive
+/// while reading). With an `embedder`, passages get real vectors for search; without, zeros.
 pub async fn dataset(embedder: Option<&mut TextEmbedding>) -> Result<(TempDir, Dataset)> {
     let ts = chrono::Utc::now().to_rfc3339();
     let chunks: Vec<Chunk> = PASSAGES

--- a/src/hf_dataset.rs
+++ b/src/hf_dataset.rs
@@ -76,7 +76,7 @@ pub(crate) enum Reindexed {
 /// writes only data — a new fragment, manifest, and transaction — and leaves the new rows
 /// unindexed (refresh the index separately with [`reindex`]). Returns [`Appended::Committed`] with
 /// the new commit oid and the resulting unindexed-row backlog (the largest across the dataset's
-/// indexes — what `sync` thresholds on), or [`Appended::Conflict`] if the head moved first — a
+/// indexes — what `push` thresholds on), or [`Appended::Conflict`] if the head moved first — a
 /// single attempt against the head it read, so the caller drives the retry.
 pub(crate) async fn append(
     repo: &HFRepository<RepoTypeDataset>,

--- a/src/hf_dataset.rs
+++ b/src/hf_dataset.rs
@@ -107,7 +107,7 @@ pub(crate) async fn append(
             unindexed,
         }),
         Err(HFError::Conflict { .. }) => Ok(Appended::Conflict),
-        Err(e) => Err(anyhow::anyhow!("data commit failed: {e}")),
+        Err(e) => Err(anyhow::Error::new(e).context("data commit failed")),
     }
 }
 
@@ -137,7 +137,7 @@ pub(crate) async fn reindex(
     match send_commit(repo, ops, parent, rev, message).await {
         Ok(info) => Ok(Reindexed::Committed(info.commit_oid.unwrap_or_else(|| "?".to_string()))),
         Err(HFError::Conflict { .. }) => Ok(Reindexed::Conflict),
-        Err(e) => Err(anyhow::anyhow!("reindex commit failed: {e}")),
+        Err(e) => Err(anyhow::Error::new(e).context("reindex commit failed")),
     }
 }
 

--- a/src/hub.rs
+++ b/src/hub.rs
@@ -21,26 +21,29 @@ pub enum Store {
     /// A local Lance store directory (e.g. `~/.funes/lancedb`).
     Local { path: PathBuf },
     /// A remote Lance dataset on the HF Hub, e.g. `hf://datasets/<org>/<repo>`.
-    Remote { uri: String, revision: Option<String> },
+    Remote { uri: String },
 }
 
 impl Store {
-    /// The default local store (`$FUNES_DB` / `~/.funes` → `…/lancedb`).
+    /// The default local store (`$FUNES_HOME` / `~/.funes` → `…/lancedb`).
     pub fn local() -> Self {
         Store::Local {
             path: PathBuf::from(dataset::local_store_dir()),
         }
     }
 
-    /// Parse a store spec: `"local"` → the default local store; an `hf://…` URI → a remote
-    /// dataset; anything else → a local store at that path.
-    pub fn parse(spec: &str, revision: Option<String>) -> Self {
+    /// Parse a store spec: `"local"` → the default local store; an `hf://…` URI or an
+    /// `<org>/<repo>` shorthand → a remote dataset; a filesystem path → a local store there. The
+    /// shorthand expands to `hf://datasets/<org>/<repo>`; a spec starting with `/`, `.`, or `~`
+    /// is always a local path (so a relative dir reads as a path, not a repo).
+    pub fn parse(spec: &str) -> Self {
         if spec == "local" {
             Store::local()
         } else if spec.starts_with("hf://") {
+            Store::Remote { uri: spec.to_string() }
+        } else if is_remote_shorthand(spec) {
             Store::Remote {
-                uri: spec.to_string(),
-                revision,
+                uri: format!("hf://datasets/{spec}"),
             }
         } else {
             Store::Local {
@@ -49,16 +52,15 @@ impl Store {
         }
     }
 
-    /// Resolve the store the read commands should use: an explicit `spec` (a CLI `--store`)
-    /// wins, else `$FUNES_STORE`, else the default local store. `revision` is taken from the
-    /// flag, else `$FUNES_REVISION` (only meaningful for a remote `hf://` store).
-    pub fn resolve(spec: Option<String>, revision: Option<String>) -> Self {
-        resolve_from(spec, revision, |k| std::env::var(k).ok())
+    /// Resolve the store the read commands should use: an explicit `spec` (a CLI `--remote`) wins,
+    /// else the persisted active store (`funes use`), else the local index.
+    pub fn resolve(spec: Option<String>) -> Self {
+        resolve_with(spec, crate::config::load().remote)
     }
 
     /// True only for the *default* local store (`$FUNES_DB`/`~/.funes`), the one a fresh install
-    /// uses. An explicit `--store <path>` or `hf://…` is not the default, even when it can't open —
-    /// so the hello-world fallback never masks a real "your store is missing" error.
+    /// uses. An explicit `--remote` or a non-default path is not the default, even when it can't
+    /// open — so the hello-world fallback never masks a real "your store is missing" error.
     pub fn is_default_local(&self) -> bool {
         matches!(self, Store::Local { path } if path.as_path() == Path::new(&dataset::local_store_dir()))
     }
@@ -79,11 +81,8 @@ impl Store {
             Store::Local { path } => {
                 dataset::open(&dataset::table_uri(&path.to_string_lossy()), HashMap::new()).await?
             }
-            Store::Remote { uri, revision } => {
+            Store::Remote { uri } => {
                 let mut opts = HashMap::new();
-                if let Some(rev) = revision {
-                    opts.insert("revision".to_string(), rev.clone());
-                }
                 if let Some(token) = hf_token() {
                     opts.insert("hf_token".to_string(), token);
                 }
@@ -95,15 +94,20 @@ impl Store {
     }
 }
 
-/// Pure core of [`Store::resolve`]: explicit `spec` wins over `$FUNES_STORE`, explicit
-/// `revision` over `$FUNES_REVISION`; blank env values are ignored. Split out so it's testable
-/// without mutating process env.
-fn resolve_from(spec: Option<String>, revision: Option<String>, env: impl Fn(&str) -> Option<String>) -> Store {
-    let nonempty = |k: &str| env(k).map(|v| v.trim().to_string()).filter(|v| !v.is_empty());
-    match spec.or_else(|| nonempty("FUNES_STORE")) {
-        Some(s) => Store::parse(&s, revision.or_else(|| nonempty("FUNES_REVISION"))),
+/// Pure core of [`Store::resolve`]: an explicit `spec` wins over the persisted active store; with
+/// neither (both blank), the local index. Split out so it's testable without touching the config.
+fn resolve_with(spec: Option<String>, active: Option<String>) -> Store {
+    let clean = |o: Option<String>| o.map(|s| s.trim().to_string()).filter(|s| !s.is_empty());
+    match clean(spec).or_else(|| clean(active)) {
+        Some(s) => Store::parse(&s),
         None => Store::local(),
     }
+}
+
+/// `<org>/<repo>[/…]` with no scheme and not a filesystem path → an HF dataset shorthand. A spec
+/// starting with `/`, `.`, or `~` is treated as a local path, never a shorthand.
+fn is_remote_shorthand(spec: &str) -> bool {
+    !spec.starts_with(['/', '.', '~']) && spec.contains('/')
 }
 
 /// HF token from the standard env var, else the `huggingface_hub` cached token file.
@@ -172,28 +176,30 @@ mod tests {
     use arrow_schema::{DataType, Field, Schema};
 
     #[test]
-    fn store_parse_local_path_remote() {
-        assert!(matches!(Store::parse("local", None), Store::Local { .. }));
-        match Store::parse("/tmp/store", None) {
+    fn store_parse_local_remote_and_shorthand() {
+        assert!(matches!(Store::parse("local"), Store::Local { .. }));
+        // explicit local paths (leading / . ~)
+        match Store::parse("/tmp/store") {
             Store::Local { path } => assert_eq!(path, std::path::PathBuf::from("/tmp/store")),
             _ => panic!("expected a local path"),
         }
-        match Store::parse("hf://datasets/org/kb", Some("abc".into())) {
-            Store::Remote { uri, revision } => {
-                assert_eq!(uri, "hf://datasets/org/kb");
-                assert_eq!(revision.as_deref(), Some("abc"));
-            }
+        assert!(matches!(Store::parse("./rel/dir"), Store::Local { .. }));
+        // full hf:// URI
+        match Store::parse("hf://datasets/org/kb") {
+            Store::Remote { uri } => assert_eq!(uri, "hf://datasets/org/kb"),
             _ => panic!("expected remote"),
+        }
+        // org/repo shorthand expands to a dataset URI
+        match Store::parse("acme/kb") {
+            Store::Remote { uri } => assert_eq!(uri, "hf://datasets/acme/kb"),
+            _ => panic!("expected remote from shorthand"),
         }
     }
 
     #[test]
     fn store_label() {
         assert_eq!(Store::Local { path: "/tmp/x".into() }.label(), "/tmp/x");
-        assert_eq!(
-            Store::parse("hf://datasets/org/kb", None).label(),
-            "hf://datasets/org/kb"
-        );
+        assert_eq!(Store::parse("hf://datasets/org/kb").label(), "hf://datasets/org/kb");
     }
 
     #[test]
@@ -220,40 +226,30 @@ mod tests {
     }
 
     #[test]
-    fn resolve_prefers_explicit_then_env_then_local() {
-        let none = |_: &str| None;
-        // Explicit spec + revision win outright.
-        match resolve_from(Some("hf://datasets/o/r".into()), Some("v1".into()), none) {
-            Store::Remote { uri, revision } => {
-                assert_eq!(uri, "hf://datasets/o/r");
-                assert_eq!(revision.as_deref(), Some("v1"));
-            }
-            _ => panic!("expected remote"),
+    fn resolve_prefers_explicit_then_active_then_local() {
+        // Explicit spec wins, with the org/repo shorthand applied.
+        match resolve_with(Some("acme/kb".into()), Some("hf://datasets/active/one".into())) {
+            Store::Remote { uri } => assert_eq!(uri, "hf://datasets/acme/kb"),
+            _ => panic!("explicit spec should win"),
         }
-        // No spec, no env -> default local store.
-        assert!(matches!(resolve_from(None, None, none), Store::Local { .. }));
-        // No explicit spec -> $FUNES_STORE used, $FUNES_REVISION fills the revision.
-        let env = |k: &str| match k {
-            "FUNES_STORE" => Some("hf://datasets/e/r".to_string()),
-            "FUNES_REVISION" => Some("envrev".to_string()),
-            _ => None,
-        };
-        match resolve_from(None, None, env) {
-            Store::Remote { uri, revision } => {
-                assert_eq!(uri, "hf://datasets/e/r");
-                assert_eq!(revision.as_deref(), Some("envrev"));
-            }
-            _ => panic!("expected remote from env"),
+        // No spec -> the persisted active store.
+        match resolve_with(None, Some("hf://datasets/active/one".into())) {
+            Store::Remote { uri } => assert_eq!(uri, "hf://datasets/active/one"),
+            _ => panic!("expected the active store"),
         }
-        // An explicit (local) spec beats a remote $FUNES_STORE.
-        let env2 = |k: &str| (k == "FUNES_STORE").then(|| "hf://datasets/env/wins".to_string());
-        match resolve_from(Some("/local/path".into()), None, env2) {
+        // Neither -> local.
+        assert!(matches!(resolve_with(None, None), Store::Local { .. }));
+        // An explicit local spec beats an active remote.
+        match resolve_with(Some("/local/path".into()), Some("hf://datasets/active/one".into())) {
             Store::Local { path } => assert_eq!(path, std::path::PathBuf::from("/local/path")),
-            _ => panic!("explicit local path should beat env remote"),
+            _ => panic!("explicit local should beat the active remote"),
         }
-        // A blank $FUNES_STORE is ignored -> local.
-        let blank = |k: &str| (k == "FUNES_STORE").then(|| "   ".to_string());
-        assert!(matches!(resolve_from(None, None, blank), Store::Local { .. }));
+        // Blank spec falls through to the active store; both blank -> local.
+        assert!(matches!(resolve_with(Some("  ".into()), None), Store::Local { .. }));
+        match resolve_with(Some("   ".into()), Some("hf://datasets/active/one".into())) {
+            Store::Remote { uri } => assert_eq!(uri, "hf://datasets/active/one"),
+            _ => panic!("blank spec should fall through to active"),
+        }
     }
 
     // --- dim guard against real local datasets ---

--- a/src/hub.rs
+++ b/src/hub.rs
@@ -32,10 +32,8 @@ impl Store {
         }
     }
 
-    /// Parse a store spec: `"local"` → the default local store; an `hf://…` URI or an
-    /// `<org>/<repo>` shorthand → a remote dataset; a filesystem path → a local store there. The
-    /// shorthand expands to `hf://datasets/<org>/<repo>`; a spec starting with `/`, `.`, or `~`
-    /// is always a local path (so a relative dir reads as a path, not a repo).
+    /// Parse a store spec: `"local"` → the local store; an `hf://…` URI or `<org>/<repo>` shorthand
+    /// → a remote; a path (`/`, `.`, `~`, or a bare name) → a local store there.
     pub fn parse(spec: &str) -> Self {
         if spec == "local" {
             Store::local()
@@ -58,9 +56,8 @@ impl Store {
         resolve_with(spec, crate::config::load().remote)
     }
 
-    /// True only for the *default* local store (`$FUNES_DB`/`~/.funes`), the one a fresh install
-    /// uses. An explicit `--remote` or a non-default path is not the default, even when it can't
-    /// open — so the hello-world fallback never masks a real "your store is missing" error.
+    /// True only for the default local store (`$FUNES_HOME`/`~/.funes`), so the hello-world
+    /// fallback fires only there — never masking a missing explicit store.
     pub fn is_default_local(&self) -> bool {
         matches!(self, Store::Local { path } if path.as_path() == Path::new(&dataset::local_store_dir()))
     }
@@ -94,8 +91,7 @@ impl Store {
     }
 }
 
-/// Pure core of [`Store::resolve`]: an explicit `spec` wins over the persisted active store; with
-/// neither (both blank), the local index. Split out so it's testable without touching the config.
+/// Pure core of [`Store::resolve`]: explicit `spec` over the active store, else local.
 fn resolve_with(spec: Option<String>, active: Option<String>) -> Store {
     let clean = |o: Option<String>| o.map(|s| s.trim().to_string()).filter(|s| !s.is_empty());
     match clean(spec).or_else(|| clean(active)) {
@@ -104,8 +100,7 @@ fn resolve_with(spec: Option<String>, active: Option<String>) -> Store {
     }
 }
 
-/// `<org>/<repo>[/…]` with no scheme and not a filesystem path → an HF dataset shorthand. A spec
-/// starting with `/`, `.`, or `~` is treated as a local path, never a shorthand.
+/// `<org>/<repo>[/…]` with no scheme and not a path (`/` `.` `~`) → an HF dataset shorthand.
 fn is_remote_shorthand(spec: &str) -> bool {
     !spec.starts_with(['/', '.', '~']) && spec.contains('/')
 }

--- a/src/hub.rs
+++ b/src/hub.rs
@@ -56,6 +56,13 @@ impl Store {
         resolve_from(spec, revision, |k| std::env::var(k).ok())
     }
 
+    /// True only for the *default* local store (`$FUNES_DB`/`~/.funes`), the one a fresh install
+    /// uses. An explicit `--store <path>` or `hf://…` is not the default, even when it can't open —
+    /// so the hello-world fallback never masks a real "your store is missing" error.
+    pub fn is_default_local(&self) -> bool {
+        matches!(self, Store::Local { path } if path.as_path() == Path::new(&dataset::local_store_dir()))
+    }
+
     /// Short label for output/provenance.
     pub fn label(&self) -> String {
         match self {

--- a/src/index.rs
+++ b/src/index.rs
@@ -50,7 +50,7 @@ fn schema() -> Arc<Schema> {
     ))
 }
 
-fn build_batch(chunks: &[chunk::Chunk], vectors: &[Vec<f32>]) -> Result<RecordBatch> {
+pub(crate) fn build_batch(chunks: &[chunk::Chunk], vectors: &[Vec<f32>]) -> Result<RecordBatch> {
     let s = |f: &dyn Fn(&chunk::Chunk) -> Option<String>| -> StringArray { chunks.iter().map(f).collect() };
     let i = |f: &dyn Fn(&chunk::Chunk) -> i64| -> Int64Array { chunks.iter().map(|c| Some(f(c))).collect() };
     let vector = FixedSizeListArray::from_iter_primitive::<Float32Type, _, _>(

--- a/src/index.rs
+++ b/src/index.rs
@@ -3,7 +3,7 @@
 //! changed session add only chunks whose id is new — a grown session (the same memory)
 //! contributes just its new turns, nothing is re-embedded or deleted.
 
-use crate::{chunk, dataset, parse};
+use crate::{chunk, config, dataset, hub, parse, push};
 use anyhow::{anyhow, Result};
 use arrow_array::types::Float32Type;
 use arrow_array::{FixedSizeListArray, Int64Array, RecordBatch, RecordBatchIterator, StringArray};
@@ -245,6 +245,17 @@ pub async fn run_index(source: &Path, no_thinking: bool) -> Result<()> {
     }
 
     println!("indexed files={n_files} skipped={n_skipped} chunks={n_chunks}");
+
+    // If a remote is attached, publish what was just built so the active store stays current.
+    // Best-effort: a failed push (offline, no token, secret gate) does not fail the local index —
+    // the delta self-heals on the next `index`. A local active store is a no-op (nothing to push).
+    if let Some(remote) = config::load().remote {
+        match push::run_push(hub::Store::parse(&remote), false).await {
+            Ok(report) => print!("{report}"),
+            Err(e) => eprintln!("indexed locally; couldn't publish to {remote}: {e}"),
+        }
+    }
+
     Ok(())
 }
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -246,12 +246,13 @@ pub async fn run_index(source: &Path, no_thinking: bool) -> Result<()> {
 
     println!("indexed files={n_files} skipped={n_skipped} chunks={n_chunks}");
 
-    // If a remote is attached, publish what was just built so the active store stays current.
-    // Best-effort: a failed push (offline, no token, secret gate) does not fail the local index —
-    // the delta self-heals on the next `index`. A local active store is a no-op (nothing to push).
+    // Publish to the attached remote, best-effort: a failed push must not fail the local index.
     if let Some(remote) = config::load().remote {
         match push::run_push(hub::Store::parse(&remote), false).await {
             Ok(report) => print!("{report}"),
+            Err(e) if push::is_read_only(&e) => {
+                eprintln!("indexed locally; {remote} is read-only for your token — recall reads it, but publishing needs write access")
+            }
             Err(e) => eprintln!("indexed locally; couldn't publish to {remote}: {e}"),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub mod capture_store;
 pub mod chunk;
+pub mod config;
 pub mod dataset;
 pub mod hello;
 pub mod hf_dataset;
@@ -14,6 +15,6 @@ pub mod hub;
 pub mod index;
 pub mod mcp;
 pub mod parse;
+pub mod push;
 pub mod recall;
 pub mod scan;
-pub mod sync;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 pub mod capture_store;
 pub mod chunk;
 pub mod dataset;
+pub mod hello;
 pub mod hf_dataset;
 pub mod hub;
 pub mod index;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,11 @@
 //! funes — recall over your past AI Agent sessions.
 //!
 //! `recall` reads the index (hybrid → rerank → recency); `index` builds/updates it
-//! from `~/.claude/projects/**/*.jsonl`. Index location is `$FUNES_DB` or `~/.funes`.
+//! from `~/.claude/projects/**/*.jsonl`. funes's home is `$FUNES_HOME` or `~/.funes`.
 
-use funes::{hub, index, mcp, recall, sync};
+use funes::{config, hub, index, mcp, push, recall};
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use clap::{Args, Parser, Subcommand};
 use std::path::PathBuf;
 
@@ -80,10 +80,16 @@ enum Cmd {
         #[command(flatten)]
         store: StoreOpts,
     },
-    /// Publish the local store's new chunks to a remote store on the HF Hub.
-    Sync {
-        #[command(flatten)]
-        store: StoreOpts,
+    /// Set the active store: the remote this host reads from and publishes to (persisted in
+    /// funes.json; honored by recall/push and the MCP server).
+    Use {
+        /// Remote to attach: `<org>/<repo>` (→ `hf://datasets/<org>/<repo>`) or a full `hf://…`
+        /// URI. Pass `local` to detach and go back to the local index.
+        store: String,
+    },
+    /// Re-publish the local index's new chunks to the active remote (manual; `index` already
+    /// publishes automatically when a remote is attached).
+    Push {
         /// Refresh the remote index after pushing (retrying on conflict) even if the unindexed
         /// backlog is below the auto-reindex threshold. With nothing new to push, reindex only.
         #[arg(long)]
@@ -96,18 +102,15 @@ enum Cmd {
 /// Which store the read commands act on. Shared by `recall`/`list`/`get`/`status`.
 #[derive(Args)]
 struct StoreOpts {
-    /// Store to read: `local` (default), an `hf://datasets/<org>/<repo>` URI, or a local path.
-    /// Falls back to $FUNES_STORE, then the local index.
+    /// A remote to read for this call — an `<org>/<repo>` shorthand or `hf://…` URI — overriding
+    /// the active store. Defaults to the active store, else the local index.
     #[arg(long)]
-    store: Option<String>,
-    /// Revision (branch/tag/sha) for a remote `hf://` store. Falls back to $FUNES_REVISION.
-    #[arg(long)]
-    revision: Option<String>,
+    remote: Option<String>,
 }
 
 impl StoreOpts {
     fn resolve(self) -> hub::Store {
-        hub::Store::resolve(self.store, self.revision)
+        hub::Store::resolve(self.remote)
     }
 }
 
@@ -164,10 +167,36 @@ async fn main() -> Result<()> {
             print!("{}", recall::status(store.resolve()).await?);
             Ok(())
         }
-        Cmd::Sync { store, force_reindex } => {
-            print!("{}", sync::run_sync(store.resolve(), force_reindex).await?);
+        Cmd::Use { store } => use_store(store),
+        Cmd::Push { force_reindex } => {
+            let remote = config::load()
+                .remote
+                .ok_or_else(|| anyhow!("no active remote — attach one with `funes use <org>/<repo>`"))?;
+            print!("{}", push::run_push(hub::Store::parse(&remote), force_reindex).await?);
             Ok(())
         }
         Cmd::Mcp => mcp::run().await,
+    }
+}
+
+/// `funes use <store>`: attach a remote (or `local` to detach), persisted in funes.json.
+fn use_store(spec: String) -> Result<()> {
+    let mut cfg = config::load();
+    if spec == "local" {
+        cfg.remote = None;
+        config::save(&cfg)?;
+        println!("active store: local index");
+        return Ok(());
+    }
+    match hub::Store::parse(&spec) {
+        hub::Store::Remote { uri } => {
+            println!("active store: {uri}");
+            cfg.remote = Some(uri);
+            config::save(&cfg)
+        }
+        hub::Store::Local { .. } => Err(anyhow!(
+            "`funes use` takes a remote (e.g. `acme/kb` or `hf://datasets/<org>/<repo>`); for the \
+             local index use `funes use local`, or relocate funes's home with $FUNES_HOME"
+        )),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -167,20 +167,28 @@ async fn main() -> Result<()> {
             print!("{}", recall::status(store.resolve()).await?);
             Ok(())
         }
-        Cmd::Use { store } => use_store(store),
+        Cmd::Use { store } => use_store(store).await,
         Cmd::Push { force_reindex } => {
             let remote = config::load()
                 .remote
                 .ok_or_else(|| anyhow!("no active remote — attach one with `funes use <org>/<repo>`"))?;
-            print!("{}", push::run_push(hub::Store::parse(&remote), force_reindex).await?);
-            Ok(())
+            match push::run_push(hub::Store::parse(&remote), force_reindex).await {
+                Ok(report) => {
+                    print!("{report}");
+                    Ok(())
+                }
+                Err(e) if push::is_read_only(&e) => Err(anyhow!(
+                    "{remote} is read-only for your token — recall can read it, but publishing needs write access (check your HF token)"
+                )),
+                Err(e) => Err(e),
+            }
         }
         Cmd::Mcp => mcp::run().await,
     }
 }
 
-/// `funes use <store>`: attach a remote (or `local` to detach), persisted in funes.json.
-fn use_store(spec: String) -> Result<()> {
+/// `funes use <store>`: attach a remote (or `local` to detach) and report the next step.
+async fn use_store(spec: String) -> Result<()> {
     let mut cfg = config::load();
     if spec == "local" {
         cfg.remote = None;
@@ -188,15 +196,66 @@ fn use_store(spec: String) -> Result<()> {
         println!("active store: local index");
         return Ok(());
     }
-    match hub::Store::parse(&spec) {
-        hub::Store::Remote { uri } => {
-            println!("active store: {uri}");
-            cfg.remote = Some(uri);
-            config::save(&cfg)
+    let uri = match hub::Store::parse(&spec) {
+        hub::Store::Remote { uri } => uri,
+        hub::Store::Local { .. } => {
+            return Err(anyhow!(
+                "`funes use` takes a remote (e.g. `acme/kb` or `hf://datasets/<org>/<repo>`); for the \
+                 local index use `funes use local`, or relocate funes's home with $FUNES_HOME"
+            ))
         }
-        hub::Store::Local { .. } => Err(anyhow!(
-            "`funes use` takes a remote (e.g. `acme/kb` or `hf://datasets/<org>/<repo>`); for the \
-             local index use `funes use local`, or relocate funes's home with $FUNES_HOME"
-        )),
+    };
+    cfg.remote = Some(uri.clone());
+    config::save(&cfg)?;
+    println!("active store: {uri}");
+
+    let local = push::store_ids(&hub::Store::local()).await;
+    let remote = push::store_ids(&hub::Store::parse(&uri)).await;
+    let unpushed = local.difference(&remote).count();
+    println!("{}", attach_hint(local.len(), remote.len(), unpushed));
+    Ok(())
+}
+
+/// The next-step hint for `funes use`.
+fn attach_hint(local: usize, remote: usize, unpushed: usize) -> String {
+    if local == 0 && remote == 0 {
+        "no memories indexed yet — run `funes index` to build your local index (it publishes here automatically)."
+            .to_string()
+    } else if local == 0 {
+        format!("the remote holds {remote} chunks — recall reads them now. if you own this remote store, run `funes index` to add this machine's sessions.")
+    } else if unpushed == 0 {
+        format!("local index: {local} chunks, all present on the remote.")
+    } else if remote == 0 {
+        format!("local index: {local} chunks, none on the remote yet — run `funes push`.")
+    } else if local > unpushed {
+        // Shares chunks with the remote → it's yours to add to; publish the extras.
+        format!("local index: {local} chunks, {unpushed} not yet on the remote — run `funes push`.")
+    } else {
+        // No shared chunks with a populated remote: a fresh host of yours, or a store you only read.
+        format!("local index: {local} chunks, remote: {remote} — no shared chunks: a new host of yours, or a store you only read. `funes push` to contribute, skip if it's not yours.")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::attach_hint;
+
+    #[test]
+    fn attach_hint_covers_each_state() {
+        // empty local + empty remote -> index
+        assert!(attach_hint(0, 0, 0).contains("funes index"));
+        // empty local + populated remote -> recall now, index to add local
+        let h = attach_hint(0, 5, 0);
+        assert!(h.contains("recall reads them") && h.contains("funes index"));
+        // local fully published -> no push hint
+        assert!(attach_hint(8, 8, 0).contains("all present"));
+        // empty remote -> first publish
+        assert!(attach_hint(8, 0, 8).contains("funes push"));
+        // local overlaps the remote (overlap = 8-5 = 3) -> push the extras
+        let h = attach_hint(8, 3, 5);
+        assert!(h.contains("5 not yet") && h.contains("funes push"));
+        // no overlap with a populated remote -> cautious, may be read-only
+        let h = attach_hint(8, 5, 8);
+        assert!(h.contains("no shared chunks") && h.contains("skip if it's not yours"));
     }
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -59,7 +59,7 @@ impl Funes {
         }): Parameters<RecallRequest>,
     ) -> String {
         match recall::recall(
-            crate::hub::Store::resolve(None, None),
+            crate::hub::Store::resolve(None),
             query,
             k.unwrap_or(8),
             30,
@@ -88,7 +88,7 @@ impl Funes {
         }): Parameters<GetRequest>,
     ) -> String {
         match recall::get(
-            crate::hub::Store::resolve(None, None),
+            crate::hub::Store::resolve(None),
             session_id,
             turn_uuid,
             window.unwrap_or(3),
@@ -103,7 +103,7 @@ impl Funes {
 
     #[tool(description = "Show funes index statistics (chunk count and store).")]
     async fn status(&self) -> String {
-        recall::status(crate::hub::Store::resolve(None, None))
+        recall::status(crate::hub::Store::resolve(None))
             .await
             .unwrap_or_else(|e| format!("status error: {e}"))
     }

--- a/src/push.rs
+++ b/src/push.rs
@@ -1,7 +1,7 @@
-//! `sync`: publish the local store's not-yet-remote chunks into a remote store on the HF Hub.
+//! `push`: publish the local store's not-yet-remote chunks into a remote store on the HF Hub.
 //!
 //! Streamed, never a full mirror. "What's already there" is the store's own chunk ids, so the
-//! delta is `local_ids − remote_ids` — the same primitive `index` uses. `sync` is orchestration:
+//! delta is `local_ids − remote_ids` — the same primitive `index` uses. `push` is orchestration:
 //! it computes the delta, runs the pre-publish secret gate, and drives the HF write operations in
 //! [`crate::hf_dataset`], which own the atomic, parent-commit-guarded commits.
 //!
@@ -11,8 +11,8 @@
 //!   guarded `create_commit`, retried against a fresh head if a concurrent push moved it. The new
 //!   rows are left unindexed (a query still finds them by brute force).
 //! - **Reindex:** a *separate* guarded commit ([`hf_dataset::reindex`]), kept off the data commit so
-//!   the data commit stays small. `sync` runs it after the data commit when the unindexed backlog
-//!   crosses [`REINDEX_THRESHOLD`] (best-effort: a head-moved conflict is a warning, the next sync
+//!   the data commit stays small. `push` runs it after the data commit when the unindexed backlog
+//!   crosses [`REINDEX_THRESHOLD`] (best-effort: a head-moved conflict is a warning, the next push
 //!   retries), or eagerly with `--force-reindex` (retried until it lands).
 
 use crate::dataset;
@@ -29,7 +29,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 /// Reindex the remote once this many appended rows are sitting unindexed (answered by a
-/// brute-force scan until folded in). Bounds per-query cost, not sync count, and is stateless —
+/// brute-force scan until folded in). Bounds per-query cost, not push count, and is stateless —
 /// [`hf_dataset::append`] reads it straight from Lance's index stats.
 const REINDEX_THRESHOLD: u64 = 2_000;
 
@@ -37,15 +37,15 @@ const REINDEX_THRESHOLD: u64 = 2_000;
 /// moving under us, so a busy remote can't spin forever.
 const MAX_COMMIT_RETRIES: u32 = 10;
 
-/// Parse `hf://datasets/<owner>/<name>/<prefix…>` into (owner, name, prefix-within-repo).
+/// Parse `hf://datasets/<owner>/<name>[/<prefix…>]` into (owner, name, prefix-within-repo). An
+/// empty prefix means the dataset lives at the repo root — matching how reads resolve a remote,
+/// so an attached `<org>/<repo>` and `recall --remote <org>/<repo>` resolve the same dataset.
 fn parse_hf(uri: &str) -> Result<(String, String, String)> {
     let rest = uri.strip_prefix("hf://").context("remote store must be an hf:// URI")?;
     let segs: Vec<&str> = rest.split('/').filter(|s| !s.is_empty()).collect();
     match segs.as_slice() {
-        ["datasets", owner, name, prefix @ ..] if !prefix.is_empty() => {
-            Ok((owner.to_string(), name.to_string(), prefix.join("/")))
-        }
-        _ => bail!("expected hf://datasets/<owner>/<name>/<path>, got {uri}"),
+        ["datasets", owner, name, prefix @ ..] => Ok((owner.to_string(), name.to_string(), prefix.join("/"))),
+        _ => bail!("expected hf://datasets/<owner>/<name>[/<path>], got {uri}"),
     }
 }
 
@@ -100,13 +100,11 @@ fn texts(batches: &[RecordBatch]) -> Vec<String> {
 /// `force_reindex`, refresh the remote index after the data commit (retrying until it lands) even
 /// if the unindexed backlog is below [`REINDEX_THRESHOLD`]; with no new chunks pending it's a pure
 /// index refresh.
-pub async fn run_sync(target: Store, force_reindex: bool) -> Result<String> {
-    let (uri, revision) = match &target {
-        Store::Remote { uri, revision } => (uri.clone(), revision.clone()),
+pub async fn run_push(target: Store, force_reindex: bool) -> Result<String> {
+    let uri = match &target {
+        Store::Remote { uri } => uri.clone(),
         Store::Local { .. } => {
-            bail!(
-                "sync needs a remote `hf://` target; the configured store is local (pass --store or set $FUNES_STORE)"
-            )
+            bail!("push target must be a remote `hf://` store — it publishes your local index up to the Hub")
         }
     };
 
@@ -138,7 +136,9 @@ pub async fn run_sync(target: Store, force_reindex: bool) -> Result<String> {
         .build()
         .context("building hf-hub client")?;
     let repo = client.dataset(owner, name);
-    let rev = revision.unwrap_or_else(|| "main".to_string());
+    // The dataset always lives on the default branch; reads/push never pin a revision (a pin would
+    // freeze you behind the last push), so HEAD of `main` is the one source of truth.
+    let rev = "main".to_string();
     let dataset_uri = format!("{uri}/{}.lance", dataset::TABLE);
     let opts = HashMap::from([("hf_token".to_string(), token), ("revision".to_string(), rev.clone())]);
 
@@ -167,7 +167,12 @@ pub async fn run_sync(target: Store, force_reindex: bool) -> Result<String> {
     // 5. First publish: build the whole dataset locally (data + indexes) and push it in one commit.
     if first_publish {
         let staging = tempfile::tempdir()?;
-        let db_dir = staging.path().join(&prefix);
+        // Empty prefix = dataset at the repo root; joining "" would leave a stray trailing separator.
+        let db_dir = if prefix.is_empty() {
+            staging.path().to_path_buf()
+        } else {
+            staging.path().join(&prefix)
+        };
         std::fs::create_dir_all(&db_dir)?;
         let table_uri = dataset::table_uri(&db_dir.to_string_lossy());
         let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
@@ -193,7 +198,7 @@ pub async fn run_sync(target: Store, force_reindex: bool) -> Result<String> {
         let info = repo
             .create_commit()
             .operations(ops)
-            .commit_message(format!("funes sync: +{n_chunks} chunks"))
+            .commit_message(format!("funes push: +{n_chunks} chunks"))
             .revision(rev.clone())
             .send()
             .await
@@ -207,7 +212,7 @@ pub async fn run_sync(target: Store, force_reindex: bool) -> Result<String> {
 
     // 6. Append the data and commit it, retrying against a fresh head if a concurrent push moved it
     // (each attempt re-appends onto the new manifest — the data commit is small, so this is cheap).
-    let message = format!("funes sync: +{n_chunks} chunks");
+    let message = format!("funes push: +{n_chunks} chunks");
     let mut attempts = 0u32;
     let (oid, unindexed) = loop {
         let attempt = hf_dataset::append(
@@ -225,7 +230,7 @@ pub async fn run_sync(target: Store, force_reindex: bool) -> Result<String> {
             Appended::Conflict => {
                 attempts += 1;
                 if attempts > MAX_COMMIT_RETRIES {
-                    bail!("data commit kept conflicting after {MAX_COMMIT_RETRIES} retries; re-run sync");
+                    bail!("data commit kept conflicting after {MAX_COMMIT_RETRIES} retries; re-run push");
                 }
             }
         }
@@ -233,7 +238,7 @@ pub async fn run_sync(target: Store, force_reindex: bool) -> Result<String> {
     let mut out = format!("{}: pushed {n_chunks} chunks (commit {oid})\n", target.label());
 
     // 7. Reindex as a separate commit: forced (retried until it lands) or, past the threshold,
-    // best-effort (one shot, warn on a conflict — the next sync retries).
+    // best-effort (one shot, warn on a conflict — the next push retries).
     if force_reindex {
         out.push_str(&reindex_forced(&repo, &dataset_uri, &opts, &rev).await?);
     } else if unindexed > REINDEX_THRESHOLD {
@@ -251,29 +256,51 @@ async fn reindex_forced(
     rev: &str,
 ) -> Result<String> {
     for _ in 0..=MAX_COMMIT_RETRIES {
-        match hf_dataset::reindex(repo, dataset_uri, opts.clone(), rev, "funes sync: reindex".to_string()).await? {
+        match hf_dataset::reindex(repo, dataset_uri, opts.clone(), rev, "funes push: reindex".to_string()).await? {
             Reindexed::Committed(oid) => return Ok(format!("  reindexed (commit {oid})\n")),
             Reindexed::AlreadyCurrent => return Ok("  index already current\n".to_string()),
             Reindexed::Conflict => continue,
         }
     }
-    bail!("reindex still conflicting after {MAX_COMMIT_RETRIES} retries; re-run sync --force-reindex")
+    bail!("reindex still conflicting after {MAX_COMMIT_RETRIES} retries; re-run push --force-reindex")
 }
 
-/// Best-effort reindex during a normal sync: one attempt, never retried. The data is already
-/// committed, so any failure here is a warning — the next sync past the threshold tries again.
+/// Best-effort reindex during a normal push: one attempt, never retried. The data is already
+/// committed, so any failure here is a warning — the next push past the threshold tries again.
 async fn reindex_auto(
     repo: &HFRepository<RepoTypeDataset>,
     dataset_uri: &str,
     opts: &HashMap<String, String>,
     rev: &str,
 ) -> String {
-    match hf_dataset::reindex(repo, dataset_uri, opts.clone(), rev, "funes sync: reindex".to_string()).await {
+    match hf_dataset::reindex(repo, dataset_uri, opts.clone(), rev, "funes push: reindex".to_string()).await {
         Ok(Reindexed::Committed(oid)) => format!("  reindexed (commit {oid})\n"),
         Ok(Reindexed::AlreadyCurrent) => String::new(),
         Ok(Reindexed::Conflict) => {
-            "  note: index not refreshed (remote head moved); will retry on a later sync\n".to_string()
+            "  note: index not refreshed (remote head moved); will retry on a later push\n".to_string()
         }
-        Err(e) => format!("  note: index not refreshed ({e}); will retry on a later sync\n"),
+        Err(e) => format!("  note: index not refreshed ({e}); will retry on a later push\n"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_hf_accepts_repo_root_and_a_prefix() {
+        // repo root: no path after <owner>/<name> -> empty prefix
+        assert_eq!(
+            parse_hf("hf://datasets/acme/kb").unwrap(),
+            ("acme".into(), "kb".into(), "".into())
+        );
+        // an explicit path within the repo is kept
+        assert_eq!(
+            parse_hf("hf://datasets/acme/kb/sub/dir").unwrap(),
+            ("acme".into(), "kb".into(), "sub/dir".into())
+        );
+        // not a dataset URI -> error
+        assert!(parse_hf("hf://acme/kb").is_err());
+        assert!(parse_hf("s3://acme/kb").is_err());
     }
 }

--- a/src/push.rs
+++ b/src/push.rs
@@ -22,7 +22,7 @@ use crate::scan;
 use anyhow::{bail, Context, Result};
 use arrow_array::{RecordBatch, RecordBatchIterator, StringArray};
 use hf_hub::repository::CommitOperation;
-use hf_hub::{HFClient, HFRepository, RepoTypeDataset};
+use hf_hub::{HFClient, HFError, HFRepository, RepoTypeDataset};
 use lance::dataset::WriteParams;
 use lance::Dataset;
 use std::collections::{HashMap, HashSet};
@@ -37,9 +37,8 @@ const REINDEX_THRESHOLD: u64 = 2_000;
 /// moving under us, so a busy remote can't spin forever.
 const MAX_COMMIT_RETRIES: u32 = 10;
 
-/// Parse `hf://datasets/<owner>/<name>[/<prefix…>]` into (owner, name, prefix-within-repo). An
-/// empty prefix means the dataset lives at the repo root — matching how reads resolve a remote,
-/// so an attached `<org>/<repo>` and `recall --remote <org>/<repo>` resolve the same dataset.
+/// Parse `hf://datasets/<owner>/<name>[/<prefix…>]` into (owner, name, prefix). Empty prefix = repo
+/// root, matching how reads resolve a remote.
 fn parse_hf(uri: &str) -> Result<(String, String, String)> {
     let rest = uri.strip_prefix("hf://").context("remote store must be an hf:// URI")?;
     let segs: Vec<&str> = rest.split('/').filter(|s| !s.is_empty()).collect();
@@ -47,6 +46,25 @@ fn parse_hf(uri: &str) -> Result<(String, String, String)> {
         ["datasets", owner, name, prefix @ ..] => Ok((owner.to_string(), name.to_string(), prefix.join("/"))),
         _ => bail!("expected hf://datasets/<owner>/<name>[/<path>], got {uri}"),
     }
+}
+
+/// Every chunk id in a store, or empty if it can't be opened (absent local index, not-yet-created
+/// or inaccessible remote).
+pub async fn store_ids(store: &Store) -> HashSet<String> {
+    match store.open().await {
+        Ok(ds) => all_ids(&ds).await.unwrap_or_default(),
+        Err(_) => HashSet::new(),
+    }
+}
+
+/// Whether a publish error is the Hub refusing the write — a 403/Forbidden, i.e. the token can't
+/// write to this remote. Matches the typed [`HFError`] preserved in the error chain.
+pub fn is_read_only(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| match cause.downcast_ref::<HFError>() {
+        Some(HFError::Forbidden { .. }) => true,
+        Some(HFError::Http { context }) => context.status.as_u16() == 403,
+        _ => false,
+    })
 }
 
 /// Every chunk id in a store (a plain `id`-column scan; plain scans aren't limit-capped).
@@ -136,8 +154,7 @@ pub async fn run_push(target: Store, force_reindex: bool) -> Result<String> {
         .build()
         .context("building hf-hub client")?;
     let repo = client.dataset(owner, name);
-    // The dataset always lives on the default branch; reads/push never pin a revision (a pin would
-    // freeze you behind the last push), so HEAD of `main` is the one source of truth.
+    // No revision pinning: always the `main` branch head.
     let rev = "main".to_string();
     let dataset_uri = format!("{uri}/{}.lance", dataset::TABLE);
     let opts = HashMap::from([("hf_token".to_string(), token), ("revision".to_string(), rev.clone())]);
@@ -202,7 +219,7 @@ pub async fn run_push(target: Store, force_reindex: bool) -> Result<String> {
             .revision(rev.clone())
             .send()
             .await
-            .map_err(|e| anyhow::anyhow!("create_commit failed: {e}"))?;
+            .map_err(|e| anyhow::Error::new(e).context("create_commit failed"))?;
         return Ok(format!(
             "{}: pushed {n_chunks} chunks (commit {})\n",
             target.label(),
@@ -286,6 +303,15 @@ async fn reindex_auto(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn is_read_only_matches_the_type_not_the_message() {
+        // We match the typed HFError, not the rendered text — a plain error that merely mentions
+        // 403/Forbidden is not a read-only signal. (HFError is #[non_exhaustive], so the positive
+        // path can't be built here; it's exercised by the gated round-trip.)
+        assert!(!is_read_only(&anyhow::anyhow!("server said 403 Forbidden")));
+        assert!(!is_read_only(&anyhow::anyhow!("no HF token")));
+    }
 
     #[test]
     fn parse_hf_accepts_repo_root_and_a_prefix() {

--- a/src/recall.rs
+++ b/src/recall.rs
@@ -4,6 +4,7 @@
 //! prints it and the MCP server returns it verbatim.
 
 use crate::dataset;
+use crate::hello;
 use crate::hub::Store;
 use anyhow::{Context, Result};
 use arrow_array::{Float32Array, Int64Array, RecordBatch, StringArray, UInt64Array};
@@ -113,6 +114,31 @@ fn stitch(a: &str, b: &str) -> String {
     format!("{a}{b}")
 }
 
+/// A dataset opened for reading, plus an optional temp dir keeping a built-in fallback alive.
+struct Read {
+    /// Keeps the hello-world temp dir alive for the dataset's lifetime; `None` for a real store.
+    _hello: Option<tempfile::TempDir>,
+    ds: Dataset,
+}
+
+/// Open a store for reading. When the default local index is absent, fall back to the built-in
+/// hello-world corpus so a fresh install can recall something useful with zero indexing — passing
+/// `embedder` gives the corpus real vectors for search (recall), `None` is fine for `get`/`list`.
+/// An explicit path or remote store that can't open is a real error, never masked by the corpus.
+async fn open_read(store: &Store, embedder: Option<&mut TextEmbedding>) -> Result<Read> {
+    match store.open().await {
+        Ok(ds) => Ok(Read { _hello: None, ds }),
+        Err(e) => {
+            if store.is_default_local() {
+                let (dir, ds) = hello::dataset(embedder).await?;
+                Ok(Read { _hello: Some(dir), ds })
+            } else {
+                Err(e)
+            }
+        }
+    }
+}
+
 /// Run the recall pipeline over one store and return the formatted results as text.
 #[allow(clippy::too_many_arguments)]
 pub async fn recall(
@@ -132,13 +158,14 @@ pub async fn recall(
         .next()
         .context("empty embedding")?;
 
-    let ds = store.open().await?;
+    let read = open_read(&store, Some(&mut embedder)).await?;
+    let ds = &read.ds;
     let where_clause = build_where(block_type.as_deref(), project.as_deref());
 
     // Hybrid retrieval: a vector ANN scan and a BM25 scan, fused by reciprocal rank. The FTS index
     // can be absent (it's best-effort at index time), so the FTS leg is skipped when it errors —
     // recall then falls back to vector-only.
-    let hits = hybrid_candidates(&ds, &qv, &query, candidates, where_clause.as_deref()).await?;
+    let hits = hybrid_candidates(ds, &qv, &query, candidates, where_clause.as_deref()).await?;
     if hits.is_empty() {
         return Ok("no results".to_string());
     }
@@ -169,7 +196,7 @@ pub async fn recall(
 
     if neighbors > 0 {
         let mut refs: Vec<&mut Hit> = top.iter_mut().map(|(h, _)| h).collect();
-        attach_neighbors(&ds, &mut refs, neighbors).await?;
+        attach_neighbors(ds, &mut refs, neighbors).await?;
     }
 
     let mut out = String::new();
@@ -367,11 +394,12 @@ async fn attach_neighbors(ds: &Dataset, hits: &mut [&mut Hit], window: i64) -> R
 
 /// Browse indexed sessions: one line per session, newest activity first.
 pub async fn list(store: Store, project: Option<String>, limit: usize) -> Result<String> {
-    let ds = store.open().await?;
+    let read = open_read(&store, None).await?;
+    let ds = &read.ds;
 
     let cols = ["session_id", "project", "ts", "role", "text"];
     let filter = project.as_deref().map(|p| format!("project = '{}'", esc(p)));
-    let batches = dataset::scan_rows(&ds, &cols, filter.as_deref(), None).await?;
+    let batches = dataset::scan_rows(ds, &cols, filter.as_deref(), None).await?;
 
     struct Sess {
         project: String,
@@ -440,11 +468,12 @@ pub async fn list(store: Store, project: Option<String>, limit: usize) -> Result
 /// Drill down on a recall hit: the named turn plus the turns within `window` of it, each
 /// reassembled (blocks in order, splits de-overlapped) into one readable passage.
 pub async fn get(store: Store, session_id: String, turn_uuid: String, window: i64) -> Result<String> {
-    let ds = store.open().await?;
+    let read = open_read(&store, None).await?;
+    let ds = &read.ds;
 
     let cols = ["turn_uuid", "seq", "ts", "role", "text", "block_idx", "split_idx"];
     let filter = format!("session_id = '{}'", esc(&session_id));
-    let batches = dataset::scan_rows(&ds, &cols, Some(filter.as_str()), None).await?;
+    let batches = dataset::scan_rows(ds, &cols, Some(filter.as_str()), None).await?;
 
     // `text` is already the rendered chunk as stored by the indexer — do not re-render.
     let mut rows: Vec<TurnRow> = Vec::new();
@@ -517,13 +546,24 @@ pub async fn get(store: Store, session_id: String, turn_uuid: String, window: i6
 }
 
 pub async fn status(store: Store) -> Result<String> {
-    let ds = store.open().await?;
-    let rows = ds.count_rows(None).await?;
-    Ok(format!(
-        "store: {}\ntable:  {}\nchunks: {rows}\n",
-        store.label(),
-        dataset::TABLE
-    ))
+    match store.open().await {
+        Ok(ds) => {
+            let rows = ds.count_rows(None).await?;
+            Ok(format!(
+                "store: {}\ntable:  {}\nchunks: {rows}\n",
+                store.label(),
+                dataset::TABLE
+            ))
+        }
+        // No personal index yet: point the user at `funes index` instead of erroring. (Recall/get/
+        // list quietly serve the built-in hello-world guide in the same situation.)
+        Err(_) if store.is_default_local() => Ok(format!(
+            "store: {}\nno personal index yet — showing the built-in guide ({} passages).\nrun `funes index` to index ~/.claude/projects, then recall your own history.\n",
+            store.label(),
+            hello::PASSAGES.len()
+        )),
+        Err(e) => Err(e),
+    }
 }
 
 #[cfg(test)]

--- a/tests/hello_world.rs
+++ b/tests/hello_world.rs
@@ -1,0 +1,55 @@
+//! A fresh install with no personal index recalls the built-in hello-world corpus, so the first
+//! `funes recall` returns something useful. Mirrors index_recall.rs but builds *no* index: it
+//! points `$FUNES_DB` at an empty temp dir and exercises the read surface's fallback. Runs the
+//! real BGE embedder + reranker (downloaded to the fastembed cache on first run).
+
+use funes::hub::Store;
+
+#[tokio::test]
+async fn recall_without_an_index_uses_the_builtin_guide() {
+    let empty = tempfile::tempdir().unwrap();
+    // $FUNES_DB points at an empty dir: Store::local() resolves there, there is no dataset to open,
+    // so the read surface must fall back to the hello-world corpus.
+    std::env::set_var("FUNES_DB", empty.path());
+
+    // recall: a question about wiring funes into an agent surfaces the MCP-setup passage.
+    let out = funes::recall::recall(
+        Store::local(),
+        "how do I connect funes to claude code".into(),
+        5,
+        30,
+        30.0,
+        1,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    assert_ne!(out, "no results", "fallback recall returned nothing: {out}");
+    assert!(out.contains("funes/hello"), "expected a built-in hello hit: {out}");
+    assert!(out.contains("claude mcp add"), "expected the MCP-setup passage: {out}");
+    assert!(
+        out.contains("→ get hello"),
+        "hit should carry a resolvable get line: {out}"
+    );
+
+    // get: the `→ get` line resolves against the corpus and expands the turn.
+    let got = funes::recall::get(Store::local(), "hello".into(), "hello-0005".into(), 3)
+        .await
+        .unwrap();
+    assert!(got.contains("claude mcp add"), "get should expand a corpus turn: {got}");
+
+    // list: the synthetic session shows under the funes project.
+    let list = funes::recall::list(Store::local(), None, 50).await.unwrap();
+    assert!(
+        list.contains("funes/hello"),
+        "list should show the built-in session: {list}"
+    );
+
+    // status: guides the user to index instead of erroring on the missing store.
+    let status = funes::recall::status(Store::local()).await.unwrap();
+    assert!(
+        status.contains("funes index"),
+        "status should point at `funes index`: {status}"
+    );
+}

--- a/tests/hello_world.rs
+++ b/tests/hello_world.rs
@@ -1,6 +1,6 @@
 //! A fresh install with no personal index recalls the built-in hello-world corpus, so the first
 //! `funes recall` returns something useful. Mirrors index_recall.rs but builds *no* index: it
-//! points `$FUNES_DB` at an empty temp dir and exercises the read surface's fallback. Runs the
+//! points `$FUNES_HOME` at an empty temp dir and exercises the read surface's fallback. Runs the
 //! real BGE embedder + reranker (downloaded to the fastembed cache on first run).
 
 use funes::hub::Store;
@@ -8,9 +8,9 @@ use funes::hub::Store;
 #[tokio::test]
 async fn recall_without_an_index_uses_the_builtin_guide() {
     let empty = tempfile::tempdir().unwrap();
-    // $FUNES_DB points at an empty dir: Store::local() resolves there, there is no dataset to open,
+    // $FUNES_HOME points at an empty dir: Store::local() resolves there, there is no dataset to open,
     // so the read surface must fall back to the hello-world corpus.
-    std::env::set_var("FUNES_DB", empty.path());
+    std::env::set_var("FUNES_HOME", empty.path());
 
     // recall: a question about wiring funes into an agent surfaces the MCP-setup passage.
     let out = funes::recall::recall(

--- a/tests/index_recall.rs
+++ b/tests/index_recall.rs
@@ -1,7 +1,7 @@
 //! End-to-end: build a real index from a tiny transcript in a temp dir, then exercise
 //! the read surface (recall / get / list / status). No mocking — this runs the real
 //! BGE embedder + reranker (downloaded to the fastembed cache on first run) against a
-//! real lancedb store under a temp `$FUNES_DB`.
+//! real lancedb store under a temp `$FUNES_HOME`.
 
 use std::io::Write;
 
@@ -28,8 +28,8 @@ fn write_transcript(source: &std::path::Path) -> (String, String) {
 async fn index_then_read_surface() {
     let db_dir = tempfile::tempdir().unwrap();
     let source = tempfile::tempdir().unwrap();
-    // db::funes_dir() reads $FUNES_DB; point the whole read/write surface at the temp dir.
-    std::env::set_var("FUNES_DB", db_dir.path());
+    // db::funes_dir() reads $FUNES_HOME; point the whole read/write surface at the temp dir.
+    std::env::set_var("FUNES_HOME", db_dir.path());
     let (session, project) = write_transcript(source.path());
 
     // Build the index for real: parse → chunk → embed → lancedb + FTS.

--- a/tests/push_round_trip.rs
+++ b/tests/push_round_trip.rs
@@ -1,15 +1,15 @@
-//! Gated live round-trip for `sync`. Build a synthetic local store, publish it to a unique
+//! Gated live round-trip for `push`. Build a synthetic local store, publish it to a unique
 //! scratch path on the shared test dataset (create), grow it by a turn and publish again
 //! (append → capture Lance's native append), recall both markers back from the remote, then delete the
 //! scratch path. No real data.
 //!
 //! Skipped unless `HF_FUNES_TEST_TOKEN` is set (it provides `HF_TOKEN` for `Store::open` / the
-//! hf-hub client) AND `trufflehog` is on PATH (sync's pre-publish gate is fail-closed). Needs a
+//! hf-hub client) AND `trufflehog` is on PATH (push's pre-publish gate is fail-closed). Needs a
 //! bigger thread stack than the default — lance + fastembed recurse deeply — so set
 //! `RUST_MIN_STACK` (CI uses the same value). To run:
 //!
 //!   export HF_FUNES_TEST_TOKEN="$(cat hf_funes_test_token.txt)"
-//!   RUST_MIN_STACK=16777216 cargo test --test sync_round_trip -- --nocapture
+//!   RUST_MIN_STACK=16777216 cargo test --test push_round_trip -- --nocapture
 
 use std::io::Write;
 use std::process::Command;
@@ -44,13 +44,13 @@ fn tool_ok(bin: &str, arg: &str) -> bool {
 }
 
 async fn recall_remote(uri: &str, query: &str) -> String {
-    funes::recall::recall(Store::parse(uri, None), query.into(), 5, 30, 0.0, 0, None, None)
+    funes::recall::recall(Store::parse(uri), query.into(), 5, 30, 0.0, 0, None, None)
         .await
         .unwrap_or_else(|e| format!("<recall error: {e}>"))
 }
 
 #[tokio::test]
-async fn sync_round_trip_create_append_recall() {
+async fn push_round_trip_create_append_recall() {
     let token = std::env::var("HF_FUNES_TEST_TOKEN")
         .unwrap_or_default()
         .trim()
@@ -60,7 +60,7 @@ async fn sync_round_trip_create_append_recall() {
         return;
     }
     if !tool_ok("trufflehog", "--version") {
-        eprintln!("skip: trufflehog not installed (sync's secret gate is fail-closed)");
+        eprintln!("skip: trufflehog not installed (push's secret gate is fail-closed)");
         return;
     }
     std::env::set_var("HF_TOKEN", &token);
@@ -73,14 +73,14 @@ async fn sync_round_trip_create_append_recall() {
     // Synthetic local store with one marked turn.
     let db_dir = tempfile::tempdir().unwrap();
     let src = tempfile::tempdir().unwrap();
-    std::env::set_var("FUNES_DB", db_dir.path());
+    std::env::set_var("FUNES_HOME", db_dir.path());
     write_session(src.path(), &[("s1", "SYNCSMOKE parsing transcripts into turns")]);
     funes::index::run_index(src.path(), false).await.unwrap();
 
     // create (first publish) → grow → append (data-only, no reindex) → recall both. The appended
     // turn is left unindexed, so recalling it back exercises Lance's brute-force fallback. Then
     // force a reindex and recall it again, now served by the index.
-    let create = funes::sync::run_sync(Store::parse(&uri, None), false).await;
+    let create = funes::push::run_push(Store::parse(&uri), false).await;
     write_session(
         src.path(),
         &[
@@ -89,15 +89,15 @@ async fn sync_round_trip_create_append_recall() {
         ],
     );
     funes::index::run_index(src.path(), false).await.unwrap();
-    let append = funes::sync::run_sync(Store::parse(&uri, None), false).await;
+    let append = funes::push::run_push(Store::parse(&uri), false).await;
     let recall_base = recall_remote(&uri, "SYNCSMOKE parsing").await;
     let recall_new = recall_remote(&uri, "SYNCSMOKE2 continuation").await;
     // Nothing new to push, so this is a pure forced reindex: fold the unindexed appended turn into
     // the index as its own commit (capture_reindex + a separate commit), then recall it again.
-    let reindex = funes::sync::run_sync(Store::parse(&uri, None), true).await;
+    let reindex = funes::push::run_push(Store::parse(&uri), true).await;
     let recall_reindexed = recall_remote(&uri, "SYNCSMOKE2 continuation").await;
-    // The model id must travel with the store (stamped in the schema metadata, uploaded by sync).
-    let remote_model = match Store::parse(&uri, None).open().await {
+    // The model id must travel with the store (stamped in the schema metadata, uploaded by push).
+    let remote_model = match Store::parse(&uri).open().await {
         Ok(t) => t.schema().metadata.get("embedding_model").cloned(),
         Err(_) => None,
     };
@@ -108,13 +108,13 @@ async fn sync_round_trip_create_append_recall() {
         .dataset(OWNER, NAME)
         .delete_folder()
         .path_in_repo(prefix)
-        .commit_message("cleanup funes sync round-trip test")
+        .commit_message("cleanup funes push round-trip test")
         .send()
         .await;
 
-    let create = create.expect("create sync");
+    let create = create.expect("create push");
     assert!(create.contains("pushed"), "create should publish: {create}");
-    let append = append.expect("append sync");
+    let append = append.expect("append push");
     assert!(
         append.contains("pushed 1 chunks"),
         "append should publish only the new chunk: {append}"
@@ -139,6 +139,6 @@ async fn sync_round_trip_create_append_recall() {
     assert_eq!(
         remote_model.as_deref(),
         Some(funes::index::MODEL),
-        "the model id should travel with the store via sync"
+        "the model id should travel with the store via push"
     );
 }

--- a/tests/push_round_trip.rs
+++ b/tests/push_round_trip.rs
@@ -8,7 +8,7 @@
 //! bigger thread stack than the default — lance + fastembed recurse deeply — so set
 //! `RUST_MIN_STACK` (CI uses the same value). To run:
 //!
-//!   export HF_FUNES_TEST_TOKEN="$(cat hf_funes_test_token.txt)"
+//!   export HF_FUNES_TEST_TOKEN=<your HF token>
 //!   RUST_MIN_STACK=16777216 cargo test --test push_round_trip -- --nocapture
 
 use std::io::Write;

--- a/tests/reindex_incremental.rs
+++ b/tests/reindex_incremental.rs
@@ -1,6 +1,6 @@
 //! Re-indexing a grown session adds only the new turns (continuation = same memory) and
 //! converges to exactly the state of indexing the final session from scratch — no duplication,
-//! no loss. Own test binary so its `$FUNES_DB` can't race the other integration test's.
+//! no loss. Own test binary so its `$FUNES_HOME` can't race the other integration test's.
 
 use std::io::Write;
 
@@ -31,7 +31,7 @@ async fn incremental_reindex_matches_from_scratch() {
     // Incremental: index 4 turns, grow the same session to 6, re-index.
     let inc_src = tempfile::tempdir().unwrap();
     let inc_db = tempfile::tempdir().unwrap();
-    std::env::set_var("FUNES_DB", inc_db.path());
+    std::env::set_var("FUNES_HOME", inc_db.path());
     write_session(inc_src.path(), 4);
     funes::index::run_index(inc_src.path(), false).await.unwrap();
     let after_first = chunk_count().await;
@@ -49,7 +49,7 @@ async fn incremental_reindex_matches_from_scratch() {
     let scratch_src = tempfile::tempdir().unwrap();
     let scratch_db = tempfile::tempdir().unwrap();
     write_session(scratch_src.path(), 6);
-    std::env::set_var("FUNES_DB", scratch_db.path());
+    std::env::set_var("FUNES_HOME", scratch_db.path());
     funes::index::run_index(scratch_src.path(), false).await.unwrap();
     let from_scratch = chunk_count().await;
 

--- a/tests/remote_recall.rs
+++ b/tests/remote_recall.rs
@@ -25,7 +25,7 @@ async fn recall_from_remote_fixture() {
     std::env::set_var("HF_TOKEN", token);
 
     // Open + read over the wire (also exercises the dim guard in open()).
-    let ds = Store::parse(FIXTURE_URI, None)
+    let ds = Store::parse(FIXTURE_URI)
         .open()
         .await
         .expect("open remote fixture over hf://");
@@ -36,17 +36,8 @@ async fn recall_from_remote_fixture() {
     // End-to-end: the full recall pipeline (hybrid vector + BM25 → rerank → recency → format) over
     // the remote store surfaces the marker chunk — exercising both the remote IVF_PQ and inverted-
     // index reads (lazy, Xet-cached). recency off, no neighbors, to keep the assertion tight.
-    let out = funes::recall::recall(
-        Store::parse(FIXTURE_URI, None),
-        MARKER.to_string(),
-        5,
-        30,
-        0.0,
-        0,
-        None,
-        None,
-    )
-    .await
-    .expect("recall over remote fixture");
+    let out = funes::recall::recall(Store::parse(FIXTURE_URI), MARKER.to_string(), 5, 30, 0.0, 0, None, None)
+        .await
+        .expect("recall over remote fixture");
     assert!(out.contains(MARKER), "recall did not surface the marker chunk: {out}");
 }

--- a/tests/remote_recall.rs
+++ b/tests/remote_recall.rs
@@ -1,7 +1,7 @@
 //! Gated live test: open the shared funes fixture hosted on the HF Hub over `hf://` and read
 //! from it. Skipped unless `HF_FUNES_TEST_TOKEN` is in the environment — to run it:
 //!
-//!   export HF_FUNES_TEST_TOKEN="$(cat hf_funes_test_token.txt)"   # or CI secret
+//!   export HF_FUNES_TEST_TOKEN=<your HF token>   # or a CI secret
 //!   cargo test --test remote_recall -- --nocapture
 //!
 //! The fixture is a stable, synthetic, read-only dataset (no real data).


### PR DESCRIPTION
## What & why

Rethinks the first-run DX so funes isn't hub-centric from the start. The arc is now **install → recall (works immediately) → index → wire into your agent → optionally attach a remote**, and the remote tier is a single stateful knob instead of a web of env vars and per-command flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
