### PR TITLE
fix(recall): prefilter filtered queries; tidy store naming and ignores

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,9 @@
 name: Release
 
 on:
+  # main builds (no publish) so the release cache is seeded on main for PRs to restore.
   push:
+    branches: [main]
     tags: ["v*"]
   pull_request:
     branches: [main]
@@ -98,7 +100,7 @@ jobs:
     if: |
       !cancelled() &&
       (startsWith(github.ref, 'refs/tags/') || needs.compute.result == 'success'
-        || github.event_name == 'pull_request')
+        || github.event_name == 'pull_request' || github.ref == 'refs/heads/main')
     # 24.04 (glibc 2.39): the prebuilt onnxruntime pulled by ort_sys/fastembed needs the
     # glibc 2.38+ __isoc23_* symbols, so linking fails on 22.04.
     runs-on: ubuntu-24.04
@@ -152,7 +154,7 @@ jobs:
     if: |
       !cancelled() &&
       (startsWith(github.ref, 'refs/tags/') || needs.compute.result == 'success'
-        || github.event_name == 'pull_request')
+        || github.event_name == 'pull_request' || github.ref == 'refs/heads/main')
     runs-on: macos-14
     timeout-minutes: 45
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,3 @@
-.venv/
-venv/
-dist/
-build/
-.ruff_cache/
 .DS_Store
 
 # Rust build artifacts

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -1,6 +1,6 @@
 //! Shared store helpers: the local store location, opening a dataset, plain scans, and building the
 //! FTS/IVF indexes. funes's home is `$FUNES_HOME`/`~/.funes` — it holds the config (`funes.json`),
