### PR TITLE
fix(index): stop auto-publishing to the remote on `funes index`

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,12 +123,13 @@ an optional skill at [skills/funes/](skills/funes/) for richer recall-triggering
 `/funes` command — optional, since the MCP server already carries when-to-use instructions.)
 
 **4. Share it across machines or a team (optional).** Attach a dataset repo you own on the
-Hugging Face Hub as your **active store**. From then on `index` publishes to it and `recall`
-reads it — no per-command flags:
+Hugging Face Hub as your **active store**. `recall` then reads it, and `funes push` publishes
+your local index to it — no per-command flags:
 
 ```bash
 funes use acme/kb        # attach hf://datasets/acme/kb as the active store (persisted in funes.json)
-funes index              # builds locally, then publishes to the active remote
+funes index              # build/update the local index
+funes push               # publish the local index's new chunks to the active remote
 funes recall "..."       # reads the active remote
 funes use local          # detach — back to the local index
 ```
@@ -141,8 +142,9 @@ changing your default, pass `--remote`:
 funes recall "..." --remote other-org/subject-kb
 ```
 
-`push` is a manual re-publish to the active remote (`index` already publishes on its own). You
-never need the Hub to use funes locally — it's a tier you opt into.
+`push` publishes your local index's new chunks to the active remote; `index` only ever writes
+locally, so uploading is always an explicit step. You never need the Hub to use funes locally —
+it's a tier you opt into.
 
 ## Building from source
 

--- a/src/hello.rs
+++ b/src/hello.rs
@@ -61,10 +61,11 @@ pub const PASSAGES: &[(&str, &str)] = &[
     (
         "assistant",
         "Optional, and later: share your memory across machines or a team via the Hugging Face \
-         Hub. `funes use <org>/<repo>` attaches a dataset repo you own as your active store — from \
-         then on `index` publishes to it and recall reads it; `funes use local` detaches. To query \
-         a different store for one call without changing your default, pass `recall --remote \
-         <org>/<repo>`. You never need the Hub to use funes locally — it's a tier you opt into.",
+         Hub. `funes use <org>/<repo>` attaches a dataset repo you own as your active store — \
+         recall then reads it, and `funes push` publishes your local index to it; `funes use \
+         local` detaches. To query a different store for one call without changing your default, \
+         pass `recall --remote <org>/<repo>`. You never need the Hub to use funes locally — it's \
+         a tier you opt into.",
     ),
     (
         "assistant",

--- a/src/index.rs
+++ b/src/index.rs
@@ -3,7 +3,7 @@
 //! changed session add only chunks whose id is new — a grown session (the same memory)
 //! contributes just its new turns, nothing is re-embedded or deleted.
 
-use crate::{chunk, config, dataset, hub, parse, push, scan};
+use crate::{chunk, dataset, parse, scan};
 use anyhow::{anyhow, Result};
 use arrow_array::types::Float32Type;
 use arrow_array::{Array, FixedSizeListArray, Int64Array, RecordBatch, RecordBatchIterator, StringArray};
@@ -309,17 +309,6 @@ pub async fn run_index(source: &Path, no_thinking: bool) -> Result<()> {
     }
 
     println!("indexed files={n_files} skipped={n_skipped} chunks={n_chunks}");
-
-    // Publish to the attached remote, best-effort: a failed push must not fail the local index.
-    if let Some(remote) = config::load().remote {
-        match push::run_push(hub::Store::parse(&remote), false).await {
-            Ok(pushed) => print!("{}", pushed.report),
-            Err(e) if push::is_read_only(&e) => {
-                eprintln!("indexed locally; {remote} is read-only for your token — recall reads it, but publishing needs write access")
-            }
-            Err(e) => eprintln!("indexed locally; couldn't publish to {remote}: {e}"),
-        }
-    }
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,8 +87,8 @@ enum Cmd {
         /// URI. Pass `local` to detach and go back to the local index.
         store: String,
     },
-    /// Re-publish the local index's new chunks to the active remote (manual; `index` already
-    /// publishes automatically when a remote is attached).
+    /// Publish the local index's new chunks to the active remote. `index` only writes locally, so
+    /// this is the one step that uploads.
     Push {
         /// Refresh the remote index after pushing (retrying on conflict) even if the unindexed
         /// backlog is below the auto-reindex threshold. With nothing new to push, reindex only.
@@ -243,10 +243,10 @@ async fn use_store(spec: String) -> Result<()> {
 /// The next-step hint for `funes use`.
 fn attach_hint(local: usize, remote: usize, unpushed: usize) -> String {
     if local == 0 && remote == 0 {
-        "no memories indexed yet — run `funes index` to build your local index (it publishes here automatically)."
+        "no memories indexed yet — run `funes index` to build your local index, then `funes push` to publish it here."
             .to_string()
     } else if local == 0 {
-        format!("the remote holds {remote} chunks — recall reads them now. if you own this remote store, run `funes index` to add this machine's sessions.")
+        format!("the remote holds {remote} chunks — recall reads them now. if you own this remote store, run `funes index` then `funes push` to add this machine's sessions.")
     } else if unpushed == 0 {
         format!("local index: {local} chunks, all present on the remote.")
     } else if remote == 0 {


### PR DESCRIPTION
`funes index` reads as a local, read-only-ish operation, but it silently pushed the local index — which holds raw transcript content — to the attached remote. A wrong active store (a typo, a test repo, someone else's) meant a plain `index` leaked your sessions there; the pre-push secret scan doesn't help when scanned content lands in the wrong repo.

Drop the auto-publish: `index` only ever writes locally; publishing is the explicit `funes push` step. (Auto-publish was a remnant of the hub-centric model — "index against a hub store builds a local DB for nothing" — which the local-first DX has since dropped.)

Updates the README, the `push`/`use` help, the built-in guide, and the `funes use` hints to match.