### PR TITLE
ci: ship an official aarch64-linux release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,9 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             arch: x86_64
+          - target: aarch64-unknown-linux-gnu
+            arch: aarch64
+            features: --features vendored-openssl
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
@@ -129,6 +132,19 @@ jobs:
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
+      # aarch64 is cross-compiled on the x86_64 runner: the cross gcc both links the binary
+      # and (via the cc crate) builds vendored OpenSSL for the target. cc derives the tool
+      # name from the target triple, so installing the package is enough.
+      - name: Install aarch64 cross toolchain
+        if: matrix.arch == 'aarch64'
+        run: |
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+          mkdir -p ~/.cargo
+          {
+            echo '[target.aarch64-unknown-linux-gnu]'
+            echo 'linker = "aarch64-linux-gnu-gcc"'
+          } >> ~/.cargo/config.toml
+
       # Stamp the computed version into the working tree (no commit) so the binary embeds
       # it via CARGO_PKG_VERSION. Skipped on tag/PR builds, which use Cargo.toml as-is.
       - name: Set release version
@@ -136,7 +152,7 @@ jobs:
         run: perl -i -pe 'if (!$d && s/^version = ".*"/version = "${{ needs.compute.outputs.version }}"/) { $d = 1 }' Cargo.toml
 
       - name: Build
-        run: cargo build --release --target ${{ matrix.target }}
+        run: cargo build --release --target ${{ matrix.target }} ${{ matrix.features }}
 
       - name: Package
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,13 +132,14 @@ jobs:
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
-      # aarch64 is cross-compiled on the x86_64 runner: the cross gcc both links the binary
-      # and (via the cc crate) builds vendored OpenSSL for the target. cc derives the tool
-      # name from the target triple, so installing the package is enough.
+      # aarch64 is cross-compiled on the x86_64 runner. gcc-aarch64-linux-gnu links the binary
+      # and (via the cc crate) builds vendored OpenSSL for the target; g++-aarch64-linux-gnu
+      # brings the target libstdc++ that onnxruntime (ort, C++) links against. cc derives the
+      # tool names from the target triple, so installing the packages is enough.
       - name: Install aarch64 cross toolchain
         if: matrix.arch == 'aarch64'
         run: |
-          sudo apt-get install -y gcc-aarch64-linux-gnu
+          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
           mkdir -p ~/.cargo
           {
             echo '[target.aarch64-unknown-linux-gnu]'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2894,6 +2894,7 @@ dependencies = [
  "lance-io",
  "lance-linalg",
  "object_store",
+ "openssl-sys",
  "rmcp",
  "serde",
  "serde_json",
@@ -5595,6 +5596,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.0+3.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5602,6 +5612,7 @@ checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,13 @@ walkdir = "2"                    # recursive *.jsonl walk
 rmcp = { version = "1", features = ["server", "macros", "transport-io", "schemars"] }  # MCP stdio server
 tempfile = "3"                   # temp dir for the pre-publish secret scan; temp files/dirs in tests
 hf-hub = { version = "1.0.0-rc.1", features = ["rustls-tls"] }  # native create_commit + parent_commit CAS + Xet upload
+# Optional handle on the transitively-pulled openssl-sys (native-tls, via fastembed + lance).
+# The `vendored-openssl` feature builds OpenSSL from source so the aarch64-linux cross-build
+# needs no target sysroot. Off by default — native and macOS builds keep their system TLS.
+openssl-sys = { version = "0.9", optional = true }
+
+[features]
+vendored-openssl = ["openssl-sys/vendored"]
 
 [profile.release]
 opt-level = 3

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Or grab a [binary](https://github.com/huggingface/funes/releases) by hand:
 | Platform | Binary |
 | --- | --- |
 | Linux x86_64 | `funes-x86_64-linux` |
+| Linux aarch64 | `funes-aarch64-linux` |
 | macOS Apple Silicon | `funes-arm64-apple-darwin` |
 
 ```bash

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -31,6 +31,7 @@ done
 # targets are built; everything else falls through to build-from-source.
 case "$(uname -s)-$(uname -m)" in
     Linux-x86_64)                  asset="funes-x86_64-linux" ;;
+    Linux-aarch64 | Linux-arm64)   asset="funes-aarch64-linux" ;;
     Darwin-arm64 | Darwin-aarch64) asset="funes-arm64-apple-darwin" ;;
     *)
         echo "funes: no prebuilt binary for $(uname -s)/$(uname -m)." >&2


### PR DESCRIPTION
Cross-compile aarch64-unknown-linux-gnu on the x86_64 runner with gcc-aarch64-linux-gnu and a vendored OpenSSL (openssl-sys/vendored), mirroring hf-mount. openssl-sys is pulled for the Linux target via native-tls (fastembed's bundled hf-hub + lance's reqwest) and can't cross-compile without a target sysroot; vendoring builds it from source instead. This is the fork not taken in 432fd9d, where aarch64-linux was dropped rather than vendored.

Also adds the funes-aarch64-linux asset, an install.sh Linux-aarch64 case, and a README row. The onnxruntime cross-link (ort-sys) is untested and validated by the first build run.