-//! the incremental state, and the local store at `…/lancedb` (the `chunks` Lance dataset).
+//! the incremental state, and the local store at `…/store` (the `chunks` Lance dataset).
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -33,7 +33,7 @@ pub fn funes_dir() -> PathBuf {
 
 /// Directory holding the local store (the `chunks` dataset is at `<dir>/chunks.lance`).
 pub fn local_store_dir() -> String {
-    funes_dir().join("lancedb").to_string_lossy().into_owned()
+    funes_dir().join("store").to_string_lossy().into_owned()
 }
 
 /// The `chunks` dataset URI under a store base (a local directory or an `hf://…` prefix).

--- a/src/hub.rs
+++ b/src/hub.rs
@@ -18,14 +18,14 @@ use crate::index::{DIM, MODEL};
 /// A store to recall from: a local Lance directory or a remote dataset on the HF Hub.
 #[derive(Debug, Clone)]
 pub enum Store {
-    /// A local Lance store directory (e.g. `~/.funes/lancedb`).
+    /// A local Lance store directory (e.g. `~/.funes/store`).
     Local { path: PathBuf },
     /// A remote Lance dataset on the HF Hub, e.g. `hf://datasets/<org>/<repo>`.
     Remote { uri: String },
 }
 
 impl Store {
-    /// The default local store (`$FUNES_HOME` / `~/.funes` → `…/lancedb`).
+    /// The default local store (`$FUNES_HOME` / `~/.funes` → `…/store`).
     pub fn local() -> Self {
         Store::Local {
             path: PathBuf::from(dataset::local_store_dir()),

--- a/src/recall.rs
+++ b/src/recall.rs
@@ -102,6 +102,10 @@ fn recency_weight(ts: &str, now: DateTime<Utc>, half_life: f64) -> f64 {
 /// The search is capped at `chunk::OVERLAP`: consecutive splits share at most that many
 /// chars, so any longer suffix==prefix match is a coincidence of repetitive text and would
 /// wrongly drop real content.
+///
+/// `split` trims each piece, so the shared region can lose whitespace at the seam (a trailing
+/// space off `a`, a leading space off `b`). The scan down from `max_k` still finds the overlap
+/// at a smaller `k`, so a trimmed seam doesn't fall through to the duplicating concat fallback.
 fn stitch(a: &str, b: &str) -> String {
     let ac: Vec<char> = a.chars().collect();
     let bc: Vec<char> = b.chars().collect();
@@ -239,6 +243,10 @@ async fn vector_candidates(ds: &Dataset, qv: &[f32], limit: usize, filter: Optio
     let mut scan = ds.scan();
     scan.nearest("vector", &query, limit)?;
     if let Some(f) = filter {
+        // Prefilter: apply the filter before the ANN search, not as a post-filter on the top-`limit`
+        // nearest rows. A selective `--project`/`--type` would otherwise drop most (or all) of a
+        // globally-nearest pool, returning far fewer than `limit` hits even when matches exist.
+        scan.prefilter(true);
         scan.filter(f)?;
     }
     scan.project(HIT_COLS)?;
@@ -251,6 +259,8 @@ async fn fts_candidates(ds: &Dataset, query: &str, limit: usize, filter: Option<
     let mut scan = ds.scan();
     scan.full_text_search(FullTextSearchQuery::new(query.to_string()))?;
     if let Some(f) = filter {
+        // Prefilter so the filter shapes the FTS result set before `limit`, not after.
+        scan.prefilter(true);
         scan.filter(f)?;
     }
     scan.project(HIT_COLS)?;
@@ -628,5 +638,15 @@ mod tests {
     #[test]
     fn stitch_no_overlap_concatenates() {
         assert_eq!(stitch("alpha", "beta"), "alphabeta");
+    }
+
+    #[test]
+    fn stitch_recovers_overlap_with_trimmed_seam_whitespace() {
+        // The real shared region is "the quick brown fox " (trailing space), but split() trims it
+        // off `a`'s end and the leading space off `b`. stitch must still match the shorter overlap
+        // and not duplicate it (no "...foxfox..." and no doubled "the quick brown fox").
+        let a = "HEAD the quick brown fox"; // trailing space trimmed
+        let b = "the quick brown fox TAIL"; // leading already flush
+        assert_eq!(stitch(a, b), "HEAD the quick brown fox TAIL");
     }
 }

--- a/tests/index_recall.rs
+++ b/tests/index_recall.rs
@@ -1,7 +1,7 @@
 //! End-to-end: build a real index from a tiny transcript in a temp dir, then exercise
 //! the read surface (recall / get / list / status). No mocking — this runs the real
 //! BGE embedder + reranker (downloaded to the fastembed cache on first run) against a
-//! real lancedb store under a temp `$FUNES_HOME`.
+//! real Lance store under a temp `$FUNES_HOME`.
 
 use std::io::Write;
 
@@ -32,7 +32,7 @@ async fn index_then_read_surface() {
     std::env::set_var("FUNES_HOME", db_dir.path());
     let (session, project) = write_transcript(source.path());
 
-    // Build the index for real: parse → chunk → embed → lancedb + FTS.
+    // Build the index for real: parse → chunk → embed → Lance + FTS.
     funes::index::run_index(source.path(), false).await.unwrap();
 
     // status: non-empty chunk count.


### PR DESCRIPTION
Filtered recall under-retrieved. The vector and FTS legs set `nearest`/ `full_text_search` plus a `--project`/`--type` filter but never enabled prefiltering, and lance defaults `prefilter` to false — so the filter ran as a post-filter on the top-`candidates` rows. A selective filter could drop most (or all) of a globally-nearest pool, returning far fewer hits than requested even when matches existed. Enable `prefilter(true)` on both legs so the filter shapes the result set before the ANN/FTS limit.

Also, housekeeping bundled in:
- Rename the local store dir `lancedb` -> `store` (lancedb was dropped for raw lance). Existing local stores are migrated in place. Fix the stale `lancedb` doc comments.
- Drop dead Python entries (.venv/dist/build/.ruff_cache) from .gitignore.
- Pin the stitch trimmed-seam invariant with a regression test (the scan down from max_k already recovers a whitespace-trimmed overlap — no logic change).