### PR TITLE
fix(recall): report a missing remote store, not lance's internal error

### DIFF
--- a/src/hub.rs
+++ b/src/hub.rs
@@ -157,13 +157,6 @@ pub async fn remote_reachability(uri: &str) -> Reachability {
     }
 }
 
-/// Whether the remote is reachable enough to read from — false only when offline, so a read can
-/// fall back to the local index. A missing or auth-failing repo is "reachable": the open then
-/// surfaces the real error.
-pub async fn remote_reachable(uri: &str) -> bool {
-    !matches!(remote_reachability(uri).await, Reachability::Offline)
-}
-
 /// A transport-level failure (no usable HTTP response) or a 5xx — the cases where degrading to the
 /// local index is appropriate (mirrors hf-hub's own transient-error classification).
 fn is_offline_error(e: &HFError) -> bool {
@@ -278,11 +271,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn remote_reachable_short_circuits_non_hf_uri() {
-        // A spec that isn't an hf:// dataset URI can't be probed; we say "reachable" so the open
+    async fn non_hf_uri_is_reachable_ok() {
+        // A spec that isn't an hf:// dataset URI can't be probed; it reports Ok so the open
         // surfaces the real error rather than masking it as offline. (No network is touched.)
-        assert!(remote_reachable("/local/path").await);
-        assert!(remote_reachable("not a uri").await);
+        assert!(matches!(remote_reachability("/local/path").await, Reachability::Ok));
+        assert!(matches!(remote_reachability("not a uri").await, Reachability::Ok));
     }
 
     #[test]

--- a/src/hub.rs
+++ b/src/hub.rs
@@ -13,7 +13,6 @@ use std::time::Duration;
 use anyhow::{anyhow, Context, Result};
 use hf_hub::{HFClient, HFError};
 use lance::dataset::Dataset;
-use lance::Error as LanceError;
 
 use crate::config;
 use crate::dataset;
@@ -168,55 +167,6 @@ fn is_offline_error(e: &HFError) -> bool {
     }
 }
 
-/// The outcome of resolving a store for reading. The embedder-backed fallbacks (`Offline` → the
-/// local index, `NoIndex` → the built-in guide) are the caller's to apply, so this stays free of
-/// `fastembed`; a missing or empty remote is a hard error with a clear message.
-// A transient return value, never stored en masse, so the `Ready(Dataset)`/unit size gap is fine —
-// boxing would only add indirection.
-#[allow(clippy::large_enum_variant)]
-pub enum ReadOutcome {
-    /// Opened and ready to query.
-    Ready(Dataset),
-    /// The remote is unreachable — recall from the local index instead.
-    Offline,
-    /// No local index yet — show the built-in guide.
-    NoIndex,
-}
-
-/// Resolve a store for reading — the one place every remote-source state is handled. An offline
-/// remote degrades (`Offline`); a missing or empty remote errors with a clear message; an absent
-/// default local index degrades (`NoIndex`); a present store opens (`Ready`). `recall`/`get`/`list`/
-/// `status` all route through this.
-pub async fn open_for_read(store: &Store) -> Result<ReadOutcome> {
-    if let Store::Remote { uri } = store {
-        match remote_reachability(uri).await {
-            Reachability::Offline => return Ok(ReadOutcome::Offline),
-            Reachability::Missing => return Err(missing_remote(uri)),
-            Reachability::Ok => {}
-        }
-    }
-    match store.open().await {
-        Ok(ds) => Ok(ReadOutcome::Ready(ds)),
-        // The default local store with no index yet → the built-in guide (the caller builds it).
-        Err(_) if store.is_default_local() => Ok(ReadOutcome::NoIndex),
-        // Opened to nothing: a reachable remote that was never pushed to, or a local path with no
-        // dataset. Either way, a clear message beats lance's internal path error.
-        Err(e) if is_missing_dataset(&e) => match store {
-            Store::Remote { uri } => Err(empty_remote(uri)),
-            Store::Local { path } => Err(anyhow!("no index found at {}", path.display())),
-        },
-        Err(e) => Err(e),
-    }
-}
-
-/// True if `e` is lance reporting the `chunks.lance` dataset isn't there — the store opened to no
-/// index (an empty or never-pushed remote, or a path with no dataset). Lets reads report an empty
-/// store instead of leaking lance's internal path/`_versions` error.
-fn is_missing_dataset(e: &anyhow::Error) -> bool {
-    e.chain()
-        .any(|c| matches!(c.downcast_ref::<LanceError>(), Some(LanceError::DatasetNotFound { .. })))
-}
-
 /// The active remote repo doesn't exist on the Hub — funes never creates it. Shared by recall,
 /// `push`, and `use` so the message is identical everywhere.
 pub fn missing_remote(uri: &str) -> anyhow::Error {
@@ -343,20 +293,6 @@ mod tests {
         // surfaces the real error rather than masking it as offline. (No network is touched.)
         assert!(matches!(remote_reachability("/local/path").await, Reachability::Ok));
         assert!(matches!(remote_reachability("not a uri").await, Reachability::Ok));
-    }
-
-    #[tokio::test]
-    async fn missing_dataset_is_detected() {
-        // Opening a path with no dataset is lance's DatasetNotFound — the empty/absent case.
-        let err = dataset::open("/nonexistent/funes-empty-store/chunks.lance", HashMap::new())
-            .await
-            .unwrap_err();
-        assert!(is_missing_dataset(&err));
-    }
-
-    #[test]
-    fn unrelated_error_is_not_missing_dataset() {
-        assert!(!is_missing_dataset(&anyhow!("some other failure")));
     }
 
     #[test]

--- a/src/hub.rs
+++ b/src/hub.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 use anyhow::{anyhow, Context, Result};
 use hf_hub::{HFClient, HFError};
 use lance::dataset::Dataset;
+use lance::Error as LanceError;
 
 use crate::config;
 use crate::dataset;
@@ -167,6 +168,72 @@ fn is_offline_error(e: &HFError) -> bool {
     }
 }
 
+/// The outcome of resolving a store for reading. The embedder-backed fallbacks (`Offline` → the
+/// local index, `NoIndex` → the built-in guide) are the caller's to apply, so this stays free of
+/// `fastembed`; a missing or empty remote is a hard error with a clear message.
+// A transient return value, never stored en masse, so the `Ready(Dataset)`/unit size gap is fine —
+// boxing would only add indirection.
+#[allow(clippy::large_enum_variant)]
+pub enum ReadOutcome {
+    /// Opened and ready to query.
+    Ready(Dataset),
+    /// The remote is unreachable — recall from the local index instead.
+    Offline,
+    /// No local index yet — show the built-in guide.
+    NoIndex,
+}
+
+/// Resolve a store for reading — the one place every remote-source state is handled. An offline
+/// remote degrades (`Offline`); a missing or empty remote errors with a clear message; an absent
+/// default local index degrades (`NoIndex`); a present store opens (`Ready`). `recall`/`get`/`list`/
+/// `status` all route through this.
+pub async fn open_for_read(store: &Store) -> Result<ReadOutcome> {
+    if let Store::Remote { uri } = store {
+        match remote_reachability(uri).await {
+            Reachability::Offline => return Ok(ReadOutcome::Offline),
+            Reachability::Missing => return Err(missing_remote(uri)),
+            Reachability::Ok => {}
+        }
+    }
+    match store.open().await {
+        Ok(ds) => Ok(ReadOutcome::Ready(ds)),
+        // The default local store with no index yet → the built-in guide (the caller builds it).
+        Err(_) if store.is_default_local() => Ok(ReadOutcome::NoIndex),
+        // Opened to nothing: a reachable remote that was never pushed to, or a local path with no
+        // dataset. Either way, a clear message beats lance's internal path error.
+        Err(e) if is_missing_dataset(&e) => match store {
+            Store::Remote { uri } => Err(empty_remote(uri)),
+            Store::Local { path } => Err(anyhow!("no index found at {}", path.display())),
+        },
+        Err(e) => Err(e),
+    }
+}
+
+/// True if `e` is lance reporting the `chunks.lance` dataset isn't there — the store opened to no
+/// index (an empty or never-pushed remote, or a path with no dataset). Lets reads report an empty
+/// store instead of leaking lance's internal path/`_versions` error.
+fn is_missing_dataset(e: &anyhow::Error) -> bool {
+    e.chain()
+        .any(|c| matches!(c.downcast_ref::<LanceError>(), Some(LanceError::DatasetNotFound { .. })))
+}
+
+/// The active remote repo doesn't exist on the Hub — funes never creates it. Shared by recall,
+/// `push`, and `use` so the message is identical everywhere.
+pub fn missing_remote(uri: &str) -> anyhow::Error {
+    anyhow!(
+        "{uri} doesn't exist on the Hub, and funes won't create it — create the dataset repo \
+         first (https://huggingface.co/new-dataset)"
+    )
+}
+
+/// The remote repo exists but holds no index yet.
+pub fn empty_remote(uri: &str) -> anyhow::Error {
+    anyhow!(
+        "{uri} exists on the Hub but holds no index yet — `funes push` to publish your local \
+         index there, or `funes use local` to read your local index"
+    )
+}
+
 /// HF token from the standard env var, else the `huggingface_hub` cached token file.
 pub(crate) fn hf_token() -> Option<String> {
     let token_file = std::env::var("HOME")
@@ -276,6 +343,20 @@ mod tests {
         // surfaces the real error rather than masking it as offline. (No network is touched.)
         assert!(matches!(remote_reachability("/local/path").await, Reachability::Ok));
         assert!(matches!(remote_reachability("not a uri").await, Reachability::Ok));
+    }
+
+    #[tokio::test]
+    async fn missing_dataset_is_detected() {
+        // Opening a path with no dataset is lance's DatasetNotFound — the empty/absent case.
+        let err = dataset::open("/nonexistent/funes-empty-store/chunks.lance", HashMap::new())
+            .await
+            .unwrap_err();
+        assert!(is_missing_dataset(&err));
+    }
+
+    #[test]
+    fn unrelated_error_is_not_missing_dataset() {
+        assert!(!is_missing_dataset(&anyhow!("some other failure")));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -227,10 +227,7 @@ async fn use_store(spec: String) -> Result<()> {
             return Ok(());
         }
         hub::Reachability::Missing => {
-            println!(
-                "note: this repo doesn't exist on the Hub yet, and funes won't create it — create \
-                 the dataset repo (https://huggingface.co/new-dataset) before you push"
-            );
+            println!("note: {}", hub::missing_remote(&uri));
             return Ok(());
         }
         hub::Reachability::Ok => {}

--- a/src/push.rs
+++ b/src/push.rs
@@ -121,10 +121,7 @@ pub async fn run_push(target: Store, force_reindex: bool) -> Result<Pushed> {
         hub::Reachability::Offline => {
             bail!("{uri} is unreachable — can't push while offline (check your connection)")
         }
-        hub::Reachability::Missing => bail!(
-            "{uri} doesn't exist on the Hub, and funes won't create it — create the dataset repo \
-             first (https://huggingface.co/new-dataset), then run push again"
-        ),
+        hub::Reachability::Missing => return Err(hub::missing_remote(&uri)),
         hub::Reachability::Ok => {}
     }
 

--- a/src/recall.rs
+++ b/src/recall.rs
@@ -6,7 +6,7 @@
 use crate::chunk;
 use crate::dataset;
 use crate::hello;
-use crate::hub::{self, Store};
+use crate::hub::{self, Reachability, Store};
 use anyhow::{Context, Result};
 use arrow_array::{Float32Array, Int64Array, RecordBatch, StringArray, UInt64Array};
 use chrono::{DateTime, Utc};
@@ -120,8 +120,10 @@ struct Read {
 async fn open_read(store: &Store, embedder: Option<&mut TextEmbedding>) -> Result<Read> {
     // Probe a remote up front: an offline host degrades fast instead of hanging on a slow open.
     if let Store::Remote { uri } = store {
-        if !hub::remote_reachable(uri).await {
-            return degrade_offline(uri, embedder).await;
+        match hub::remote_reachability(uri).await {
+            Reachability::Offline => return degrade_offline(uri, embedder).await,
+            Reachability::Missing => return Err(empty_store(store)),
+            Reachability::Ok => {}
         }
     }
     match store.open().await {
@@ -165,6 +167,18 @@ async fn degrade_offline(uri: &str, embedder: Option<&mut TextEmbedding>) -> Res
             })
         }
     }
+}
+
+/// User-facing error for a store the Hub reports as [`Reachability::Missing`] — the repo doesn't
+/// exist (or holds no index) — instead of letting the open leak lance's internal
+/// `chunks.lance`/`_versions` path error.
+fn empty_store(store: &Store) -> anyhow::Error {
+    anyhow::anyhow!(
+        "the store at {} was not found on the Hub — it doesn't exist yet or holds no index. \
+         push one with `funes index` (or `funes push`), or `funes use local` to read your \
+         local index.",
+        store.label()
+    )
 }
 
 /// The embedder + reranker, loaded once and shared. Loading them (ONNX init) is the costly part of
@@ -608,11 +622,15 @@ pub async fn get(store: Store, session_id: String, turn_uuid: String, window: i6
 pub async fn status(store: Store) -> Result<String> {
     // An unreachable remote degrades to the local index's status, like the read commands.
     if let Store::Remote { uri } = &store {
-        if !hub::remote_reachable(uri).await {
-            let body = Box::pin(status(Store::local())).await?;
-            return Ok(format!(
-                "remote {uri} unreachable — showing the local index instead\n{body}"
-            ));
+        match hub::remote_reachability(uri).await {
+            Reachability::Offline => {
+                let body = Box::pin(status(Store::local())).await?;
+                return Ok(format!(
+                    "remote {uri} unreachable — showing the local index instead\n{body}"
+                ));
+            }
+            Reachability::Missing => return Err(empty_store(&store)),
+            Reachability::Ok => {}
         }
     }
     match store.open().await {

--- a/src/recall.rs
+++ b/src/recall.rs
@@ -6,14 +6,13 @@
 use crate::chunk;
 use crate::dataset;
 use crate::hello;
-use crate::hub::{self, Reachability, Store};
+use crate::hub::{self, ReadOutcome, Store};
 use anyhow::{Context, Result};
 use arrow_array::{Float32Array, Int64Array, RecordBatch, StringArray, UInt64Array};
 use chrono::{DateTime, Utc};
 use fastembed::{EmbeddingModel, InitOptions, RerankInitOptions, RerankerModel, TextEmbedding, TextRerank};
 use futures::TryStreamExt;
 use lance::dataset::{Dataset, ROW_ID};
-use lance::Error as LanceError;
 use lance_index::scalar::FullTextSearchQuery;
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::Write as _;
@@ -109,55 +108,40 @@ struct Read {
     note: Option<String>,
 }
 
-/// Open a store for reading, degrading gracefully:
-/// - an active remote we can't reach (offline) falls back to the local index, then to the built-in
-///   guide — recall keeps working without the network;
-/// - the absent default local index falls back to the built-in guide, so a fresh install can recall
-///   something useful with zero indexing.
-///
-/// A remote that *is* reachable but fails to open (wrong schema, missing dataset) is a real error
-/// and surfaces. Passing `embedder` gives the built-in corpus real vectors for search (recall);
-/// `None` is fine for `get`/`list`.
+/// Open a store for reading, applying the embedder-backed fallbacks [`hub::open_for_read`] leaves to
+/// the caller: an unreachable remote degrades to the local index (then the built-in guide), and an
+/// absent local index serves the guide — so recall keeps working offline and on a fresh install. A
+/// missing or empty remote surfaces as an error from the helper. Passing `embedder` gives the
+/// built-in corpus real vectors for search (recall); `None` suits `get`/`list`.
 async fn open_read(store: &Store, embedder: Option<&mut TextEmbedding>) -> Result<Read> {
-    // Probe a remote up front: an offline host degrades fast instead of hanging on a slow open.
-    if let Store::Remote { uri } = store {
-        if matches!(hub::remote_reachability(uri).await, Reachability::Offline) {
-            return degrade_offline(uri, embedder).await;
-        }
-    }
-    match store.open().await {
-        Ok(ds) => Ok(Read {
+    match hub::open_for_read(store).await? {
+        ReadOutcome::Ready(ds) => Ok(Read {
             _hello: None,
             ds,
             note: None,
         }),
-        Err(e) => {
-            if store.is_default_local() {
-                let (dir, ds) = hello::dataset(embedder).await?;
-                Ok(Read {
-                    _hello: Some(dir),
-                    ds,
-                    note: None,
-                })
-            } else if is_missing_dataset(&e) {
-                Err(empty_store(store))
-            } else {
-                Err(e)
-            }
+        ReadOutcome::Offline => degrade_offline(&store.label(), embedder).await,
+        ReadOutcome::NoIndex => {
+            let (dir, ds) = hello::dataset(embedder).await?;
+            Ok(Read {
+                _hello: Some(dir),
+                ds,
+                note: None,
+            })
         }
     }
 }
 
-/// Degrade an unreachable remote to the local index, or to the built-in guide if there's no local
+/// An unreachable remote degrades to the local index, or to the built-in guide if there's no local
 /// index either, carrying a note that explains what happened.
 async fn degrade_offline(uri: &str, embedder: Option<&mut TextEmbedding>) -> Result<Read> {
-    match Store::local().open().await {
-        Ok(ds) => Ok(Read {
+    match hub::open_for_read(&Store::local()).await {
+        Ok(ReadOutcome::Ready(ds)) => Ok(Read {
             _hello: None,
             ds,
             note: Some(format!("remote {uri} unreachable — recalling from your local index\n")),
         }),
-        Err(_) => {
+        _ => {
             let (dir, ds) = hello::dataset(embedder).await?;
             Ok(Read {
                 _hello: Some(dir),
@@ -168,24 +152,6 @@ async fn degrade_offline(uri: &str, embedder: Option<&mut TextEmbedding>) -> Res
             })
         }
     }
-}
-
-/// True if `e` is lance reporting the `chunks.lance` dataset isn't there — a reachable store with no
-/// index: a remote repo that's empty or never-pushed, one that doesn't exist, or a local path with
-/// no dataset. Lets the read commands report an empty store instead of leaking lance's internal
-/// path/`_versions` error.
-fn is_missing_dataset(e: &anyhow::Error) -> bool {
-    e.chain()
-        .any(|c| matches!(c.downcast_ref::<LanceError>(), Some(LanceError::DatasetNotFound { .. })))
-}
-
-/// User-facing error for a reachable store that holds no index — empty, never pushed, or absent.
-fn empty_store(store: &Store) -> anyhow::Error {
-    anyhow::anyhow!(
-        "the store at {} is empty — no index found there. publish a local index to it with \
-         `funes push`, or `funes use local` to read your local index.",
-        store.label()
-    )
 }
 
 /// The embedder + reranker, loaded once and shared. Loading them (ONNX init) is the costly part of
@@ -627,17 +593,8 @@ pub async fn get(store: Store, session_id: String, turn_uuid: String, window: i6
 }
 
 pub async fn status(store: Store) -> Result<String> {
-    // An unreachable remote degrades to the local index's status, like the read commands.
-    if let Store::Remote { uri } = &store {
-        if matches!(hub::remote_reachability(uri).await, Reachability::Offline) {
-            let body = Box::pin(status(Store::local())).await?;
-            return Ok(format!(
-                "remote {uri} unreachable — showing the local index instead\n{body}"
-            ));
-        }
-    }
-    match store.open().await {
-        Ok(ds) => {
+    match hub::open_for_read(&store).await? {
+        ReadOutcome::Ready(ds) => {
             let rows = ds.count_rows(None).await?;
             Ok(format!(
                 "store: {}\ntable:  {}\nchunks: {rows}\n",
@@ -645,15 +602,21 @@ pub async fn status(store: Store) -> Result<String> {
                 dataset::TABLE
             ))
         }
-        // No personal index yet: point the user at `funes index` instead of erroring. (Recall/get/
-        // list quietly serve the built-in hello-world guide in the same situation.)
-        Err(_) if store.is_default_local() => Ok(format!(
+        // An unreachable remote shows the local index's status instead, like the read commands.
+        ReadOutcome::Offline => {
+            let body = Box::pin(status(Store::local())).await?;
+            Ok(format!(
+                "remote {} unreachable — showing the local index instead\n{body}",
+                store.label()
+            ))
+        }
+        // No personal index yet: point at `funes index` instead of erroring. (recall/get/list
+        // quietly serve the built-in guide in the same situation.)
+        ReadOutcome::NoIndex => Ok(format!(
             "store: {}\nno personal index yet — showing the built-in guide ({} passages).\nrun `funes index` to index ~/.claude/projects, then recall your own history.\n",
             store.label(),
             hello::PASSAGES.len()
         )),
-        Err(e) if is_missing_dataset(&e) => Err(empty_store(&store)),
-        Err(e) => Err(e),
     }
 }
 
@@ -661,20 +624,6 @@ pub async fn status(store: Store) -> Result<String> {
 mod tests {
     use super::*;
     use chrono::TimeZone;
-
-    #[tokio::test]
-    async fn missing_dataset_error_is_detected() {
-        // A path with no dataset is lance's DatasetNotFound — the empty/absent-store case.
-        let err = dataset::open("/nonexistent/funes-empty-store/chunks.lance", HashMap::new())
-            .await
-            .unwrap_err();
-        assert!(is_missing_dataset(&err));
-    }
-
-    #[test]
-    fn unrelated_error_is_not_missing_dataset() {
-        assert!(!is_missing_dataset(&anyhow::anyhow!("some other failure")));
-    }
 
     #[test]
     fn esc_doubles_single_quotes() {

--- a/src/recall.rs
+++ b/src/recall.rs
@@ -6,13 +6,14 @@
 use crate::chunk;
 use crate::dataset;
 use crate::hello;
-use crate::hub::{self, ReadOutcome, Store};
+use crate::hub::{self, Reachability, Store};
 use anyhow::{Context, Result};
 use arrow_array::{Float32Array, Int64Array, RecordBatch, StringArray, UInt64Array};
 use chrono::{DateTime, Utc};
 use fastembed::{EmbeddingModel, InitOptions, RerankInitOptions, RerankerModel, TextEmbedding, TextRerank};
 use futures::TryStreamExt;
 use lance::dataset::{Dataset, ROW_ID};
+use lance::Error as LanceError;
 use lance_index::scalar::FullTextSearchQuery;
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::Write as _;
@@ -108,13 +109,62 @@ struct Read {
     note: Option<String>,
 }
 
-/// Open a store for reading, applying the embedder-backed fallbacks [`hub::open_for_read`] leaves to
+/// The outcome of resolving a store for reading. The embedder-backed fallbacks (`Offline` → the
+/// local index, `NoIndex` → the built-in guide) are this module's to apply, so the resolver stays
+/// free of model/`hello` concerns; a missing or empty remote is a hard error with a clear message.
+// A transient return value, never stored en masse, so the `Ready(Dataset)`/unit size gap is fine —
+// boxing would only add indirection.
+#[allow(clippy::large_enum_variant)]
+enum ReadOutcome {
+    /// Opened and ready to query.
+    Ready(Dataset),
+    /// The remote is unreachable — recall from the local index instead.
+    Offline,
+    /// No local index yet — show the built-in guide.
+    NoIndex,
+}
+
+/// Resolve a store for reading — the one place every source state is handled. An offline remote
+/// degrades (`Offline`); a missing or empty remote errors with a clear message; an absent default
+/// local index degrades (`NoIndex`); a present store opens (`Ready`). All read verbs route through
+/// this; the remote-state classification and messages come from `hub`.
+async fn open_for_read(store: &Store) -> Result<ReadOutcome> {
+    if let Store::Remote { uri } = store {
+        match hub::remote_reachability(uri).await {
+            Reachability::Offline => return Ok(ReadOutcome::Offline),
+            Reachability::Missing => return Err(hub::missing_remote(uri)),
+            Reachability::Ok => {}
+        }
+    }
+    match store.open().await {
+        Ok(ds) => Ok(ReadOutcome::Ready(ds)),
+        // The default local store with no index yet → the built-in guide (built below).
+        Err(_) if store.is_default_local() => Ok(ReadOutcome::NoIndex),
+        // Opened to nothing: a reachable remote never pushed to, or a local path with no dataset.
+        // Either way, a clear message beats lance's internal path error.
+        Err(e) if is_missing_dataset(&e) => match store {
+            Store::Remote { uri } => Err(hub::empty_remote(uri)),
+            Store::Local { path } => Err(anyhow::anyhow!("no index found at {}", path.display())),
+        },
+        Err(e) => Err(e),
+    }
+}
+
+/// True if `e` is lance reporting the `chunks.lance` dataset isn't there — the store opened to no
+/// index (an empty or never-pushed remote, or a path with no dataset). Lets reads report an empty
+/// store instead of leaking lance's internal path/`_versions` error.
+fn is_missing_dataset(e: &anyhow::Error) -> bool {
+    e.chain()
+        .any(|c| matches!(c.downcast_ref::<LanceError>(), Some(LanceError::DatasetNotFound { .. })))
+}
+
+/// Open a store for reading, applying the embedder-backed fallbacks [`open_for_read`] leaves to
 /// the caller: an unreachable remote degrades to the local index (then the built-in guide), and an
 /// absent local index serves the guide — so recall keeps working offline and on a fresh install. A
 /// missing or empty remote surfaces as an error from the helper. Passing `embedder` gives the
 /// built-in corpus real vectors for search (recall); `None` suits `get`/`list`.
 async fn open_read(store: &Store, embedder: Option<&mut TextEmbedding>) -> Result<Read> {
-    match hub::open_for_read(store).await? {
+    match open_for_read(store).await? {
         ReadOutcome::Ready(ds) => Ok(Read {
             _hello: None,
             ds,
@@ -135,7 +185,7 @@ async fn open_read(store: &Store, embedder: Option<&mut TextEmbedding>) -> Resul
 /// An unreachable remote degrades to the local index, or to the built-in guide if there's no local
 /// index either, carrying a note that explains what happened.
 async fn degrade_offline(uri: &str, embedder: Option<&mut TextEmbedding>) -> Result<Read> {
-    match hub::open_for_read(&Store::local()).await {
+    match open_for_read(&Store::local()).await {
         Ok(ReadOutcome::Ready(ds)) => Ok(Read {
             _hello: None,
             ds,
@@ -593,7 +643,7 @@ pub async fn get(store: Store, session_id: String, turn_uuid: String, window: i6
 }
 
 pub async fn status(store: Store) -> Result<String> {
-    match hub::open_for_read(&store).await? {
+    match open_for_read(&store).await? {
         ReadOutcome::Ready(ds) => {
             let rows = ds.count_rows(None).await?;
             Ok(format!(
@@ -624,6 +674,20 @@ pub async fn status(store: Store) -> Result<String> {
 mod tests {
     use super::*;
     use chrono::TimeZone;
+
+    #[tokio::test]
+    async fn missing_dataset_is_detected() {
+        // Opening a path with no dataset is lance's DatasetNotFound — the empty/absent case.
+        let err = dataset::open("/nonexistent/funes-empty-store/chunks.lance", HashMap::new())
+            .await
+            .unwrap_err();
+        assert!(is_missing_dataset(&err));
+    }
+
+    #[test]
+    fn unrelated_error_is_not_missing_dataset() {
+        assert!(!is_missing_dataset(&anyhow::anyhow!("some other failure")));
+    }
 
     #[test]
     fn esc_doubles_single_quotes() {

--- a/src/recall.rs
+++ b/src/recall.rs
@@ -13,6 +13,7 @@ use chrono::{DateTime, Utc};
 use fastembed::{EmbeddingModel, InitOptions, RerankInitOptions, RerankerModel, TextEmbedding, TextRerank};
 use futures::TryStreamExt;
 use lance::dataset::{Dataset, ROW_ID};
+use lance::Error as LanceError;
 use lance_index::scalar::FullTextSearchQuery;
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::Write as _;
@@ -120,10 +121,8 @@ struct Read {
 async fn open_read(store: &Store, embedder: Option<&mut TextEmbedding>) -> Result<Read> {
     // Probe a remote up front: an offline host degrades fast instead of hanging on a slow open.
     if let Store::Remote { uri } = store {
-        match hub::remote_reachability(uri).await {
-            Reachability::Offline => return degrade_offline(uri, embedder).await,
-            Reachability::Missing => return Err(empty_store(store)),
-            Reachability::Ok => {}
+        if matches!(hub::remote_reachability(uri).await, Reachability::Offline) {
+            return degrade_offline(uri, embedder).await;
         }
     }
     match store.open().await {
@@ -140,6 +139,8 @@ async fn open_read(store: &Store, embedder: Option<&mut TextEmbedding>) -> Resul
                     ds,
                     note: None,
                 })
+            } else if is_missing_dataset(&e) {
+                Err(empty_store(store))
             } else {
                 Err(e)
             }
@@ -169,14 +170,20 @@ async fn degrade_offline(uri: &str, embedder: Option<&mut TextEmbedding>) -> Res
     }
 }
 
-/// User-facing error for a store the Hub reports as [`Reachability::Missing`] — the repo doesn't
-/// exist (or holds no index) — instead of letting the open leak lance's internal
-/// `chunks.lance`/`_versions` path error.
+/// True if `e` is lance reporting the `chunks.lance` dataset isn't there — a reachable store with no
+/// index: a remote repo that's empty or never-pushed, one that doesn't exist, or a local path with
+/// no dataset. Lets the read commands report an empty store instead of leaking lance's internal
+/// path/`_versions` error.
+fn is_missing_dataset(e: &anyhow::Error) -> bool {
+    e.chain()
+        .any(|c| matches!(c.downcast_ref::<LanceError>(), Some(LanceError::DatasetNotFound { .. })))
+}
+
+/// User-facing error for a reachable store that holds no index — empty, never pushed, or absent.
 fn empty_store(store: &Store) -> anyhow::Error {
     anyhow::anyhow!(
-        "the store at {} was not found on the Hub — it doesn't exist yet or holds no index. \
-         push one with `funes index` (or `funes push`), or `funes use local` to read your \
-         local index.",
+        "the store at {} is empty — no index found there. publish a local index to it with \
+         `funes push`, or `funes use local` to read your local index.",
         store.label()
     )
 }
@@ -622,15 +629,11 @@ pub async fn get(store: Store, session_id: String, turn_uuid: String, window: i6
 pub async fn status(store: Store) -> Result<String> {
     // An unreachable remote degrades to the local index's status, like the read commands.
     if let Store::Remote { uri } = &store {
-        match hub::remote_reachability(uri).await {
-            Reachability::Offline => {
-                let body = Box::pin(status(Store::local())).await?;
-                return Ok(format!(
-                    "remote {uri} unreachable — showing the local index instead\n{body}"
-                ));
-            }
-            Reachability::Missing => return Err(empty_store(&store)),
-            Reachability::Ok => {}
+        if matches!(hub::remote_reachability(uri).await, Reachability::Offline) {
+            let body = Box::pin(status(Store::local())).await?;
+            return Ok(format!(
+                "remote {uri} unreachable — showing the local index instead\n{body}"
+            ));
         }
     }
     match store.open().await {
@@ -649,6 +652,7 @@ pub async fn status(store: Store) -> Result<String> {
             store.label(),
             hello::PASSAGES.len()
         )),
+        Err(e) if is_missing_dataset(&e) => Err(empty_store(&store)),
         Err(e) => Err(e),
     }
 }
@@ -657,6 +661,20 @@ pub async fn status(store: Store) -> Result<String> {
 mod tests {
     use super::*;
     use chrono::TimeZone;
+
+    #[tokio::test]
+    async fn missing_dataset_error_is_detected() {
+        // A path with no dataset is lance's DatasetNotFound — the empty/absent-store case.
+        let err = dataset::open("/nonexistent/funes-empty-store/chunks.lance", HashMap::new())
+            .await
+            .unwrap_err();
+        assert!(is_missing_dataset(&err));
+    }
+
+    #[test]
+    fn unrelated_error_is_not_missing_dataset() {
+        assert!(!is_missing_dataset(&anyhow::anyhow!("some other failure")));
+    }
 
     #[test]
     fn esc_doubles_single_quotes() {


### PR DESCRIPTION
## Problem

Pointing funes at a remote store that doesn't exist on the Hub — a deleted or mistyped dataset repo — surfaced lance's internal error verbatim through `recall`/`get`/`list`/`status`:

```
Error: opening the dataset
Caused by:
    0: Dataset at path chunks.lance was not found: Not found: chunks.lance/_versions,
       .../lance-table-7.0.0/src/io/commit.rs:646 ...
```

The read path only acted on `Reachability::Offline` and let every other probe result fall through to `open()`.
