### PR TITLE
Graceful offline remote handling

### DIFF
--- a/src/hub.rs
+++ b/src/hub.rs
@@ -126,7 +126,7 @@ const PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 /// responded at all: a 403/404/auth answer still counts, since those are real errors the open
 /// should surface rather than an offline signal. Only a transport failure (no connection, DNS, or
 /// timeout), a 5xx, or our own timeout marks it unreachable.
-pub(crate) async fn remote_reachable(uri: &str) -> bool {
+pub async fn remote_reachable(uri: &str) -> bool {
     let Ok((owner, name, _)) = parse_hf(uri) else {
         return true; // not an hf:// dataset URI — let the open report the real error
     };

--- a/src/hub.rs
+++ b/src/hub.rs
@@ -121,11 +121,8 @@ pub(crate) fn parse_hf(uri: &str) -> Result<(String, String, String)> {
 /// How long the reachability probe waits before treating a remote as offline.
 const PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Whether the remote dataset at `uri` answers a lightweight probe — so a read can fall back to the
-/// local index when it can't, instead of hanging on a slow network open. "Reachable" means the Hub
-/// responded at all: a 403/404/auth answer still counts, since those are real errors the open
-/// should surface rather than an offline signal. Only a transport failure (no connection, DNS, or
-/// timeout), a 5xx, or our own timeout marks it unreachable.
+/// Whether the remote dataset at `uri` answers a lightweight probe, so a read can fall back to the
+/// local index instead of hanging on a slow open when the remote is offline.
 pub async fn remote_reachable(uri: &str) -> bool {
     let Ok((owner, name, _)) = parse_hf(uri) else {
         return true; // not an hf:// dataset URI — let the open report the real error

--- a/src/hub.rs
+++ b/src/hub.rs
@@ -8,8 +8,10 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
+use hf_hub::{HFClient, HFError};
 use lance::dataset::Dataset;
 
 use crate::dataset;
@@ -105,6 +107,56 @@ fn is_remote_shorthand(spec: &str) -> bool {
     !spec.starts_with(['/', '.', '~']) && spec.contains('/')
 }
 
+/// Parse `hf://datasets/<owner>/<name>[/<prefix…>]` into (owner, name, prefix). Empty prefix = repo
+/// root, matching how reads resolve a remote.
+pub(crate) fn parse_hf(uri: &str) -> Result<(String, String, String)> {
+    let rest = uri.strip_prefix("hf://").context("remote store must be an hf:// URI")?;
+    let segs: Vec<&str> = rest.split('/').filter(|s| !s.is_empty()).collect();
+    match segs.as_slice() {
+        ["datasets", owner, name, prefix @ ..] => Ok((owner.to_string(), name.to_string(), prefix.join("/"))),
+        _ => anyhow::bail!("expected hf://datasets/<owner>/<name>[/<path>], got {uri}"),
+    }
+}
+
+/// How long the reachability probe waits before treating a remote as offline.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Whether the remote dataset at `uri` answers a lightweight probe — so a read can fall back to the
+/// local index when it can't, instead of hanging on a slow network open. "Reachable" means the Hub
+/// responded at all: a 403/404/auth answer still counts, since those are real errors the open
+/// should surface rather than an offline signal. Only a transport failure (no connection, DNS, or
+/// timeout), a 5xx, or our own timeout marks it unreachable.
+pub(crate) async fn remote_reachable(uri: &str) -> bool {
+    let Ok((owner, name, _)) = parse_hf(uri) else {
+        return true; // not an hf:// dataset URI — let the open report the real error
+    };
+    // No retries: this is a reachability check, so one failed request already means offline. Without
+    // this, hf-hub's default exponential backoff (5 attempts) would drag the probe out for seconds.
+    let mut builder = HFClient::builder().retry_max_attempts(0);
+    if let Some(token) = hf_token() {
+        builder = builder.token(token);
+    }
+    let Ok(client) = builder.build() else {
+        return true;
+    };
+    let repo = client.dataset(owner, name);
+    match tokio::time::timeout(PROBE_TIMEOUT, repo.info().send()).await {
+        Err(_elapsed) => false,
+        Ok(Ok(_)) => true,
+        Ok(Err(e)) => !is_offline_error(&e),
+    }
+}
+
+/// A transport-level failure (no usable HTTP response) or a 5xx — the cases where degrading to the
+/// local index is appropriate (mirrors hf-hub's own transient-error classification).
+fn is_offline_error(e: &HFError) -> bool {
+    match e {
+        HFError::Request { source, .. } => source.is_connect() || source.is_timeout(),
+        HFError::Http { context } => matches!(context.status.as_u16(), 500 | 502 | 503 | 504),
+        _ => false,
+    }
+}
+
 /// HF token from the standard env var, else the `huggingface_hub` cached token file.
 pub(crate) fn hf_token() -> Option<String> {
     let token_file = std::env::var("HOME")
@@ -189,6 +241,31 @@ mod tests {
             Store::Remote { uri } => assert_eq!(uri, "hf://datasets/acme/kb"),
             _ => panic!("expected remote from shorthand"),
         }
+    }
+
+    #[test]
+    fn parse_hf_accepts_repo_root_and_a_prefix() {
+        // repo root: no path after <owner>/<name> -> empty prefix
+        assert_eq!(
+            parse_hf("hf://datasets/acme/kb").unwrap(),
+            ("acme".into(), "kb".into(), "".into())
+        );
+        // an explicit path within the repo is kept
+        assert_eq!(
+            parse_hf("hf://datasets/acme/kb/sub/dir").unwrap(),
+            ("acme".into(), "kb".into(), "sub/dir".into())
+        );
+        // not a dataset URI -> error
+        assert!(parse_hf("hf://acme/kb").is_err());
+        assert!(parse_hf("s3://acme/kb").is_err());
+    }
+
+    #[tokio::test]
+    async fn remote_reachable_short_circuits_non_hf_uri() {
+        // A spec that isn't an hf:// dataset URI can't be probed; we say "reachable" so the open
+        // surfaces the real error rather than masking it as offline. (No network is touched.)
+        assert!(remote_reachable("/local/path").await);
+        assert!(remote_reachable("not a uri").await);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -209,6 +209,13 @@ async fn use_store(spec: String) -> Result<()> {
     config::save(&cfg)?;
     println!("active store: {uri}");
 
+    // The overlap heuristic reads the remote's chunk ids; an unreachable remote would read as empty
+    // and wrongly hint at pushing. Attach anyway and say so — recall falls back to the local index.
+    if !hub::remote_reachable(&uri).await {
+        println!("remote currently unreachable — recall will use your local index until it's back");
+        return Ok(());
+    }
+
     let local = push::store_ids(&hub::Store::local()).await;
     let remote = push::store_ids(&hub::Store::parse(&uri)).await;
     let unpushed = local.difference(&remote).count();

--- a/src/push.rs
+++ b/src/push.rs
@@ -37,17 +37,6 @@ const REINDEX_THRESHOLD: u64 = 2_000;
 /// moving under us, so a busy remote can't spin forever.
 const MAX_COMMIT_RETRIES: u32 = 10;
 
-/// Parse `hf://datasets/<owner>/<name>[/<prefix…>]` into (owner, name, prefix). Empty prefix = repo
-/// root, matching how reads resolve a remote.
-fn parse_hf(uri: &str) -> Result<(String, String, String)> {
-    let rest = uri.strip_prefix("hf://").context("remote store must be an hf:// URI")?;
-    let segs: Vec<&str> = rest.split('/').filter(|s| !s.is_empty()).collect();
-    match segs.as_slice() {
-        ["datasets", owner, name, prefix @ ..] => Ok((owner.to_string(), name.to_string(), prefix.join("/"))),
-        _ => bail!("expected hf://datasets/<owner>/<name>[/<path>], got {uri}"),
-    }
-}
-
 /// Every chunk id in a store, or empty if it can't be opened (absent local index, not-yet-created
 /// or inaccessible remote).
 pub async fn store_ids(store: &Store) -> HashSet<String> {
@@ -147,7 +136,7 @@ pub async fn run_push(target: Store, force_reindex: bool) -> Result<String> {
     }
 
     // 2. HF repo handle (every write path below needs it).
-    let (owner, name, prefix) = parse_hf(&uri)?;
+    let (owner, name, prefix) = hub::parse_hf(&uri)?;
     let token = hub::hf_token().context("no HF token (set HF_TOKEN) — required to push")?;
     let client = HFClient::builder()
         .token(token.clone())
@@ -311,22 +300,5 @@ mod tests {
         // path can't be built here; it's exercised by the gated round-trip.)
         assert!(!is_read_only(&anyhow::anyhow!("server said 403 Forbidden")));
         assert!(!is_read_only(&anyhow::anyhow!("no HF token")));
-    }
-
-    #[test]
-    fn parse_hf_accepts_repo_root_and_a_prefix() {
-        // repo root: no path after <owner>/<name> -> empty prefix
-        assert_eq!(
-            parse_hf("hf://datasets/acme/kb").unwrap(),
-            ("acme".into(), "kb".into(), "".into())
-        );
-        // an explicit path within the repo is kept
-        assert_eq!(
-            parse_hf("hf://datasets/acme/kb/sub/dir").unwrap(),
-            ("acme".into(), "kb".into(), "sub/dir".into())
-        );
-        // not a dataset URI -> error
-        assert!(parse_hf("hf://acme/kb").is_err());
-        assert!(parse_hf("s3://acme/kb").is_err());
     }
 }

--- a/src/push.rs
+++ b/src/push.rs
@@ -115,6 +115,12 @@ pub async fn run_push(target: Store, force_reindex: bool) -> Result<String> {
         }
     };
 
+    // Fail fast when offline. Otherwise the remote read below sees an empty set, mistakes the
+    // unreachable remote for a first publish, and builds the whole dataset before the commit fails.
+    if !hub::remote_reachable(&uri).await {
+        bail!("{uri} is unreachable — can't push while offline (check your connection)");
+    }
+
     // 1. Delta: local_ids − remote_ids (remote absent => first publish).
     let local = Store::local().open().await?;
     let local_ids = all_ids(&local).await?;

--- a/src/recall.rs
+++ b/src/recall.rs
@@ -5,7 +5,7 @@
 
 use crate::dataset;
 use crate::hello;
-use crate::hub::Store;
+use crate::hub::{self, Store};
 use anyhow::{Context, Result};
 use arrow_array::{Float32Array, Int64Array, RecordBatch, StringArray, UInt64Array};
 use chrono::{DateTime, Utc};
@@ -123,22 +123,66 @@ struct Read {
     /// Keeps the hello-world temp dir alive for the dataset's lifetime; `None` for a real store.
     _hello: Option<tempfile::TempDir>,
     ds: Dataset,
+    /// A degradation note to prepend to the command's output (e.g. the remote was unreachable);
+    /// `None` when the requested store opened normally.
+    note: Option<String>,
 }
 
-/// Open a store for reading. When the default local index is absent, fall back to the built-in
-/// hello-world corpus so a fresh install can recall something useful with zero indexing — passing
-/// `embedder` gives the corpus real vectors for search (recall), `None` is fine for `get`/`list`.
-/// An explicit path or remote store that can't open is a real error, never masked by the corpus.
+/// Open a store for reading, degrading gracefully:
+/// - an active remote we can't reach (offline) falls back to the local index, then to the built-in
+///   guide — recall keeps working without the network;
+/// - the absent default local index falls back to the built-in guide, so a fresh install can recall
+///   something useful with zero indexing.
+///
+/// A remote that *is* reachable but fails to open (wrong schema, missing dataset) is a real error
+/// and surfaces. Passing `embedder` gives the built-in corpus real vectors for search (recall);
+/// `None` is fine for `get`/`list`.
 async fn open_read(store: &Store, embedder: Option<&mut TextEmbedding>) -> Result<Read> {
+    // Probe a remote up front: an offline host degrades fast instead of hanging on a slow open.
+    if let Store::Remote { uri } = store {
+        if !hub::remote_reachable(uri).await {
+            return degrade_offline(uri, embedder).await;
+        }
+    }
     match store.open().await {
-        Ok(ds) => Ok(Read { _hello: None, ds }),
+        Ok(ds) => Ok(Read {
+            _hello: None,
+            ds,
+            note: None,
+        }),
         Err(e) => {
             if store.is_default_local() {
                 let (dir, ds) = hello::dataset(embedder).await?;
-                Ok(Read { _hello: Some(dir), ds })
+                Ok(Read {
+                    _hello: Some(dir),
+                    ds,
+                    note: None,
+                })
             } else {
                 Err(e)
             }
+        }
+    }
+}
+
+/// Degrade an unreachable remote to the local index, or to the built-in guide if there's no local
+/// index either, carrying a note that explains what happened.
+async fn degrade_offline(uri: &str, embedder: Option<&mut TextEmbedding>) -> Result<Read> {
+    match Store::local().open().await {
+        Ok(ds) => Ok(Read {
+            _hello: None,
+            ds,
+            note: Some(format!("remote {uri} unreachable — recalling from your local index\n")),
+        }),
+        Err(_) => {
+            let (dir, ds) = hello::dataset(embedder).await?;
+            Ok(Read {
+                _hello: Some(dir),
+                ds,
+                note: Some(format!(
+                    "remote {uri} unreachable and no local index yet — showing the built-in guide\n"
+                )),
+            })
         }
     }
 }
@@ -163,6 +207,7 @@ pub async fn recall(
         .context("empty embedding")?;
 
     let read = open_read(&store, Some(&mut embedder)).await?;
+    let note = read.note.clone().unwrap_or_default();
     let ds = &read.ds;
     let where_clause = build_where(block_type.as_deref(), project.as_deref());
 
@@ -171,7 +216,7 @@ pub async fn recall(
     // recall then falls back to vector-only.
     let hits = hybrid_candidates(ds, &qv, &query, candidates, where_clause.as_deref()).await?;
     if hits.is_empty() {
-        return Ok("no results".to_string());
+        return Ok(format!("{note}no results"));
     }
 
     let mut reranker = TextRerank::try_new(RerankInitOptions::new(RerankerModel::BGERerankerBase))?;
@@ -203,7 +248,7 @@ pub async fn recall(
         attach_neighbors(ds, &mut refs, neighbors).await?;
     }
 
-    let mut out = String::new();
+    let mut out = note;
     for (h, score) in &top {
         let s8 = &h.session_id[..h.session_id.len().min(8)];
         let _ = writeln!(
@@ -405,6 +450,7 @@ async fn attach_neighbors(ds: &Dataset, hits: &mut [&mut Hit], window: i64) -> R
 /// Browse indexed sessions: one line per session, newest activity first.
 pub async fn list(store: Store, project: Option<String>, limit: usize) -> Result<String> {
     let read = open_read(&store, None).await?;
+    let note = read.note.clone().unwrap_or_default();
     let ds = &read.ds;
 
     let cols = ["session_id", "project", "ts", "role", "text"];
@@ -472,13 +518,14 @@ pub async fn list(store: Store, project: Option<String>, limit: usize) -> Result
     if out.is_empty() {
         out.push_str("no sessions\n");
     }
-    Ok(out)
+    Ok(format!("{note}{out}"))
 }
 
 /// Drill down on a recall hit: the named turn plus the turns within `window` of it, each
 /// reassembled (blocks in order, splits de-overlapped) into one readable passage.
 pub async fn get(store: Store, session_id: String, turn_uuid: String, window: i64) -> Result<String> {
     let read = open_read(&store, None).await?;
+    let note = read.note.clone().unwrap_or_default();
     let ds = &read.ds;
 
     let cols = ["turn_uuid", "seq", "ts", "role", "text", "block_idx", "split_idx"];
@@ -514,7 +561,7 @@ pub async fn get(store: Store, session_id: String, turn_uuid: String, window: i6
 
     let center = match rows.iter().find(|r| r.1 == turn_uuid) {
         Some(r) => r.0,
-        None => return Ok(format!("turn {turn_uuid} not found in session {session_id}\n")),
+        None => return Ok(format!("{note}turn {turn_uuid} not found in session {session_id}\n")),
     };
 
     // Group selected rows by (seq, turn_uuid).
@@ -552,10 +599,19 @@ pub async fn get(store: Store, session_id: String, turn_uuid: String, window: i6
         let _ = writeln!(out, "{}", blocks.join("\n\n"));
         let _ = writeln!(out, "---");
     }
-    Ok(out)
+    Ok(format!("{note}{out}"))
 }
 
 pub async fn status(store: Store) -> Result<String> {
+    // An unreachable remote degrades to the local index's status, like the read commands.
+    if let Store::Remote { uri } = &store {
+        if !hub::remote_reachable(uri).await {
+            let body = Box::pin(status(Store::local())).await?;
+            return Ok(format!(
+                "remote {uri} unreachable — showing the local index instead\n{body}"
+            ));
+        }
+    }
     match store.open().await {
         Ok(ds) => {
             let rows = ds.count_rows(None).await?;


### PR DESCRIPTION
When the used remote is offline, warn the user and switch to the local store for recall.