### PR TITLE
Add parquet traces indexer and benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2798,6 +2798,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -2895,6 +2896,7 @@ dependencies = [
  "lance-linalg",
  "object_store",
  "openssl-sys",
+ "parquet",
  "rmcp",
  "serde",
  "serde_json",
@@ -3889,6 +3891,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "integer-encoding"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
 name = "interpolate_name"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4081,7 +4089,7 @@ dependencies = [
  "jiff",
  "nom 8.0.0",
  "num-traits",
- "ordered-float",
+ "ordered-float 5.3.0",
  "rand 0.9.4",
  "serde",
  "serde_json",
@@ -5625,6 +5633,15 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
@@ -5708,6 +5725,39 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "parquet"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dafa7d01085b62a47dd0c1829550a0a36710ea9c4fe358a05a85477cec8a908"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-schema",
+ "arrow-select",
+ "base64 0.22.1",
+ "brotli",
+ "bytes",
+ "chrono",
+ "flate2",
+ "half",
+ "hashbrown 0.17.1",
+ "lz4_flex",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "paste",
+ "seq-macro",
+ "simdutf8",
+ "snap",
+ "thrift",
+ "twox-hash",
+ "zstd",
 ]
 
 [[package]]
@@ -7369,6 +7419,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "snap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+
+[[package]]
 name = "socket2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7682,6 +7738,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if 1.0.4",
+]
+
+[[package]]
+name = "thrift"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "ordered-float 2.10.1",
 ]
 
 [[package]]
@@ -9077,6 +9144,12 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "977347db8caa080403f6b6b7c1cda9479a8e869316f7e13a59b19076a40f94e3"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ lance = "=7.0.0"                 # Dataset open/scan/append + create_index, loca
 lance-io = { version = "=7.0.0", features = ["huggingface", "gcp"] }  # hf:// object store + WrappingObjectStore
 lance-index = "=7.0.0"           # FTS/IVF index params + FullTextSearchQuery
 lance-linalg = "=7.0.0"          # MetricType for the IVF_PQ index
+parquet = "58"                   # read agent-trace datasets stored as parquet (arrow-rs, matches arrow-* = "58")
 object_store = "=0.13.2"         # the ObjectStore trait the capture wrapper implements (matches lance-io)
 async-trait = "0.1"              # for the ObjectStore impl in src/capture_store.rs
 bytes = "1"                      # captured write payloads

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,15 @@ openssl-sys = { version = "0.9", optional = true }
 [features]
 vendored-openssl = ["openssl-sys/vendored"]
 
+# Benchmarks live under benchmark/ alongside their README; run via `cargo run --example <name>`.
+[[example]]
+name = "bench_recall"
+path = "benchmark/bench_recall.rs"
+
+[[example]]
+name = "bench_index"
+path = "benchmark/bench_index.rs"
+
 [profile.release]
 opt-level = 3
 

--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ recall(query) ──>  vector + BM25  →  RRF  →  cross-encoder rerank  →  
 
 ## Sources
 
-> **For now, the only supported source is Claude Code** — session transcripts under
-> `~/.claude/projects/**/*.jsonl` (subagent sidechains included). Support for other agent
-> frameworks is planned.
+> **Two sources are supported today:** Claude Code session transcripts under
+> `~/.claude/projects/**/*.jsonl` (subagent sidechains included — the default), and agent-trace
+> **parquet** datasets (HF-style, one row per session) via `funes index path/to/traces.parquet`.
 
-The Claude coupling is confined to the **parse** step: it reads Claude's transcript format
-into a generic turn/block shape. Everything downstream — chunk → embed → store → recall — is
-source-agnostic and operates on that shape. Adding another framework means writing one new
-parser to the same shape, not touching the index or query path.
+Each source is a [`TraceSource`](src/source.rs) that reads its format into a generic turn/block
+shape; everything downstream — chunk → embed → store → recall — is source-agnostic and operates on
+that shape. Adding another framework means implementing one trait (and a branch in `source::open`),
+not touching the index or query path.
 
 ## Install
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,151 @@
+# Benchmarks
+
+Two runnable examples, each `cargo run --release --example <name>`:
+
+- **`bench_recall`** — `recall()` latency, local vs remote, cold vs warm (below).
+- **`bench_index`** — `index` build time, throughput, and store compactness (at the end).
+
+## `bench_recall` — recall latency
+
+`bench_recall.rs` times the full `recall()` call over **one dataset, local vs remote and cold vs
+warm**, so you can see what the remote (`hf://`) tier costs. To keep it apples-to-apples it
+downloads the `--remote` dataset to a temp dir and benchmarks that local copy against the same
+dataset over `hf://` — both legs run identical data, so the gap is the I/O path, not the corpus.
+
+## What it measures
+
+Every timed call runs the whole recall pipeline:
+
+```
+embed query → vector ANN + BM25 FTS (fused by RRF) → cross-encoder rerank → recency → neighbors → format
+```
+
+The CPU stages (query embed + BGE cross-encoder rerank) are identical whatever the store, so the
+local↔remote gap is entirely the I/O path: opening the dataset, the ANN/FTS scans, and the neighbor
+fetch. The embed + rerank models are loaded once in a warm-up call that is **excluded** from all
+timings.
+
+For each store the harness reports a single **cold** call followed by the min / median / max of
+`--iters` **warm** calls:
+
+- **remote cold** — the Xet chunk cache is empty (`--cold` gives it a fresh temp cache), so the
+  IVF_PQ/FTS index and the touched Lance fragments are downloaded over `hf://`.
+- **remote warm** — Xet-cached data, but `recall()` still re-opens the dataset each call (manifest +
+  index-descriptor round-trips), which dominates the warm remote cost.
+- **local** — the same dataset on disk; there's no real cold/warm gap (the OS page cache is already
+  warm and the models are loaded), so `local` is the floor the remote legs are measured against.
+
+## Usage
+
+Build in release (a debug build is far slower and not representative):
+
+```sh
+cargo run --release --example bench_recall -- "<query>" --remote dacorvo/funes-bench --iters 5 --cold
+```
+
+The bench downloads `--remote` (via the `hf` CLI, using your logged-in token for a private repo) to
+a temp dir and benchmarks that local copy against the same dataset over `hf://` — both legs run
+identical data, so the gap is the I/O path, not the corpus.
+
+### Options
+
+| flag | default | meaning |
+|------|---------|---------|
+| `<query>` (positional) | `"how does recall rerank candidates"` | the text to recall |
+| `--remote <spec>` | `dacorvo/funes-bench` | dataset to benchmark (`org/repo` or `hf://…`), used for both legs |
+| `--iters <N>` | `5` | warm iterations timed per store (after the one cold call) |
+| `--cold` | off | give the remote leg a throwaway `HF_XET_CACHE` temp dir so its cold call is a true download (your real cache is left untouched) |
+| `--k <N>` | `8` | results returned |
+| `--candidates <N>` | `30` | fused candidates reranked |
+| `--neighbors <N>` | `1` | adjacent chunks attached per hit |
+
+> `--cold` only relocates the Xet **cache** (via `HF_XET_CACHE`) to a temp dir for the run — it does
+> not touch your real `~/.cache/huggingface/xet`, your HF token, or `HF_HOME`. With `--cold` the
+> dataset is fetched twice: once by `hf download` for the local copy, once over Xet for the remote
+> cold call.
+
+## Reading the output
+
+```
+dataset: dacorvo/funes-bench   query: "ray traced multiplayer shooter with bots"   k=8 candidates=30 neighbors=1   warm iters=5
+
+store     cold(ms)   warm_lo  warm_med   warm_hi  hits
+local        896.9     796.1     814.6    4486.6     8
+remote      9804.5    8257.2    8796.7    8900.6     8
+
+remote vs local:  10.9× slower cold,  10.8× slower warm (median),  10.4× warm best-case
+```
+
+Both legs index the same ≈21.6k-chunk dataset (`hits` matches, confirming equal work). The headline
+line reports the slowdown over the local floor: remote **cold** (~10–14 s across runs, depending on
+download bandwidth) pays the full Xet download of the index + touched Lance fragments; even **warm** it's
+~10× local. `warm best-case` (`warm_lo`) is the most stable factor — the `warm_hi` spikes are
+page-cache/GC noise at low `--iters`. Most of the warm-remote cost is `recall()` re-opening the
+dataset on every call, which a long-lived process (the MCP server) that opens once would avoid.
+
+## Caveats
+
+- It times **one query string**, repeated. Rerank load is fixed (always `--candidates`), but embed
+  and ANN/FTS selectivity vary by query — run a few representative queries (short/long, common/rare
+  terms) for a sturdier picture.
+- Needs the `hf` CLI for the download (unless `--local` is given) and, for a private dataset, a
+  logged-in HF token.
+
+## Building a benchmark store
+
+The remote target above was built from a public agent-trace dataset with funes' parquet indexer:
+
+```sh
+# 1. fetch the auto-converted parquet (one row per session)
+hf download Glint-Research/Fable-5-traces --repo-type dataset \
+  --revision refs/convert/parquet --include "pi_agent/train/0000.parquet" --local-dir ./traces
+
+# 2. (optional) slice to ~N sessions to hit a target chunk count, then index into an isolated home
+FUNES_HOME=./bench-home funes index ./traces/pi_agent/train/0000.parquet
+
+# 3. publish to a Hub dataset repo you own (create it first; funes won't), which re-materializes a
+#    clean, compact dataset on the remote
+hf repo create <org>/<repo> --repo-type dataset
+FUNES_HOME=./bench-home funes use <org>/<repo>
+FUNES_HOME=./bench-home funes push
+```
+
+`funes index <file>.parquet` indexes the whole file as a bulk import (one append, so the store stays
+compact); see `src/traces.rs`. The push gate redacts/holds back any rows containing secrets before
+upload.
+
+## `bench_index` — index build
+
+`bench_index.rs` times an `index` build into a throwaway `$FUNES_HOME` (your real store and config
+are untouched; no remote is attached there, so nothing is pushed) and reports build time, embedding
+throughput, and how compact the resulting store is.
+
+`--sessions <N>` caps how many sessions are indexed (default **500**) so the build doesn't run long
+over a big tree or the full parquet — raise it for a longer, steadier measurement.
+
+```sh
+cargo run --release --example bench_index -- path/to/traces.parquet                 # first 500 sessions
+cargo run --release --example bench_index -- ~/.claude/projects --sessions 100       # a JSONL tree, capped
+cargo run --release --example bench_index -- path/to/traces.parquet --sessions 5000  # longer run
+```
+
+Example output:
+
+```
+=== index benchmark ===
+source:           Fable-5-traces.parquet
+elapsed:          385.0s  (incl. model load)
+sessions:         4665
+chunks:           21767
+throughput:       57 chunks/s
+store size:       53 MB
+lance fragments:  1
+```
+
+The three counts are deliberately distinct granularities: **4665 sessions** chunk into **21767
+chunks**, all written into **1 Lance fragment** (a physical data file). `lance fragments: 1` confirms
+the bulk-import path stayed compact — a regression to per-session appends would show one fragment per
+session and a much larger store. (That run indexed the whole file; pass a large `--sessions` to do
+likewise — the default 500 builds far faster.) Elapsed includes the one-time embedding-model load,
+so throughput is a slight under-estimate on small inputs.
+

--- a/benchmark/bench_index.rs
+++ b/benchmark/bench_index.rs
@@ -1,0 +1,97 @@
+//! Benchmark `funes index <source>`: build time, embedding throughput, and the compactness of the
+//! resulting store. Useful for tracking the parquet bulk-import path (one append, one Lance fragment) and
+//! catching regressions like per-session appends bloating the store.
+//!
+//! The index is built into a throwaway `$FUNES_HOME` so your real store and config are untouched
+//! (no remote is attached there, so no push fires).
+//!
+//! ```text
+//! cargo run --release --example bench_index -- path/to/traces.parquet
+//! cargo run --release --example bench_index -- ~/.claude/projects   # a JSONL tree
+//! ```
+//!
+//! Elapsed includes the one-time embedding-model load (~1-2s), so reported throughput is a slight
+//! under-estimate on small inputs and accurate on large ones.
+
+use anyhow::Result;
+use arrow_array::{Array, StringArray};
+use clap::Parser;
+use funes::hub::Store;
+use funes::index::run_index;
+use futures::TryStreamExt;
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::time::Instant;
+use walkdir::WalkDir;
+
+#[derive(Parser)]
+#[command(about = "Benchmark index build: time, throughput, store compactness")]
+struct Args {
+    /// Source to index: a `.parquet` trace dataset or a directory of JSONL transcripts.
+    source: PathBuf,
+    /// Index at most this many sessions, to bound build time. Raise it for a longer, steadier run.
+    #[arg(long, default_value_t = 500)]
+    sessions: usize,
+    /// Exclude thinking blocks (passed through to `index`).
+    #[arg(long)]
+    no_thinking: bool,
+}
+
+/// Total bytes of every file under `dir`.
+fn dir_bytes(dir: &std::path::Path) -> u64 {
+    WalkDir::new(dir)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter_map(|e| e.metadata().ok())
+        .filter(|m| m.is_file())
+        .map(|m| m.len())
+        .sum()
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let a = Args::parse();
+
+    // Build into a throwaway FUNES_HOME (held alive for the run): the real store/config are untouched
+    // and, with no remote attached there, `index` won't push.
+    let home = tempfile::Builder::new().prefix("funes-bench-index-").tempdir()?;
+    std::env::set_var("FUNES_HOME", home.path());
+
+    let t = Instant::now();
+    run_index(a.source.as_path(), a.no_thinking, Some(a.sessions)).await?;
+    let secs = t.elapsed().as_secs_f64();
+
+    // Inspect the built store: chunks (rows), distinct sessions, on-disk size, and Lance fragments —
+    // three different granularities, so the output shows they don't coincide.
+    let store = home.path().join("store");
+    let ds = Store::local().open().await?;
+    let chunks = ds.count_rows(None).await?;
+    let mut scan = ds.scan();
+    scan.project(&["session_id"])?;
+    let mut stream = scan.try_into_stream().await?;
+    let mut sids = HashSet::new();
+    while let Some(batch) = stream.try_next().await? {
+        if let Some(col) = batch
+            .column_by_name("session_id")
+            .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+        {
+            (0..col.len()).filter(|&i| !col.is_null(i)).for_each(|i| {
+                sids.insert(col.value(i).to_string());
+            });
+        }
+    }
+    let sessions = sids.len();
+    let mb = dir_bytes(&store) as f64 / 1e6;
+    let data = store.join("chunks.lance").join("data");
+    let fragments = std::fs::read_dir(&data).map(|d| d.count()).unwrap_or(0);
+
+    println!("\n=== index benchmark ===");
+    println!("source:           {}", a.source.display());
+    println!("elapsed:          {secs:.1}s  (incl. model load)");
+    println!("sessions:         {sessions}");
+    println!("chunks:           {chunks}");
+    println!("throughput:       {:.0} chunks/s", chunks as f64 / secs.max(0.001));
+    println!("store size:       {mb:.0} MB");
+    println!("lance fragments:  {fragments}");
+    Ok(())
+}

--- a/benchmark/bench_recall.rs
+++ b/benchmark/bench_recall.rs
@@ -1,0 +1,197 @@
+//! Benchmark `recall()` latency, local vs remote, cold vs warm — over the **same dataset** so the
+//! comparison isolates the I/O path, not differences in the data.
+//!
+//! The CPU stages of recall (query embed, cross-encoder rerank) are identical whatever the store;
+//! the local↔remote difference is entirely in the I/O stages (store open, vector ANN scan, BM25
+//! scan, neighbor scan). To compare them fairly the bench downloads the `--remote` dataset to a
+//! temp dir and benchmarks that local copy against the same dataset over `hf://`.
+//!
+//! ```text
+//! cargo run --release --example bench_recall -- "your query" \
+//!     --remote dacorvo/funes-bench --iters 5 --cold
+//! ```
+//!
+//! `--cold` points the Xet cache (`HF_XET_CACHE`) at a throwaway temp dir so the remote cold call
+//! is a true download, leaving your real `~/.cache/huggingface/xet` untouched. (It does not, and
+//! cannot portably, drop the OS page cache, so the local cold figure is only as cold as the page
+//! cache happens to be.) Downloading the dataset needs the `hf` CLI and, for a private repo, a
+//! logged-in token (the same token recall uses).
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use funes::hub::Store;
+use funes::recall::recall;
+use std::path::Path;
+use std::process::Command;
+use std::time::Instant;
+use tempfile::TempDir;
+
+#[derive(Parser)]
+#[command(about = "Benchmark recall latency over one dataset: local vs remote, cold vs warm")]
+struct Args {
+    /// Query to recall.
+    #[arg(default_value = "how does recall rerank candidates")]
+    query: String,
+    /// Dataset to benchmark (`org/repo` or `hf://…`), used for BOTH legs.
+    #[arg(long, default_value = "dacorvo/funes-bench")]
+    remote: String,
+    /// Warm iterations timed per store (after the one cold call).
+    #[arg(long, default_value_t = 5)]
+    iters: usize,
+    /// Give the remote leg a throwaway temp Xet cache so its cold call is a true download — your
+    /// real `~/.cache/huggingface/xet` is left untouched.
+    #[arg(long)]
+    cold: bool,
+    /// Results to return (recall `k`).
+    #[arg(long, default_value_t = 8)]
+    k: usize,
+    /// Fused candidates to rerank.
+    #[arg(long, default_value_t = 30)]
+    candidates: usize,
+    /// Neighbor chunks attached per hit.
+    #[arg(long, default_value_t = 1)]
+    neighbors: i64,
+}
+
+/// One timed `recall()` call: elapsed millis and the number of hits in the output.
+async fn time_recall(store: &Store, a: &Args) -> Result<(f64, usize)> {
+    let t = Instant::now();
+    let out = recall(
+        store.clone(),
+        a.query.clone(),
+        a.k,
+        a.candidates,
+        0.0,
+        a.neighbors,
+        None,
+        None,
+    )
+    .await?;
+    let ms = t.elapsed().as_secs_f64() * 1000.0;
+    // Each hit prints a `→ get <session> <turn>` line.
+    let hits = out.matches("→ get ").count();
+    Ok((ms, hits))
+}
+
+/// Download the `--remote` dataset into `dest` (which then holds `chunks.lance`) so it can be opened
+/// as a local store. Shells out to the `hf` CLI; a private repo uses the logged-in token.
+///
+/// The download gets its OWN throwaway Xet cache: otherwise it would pre-warm the cache the remote
+/// leg reads (Xet reconstructs files through `HF_XET_CACHE`), and the remote "cold" call would hit
+/// chunks this very download just fetched — measuring a warm read, not a cold one.
+fn download_dataset(remote: &str, dest: &Path) -> Result<()> {
+    let repo = remote.strip_prefix("hf://datasets/").unwrap_or(remote);
+    let dl_xet = tempfile::Builder::new().prefix("funes-bench-dl-xet-").tempdir()?;
+    eprintln!("downloading {repo} → {} (local leg)…", dest.display());
+    let ok = Command::new("hf")
+        .args(["download", repo, "--repo-type", "dataset", "--local-dir"])
+        .arg(dest)
+        .env("HF_XET_CACHE", dl_xet.path())
+        .status()
+        .context("run `hf download` (is the huggingface CLI installed?)")?
+        .success();
+    if !ok {
+        anyhow::bail!("`hf download {repo}` failed");
+    }
+    Ok(())
+}
+
+/// Point the Xet chunk cache at a fresh temp dir so the first remote read is genuinely cold, without
+/// touching the user's real `~/.cache/huggingface/xet`. `HF_XET_CACHE` relocates only the chunk
+/// cache — the HF token and `HF_HOME` are untouched, so auth still works. The returned dir must stay
+/// alive for the run; dropping it removes the temp cache.
+fn isolate_xet_cache() -> Result<TempDir> {
+    let dir = tempfile::Builder::new().prefix("funes-bench-xet-").tempdir()?;
+    std::env::set_var("HF_XET_CACHE", dir.path());
+    eprintln!(
+        "cold: isolated Xet cache at {} (real cache untouched)",
+        dir.path().display()
+    );
+    Ok(dir)
+}
+
+/// The timings the x-factor summary compares (milliseconds). The full row (incl. warm_hi, hits) is
+/// printed live by `bench_store`; only these are needed afterwards.
+struct Stats {
+    cold: f64,
+    warm_lo: f64,
+    warm_med: f64,
+}
+
+async fn bench_store(name: &str, store: &Store, a: &Args) -> Result<Stats> {
+    let (cold, hits) = time_recall(store, a).await?;
+
+    let mut warm: Vec<f64> = Vec::with_capacity(a.iters);
+    for _ in 0..a.iters {
+        warm.push(time_recall(store, a).await?.0);
+    }
+    warm.sort_by(|x, y| x.partial_cmp(y).unwrap());
+    let (warm_lo, warm_med, warm_hi) = if warm.is_empty() {
+        (cold, cold, cold)
+    } else {
+        (warm[0], warm[warm.len() / 2], warm[warm.len() - 1])
+    };
+
+    // Print the row live, so the local leg shows before the slow remote one runs.
+    println!("{name:<8} {cold:>9.1} {warm_lo:>9.1} {warm_med:>9.1} {warm_hi:>9.1} {hits:>5}");
+    Ok(Stats {
+        cold,
+        warm_lo,
+        warm_med,
+    })
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let a = Args::parse();
+    let remote = Store::parse(a.remote.trim());
+
+    // With --cold, redirect the Xet cache to a temp dir for the whole run (held alive here) so the
+    // remote leg starts cold without disturbing the user's real cache. The local leg uses no Xet.
+    let _xet_guard = if a.cold { Some(isolate_xet_cache()?) } else { None };
+
+    // The local leg is a fresh download of the SAME dataset, so local vs remote isolates the hf://
+    // I/O path rather than comparing two different stores. `local_dir` is held to the end of the run
+    // so the downloaded copy isn't removed mid-benchmark.
+    let local_dir = tempfile::Builder::new().prefix("funes-bench-local-").tempdir()?;
+    download_dataset(a.remote.trim(), local_dir.path())?;
+    let local = Store::Local {
+        path: local_dir.path().to_path_buf(),
+    };
+
+    // Warm up the embed + rerank models once (against the local copy), so the one-time model load
+    // (hundreds of ms, identical for every store) is excluded from all timings below.
+    eprintln!("loading models…");
+    let _ = recall(local.clone(), a.query.clone(), 1, 5, 0.0, 0, None, None).await;
+
+    println!(
+        "\ndataset: {}   query: {:?}   k={} candidates={} neighbors={}   warm iters={}\n",
+        a.remote, a.query, a.k, a.candidates, a.neighbors, a.iters
+    );
+    println!(
+        "{:<8} {:>9} {:>9} {:>9} {:>9} {:>5}",
+        "store", "cold(ms)", "warm_lo", "warm_med", "warm_hi", "hits"
+    );
+
+    let l = bench_store("local", &local, &a).await?;
+    let r = bench_store("remote", &remote, &a).await?;
+
+    // Headline: how much the remote tier costs over a local copy of the same data.
+    let x = |remote: f64, local: f64| if local > 0.0 { remote / local } else { f64::NAN };
+    println!(
+        "\nremote vs local:  {:.1}× slower cold,  {:.1}× slower warm (median),  {:.1}× warm best-case",
+        x(r.cold, l.cold),
+        x(r.warm_med, l.warm_med),
+        x(r.warm_lo, l.warm_lo),
+    );
+
+    if a.cold {
+        println!("\nnote: --cold gave the remote leg an empty (temp) Xet cache, so its cold call is a true");
+        println!("      download. The OS page cache isn't dropped, so the local cold figure is only as");
+        println!("      cold as the page cache already was.");
+    } else {
+        println!("\nnote: without --cold the remote leg used your existing Xet cache, so its 'cold' call may");
+        println!("      already be partly warm. Pass --cold for a true cold-download measurement.");
+    }
+    Ok(())
+}

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -1,7 +1,7 @@
 //! Render blocks to text and split into chunks.
 //! All indexing is by Unicode code point (char), not bytes.
 
-use crate::parse::Turn;
+use crate::trace::Turn;
 use arrow_array::{Array, Int64Array, RecordBatch, StringArray};
 use sha1::{Digest, Sha1};
 use std::collections::HashMap;
@@ -261,7 +261,7 @@ pub fn chunks_from_turns(turns: &[Turn], include_thinking: bool) -> Vec<Chunk> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::parse::{Block, Turn};
+    use crate::trace::{Block, Turn};
 
     fn block(block_type: &str, text: &str, tool_name: Option<&str>) -> Block {
         Block {

--- a/src/claude_traces.rs
+++ b/src/claude_traces.rs
@@ -1,28 +1,12 @@
-//! Parse Claude Code session transcripts (`*.jsonl`) into turns + blocks.
+//! Parse Claude Code session transcripts (`*.jsonl`) into the shared [`crate::trace`] turn/block
+//! model. This is the Claude Code source parser; the model itself lives in `trace.rs`.
 
 use serde_json::Value;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
 
-pub struct Block {
-    pub block_type: String, // "text" | "thinking" | "tool_use" | "tool_result"
-    pub text: String,
-    pub tool_name: Option<String>,
-    pub tool_use_id: Option<String>,
-}
-
-pub struct Turn {
-    pub session_id: String,
-    pub project: String,
-    pub turn_uuid: String,
-    pub parent_uuid: Option<String>,
-    pub seq: i64,
-    pub ts: String,
-    pub role: String,
-    pub blocks: Vec<Block>,
-    pub source_path: String,
-}
+use crate::trace::{Block, Turn};
 
 /// All `*.jsonl` under `root`, recursively, sorted by path.
 pub fn iter_jsonl_files(root: &Path) -> Vec<PathBuf> {

--- a/src/hf_traces.rs
+++ b/src/hf_traces.rs
@@ -1,0 +1,283 @@
+//! Index agent-trace datasets stored as parquet (one row per session) into the same `Turn`/`Block`
+//! shape the JSONL parser produces, so the rest of the index pipeline is reused unchanged.
+//!
+//! The layout targeted is the HF auto-converted parquet of pi-harness traces (e.g.
+//! `Glint-Research/Fable-5-traces`): each row is one session whose `messages` column is a list of
+//! JSON-encoded OpenAI-style chat messages — `{role, content, reasoning_content?, tool_calls?}`.
+//! `reasoning_content` becomes a thinking block, `content` a text block, and each `tool_calls`
+//! entry a tool_use block, matching funes' block vocabulary.
+
+use crate::trace::{Block, Turn};
+
+use anyhow::{anyhow, Context, Result};
+use arrow_array::{Array, LargeStringArray, ListArray, RecordBatch, StringArray};
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use serde_json::Value;
+use std::fs::File;
+use std::path::Path;
+
+/// Read agent-trace sessions from a parquet file as a flat stream of turns — at most `limit`
+/// sessions (one row each), skipping rows whose messages yield no indexable block. Each `Turn`
+/// carries its own `session_id`, so the index pipeline groups them without a per-session wrapper —
+/// mirroring `claude_traces::turns_from_jsonl_file`, which also returns `Vec<Turn>`.
+pub fn turns_from_parquet(path: &Path, project: &str, limit: Option<usize>) -> Result<Vec<Turn>> {
+    let file = File::open(path).with_context(|| format!("open parquet {}", path.display()))?;
+    let reader = ParquetRecordBatchReaderBuilder::try_new(file)?.build()?;
+    let cap = limit.unwrap_or(usize::MAX);
+
+    let mut out: Vec<Turn> = Vec::new();
+    let mut sessions = 0usize;
+    for batch in reader {
+        let batch = batch?;
+        if batch.column_by_name("session_id").is_none() {
+            return Err(anyhow!("parquet has no `session_id` column"));
+        }
+        let messages = batch
+            .column_by_name("messages")
+            .context("parquet has no `messages` column")?
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .context("`messages` is not a list column")?;
+
+        for i in 0..batch.num_rows() {
+            if sessions >= cap {
+                return Ok(out);
+            }
+            let sid = match str_at(&batch, "session_id", i) {
+                Some(s) => s,
+                None => continue,
+            };
+            if messages.is_null(i) {
+                continue;
+            }
+            let ts = str_at(&batch, "sent_at", i).unwrap_or_default();
+            let source = str_at(&batch, "file_path", i).unwrap_or_else(|| path.display().to_string());
+
+            let msgs = parse_message_list(&messages.value(i))?;
+            let turns = turns_from_messages(&msgs, &sid, project, &ts, &source);
+            if !turns.is_empty() {
+                out.extend(turns);
+                sessions += 1;
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// A `Utf8`/`LargeUtf8` column's non-null value at row `i`. HF auto-conversion can emit either
+/// physical width, so accept both — the same dual handling `parse_message_list` uses for the
+/// message elements.
+fn str_at(batch: &RecordBatch, name: &str, i: usize) -> Option<String> {
+    let col = batch.column_by_name(name)?;
+    if let Some(a) = col.as_any().downcast_ref::<StringArray>() {
+        (!a.is_null(i)).then(|| a.value(i).to_string())
+    } else if let Some(a) = col.as_any().downcast_ref::<LargeStringArray>() {
+        (!a.is_null(i)).then(|| a.value(i).to_string())
+    } else {
+        None
+    }
+}
+
+/// The JSON-string elements of one row's `messages` list, parsed. The list's value type is the
+/// `arrow.json` extension over either `Utf8` or `LargeUtf8`, so accept both physical widths.
+fn parse_message_list(elems: &dyn Array) -> Result<Vec<Value>> {
+    let raw: Vec<&str> = if let Some(a) = elems.as_any().downcast_ref::<StringArray>() {
+        (0..a.len()).filter(|&i| !a.is_null(i)).map(|i| a.value(i)).collect()
+    } else if let Some(a) = elems.as_any().downcast_ref::<LargeStringArray>() {
+        (0..a.len()).filter(|&i| !a.is_null(i)).map(|i| a.value(i)).collect()
+    } else {
+        return Err(anyhow!("`messages` elements are neither Utf8 nor LargeUtf8"));
+    };
+    // Skip any element that isn't valid JSON, mirroring the JSONL parser's per-line tolerance in
+    // `parse.rs`; a row whose messages all fail to parse simply yields no turns and is dropped.
+    Ok(raw
+        .iter()
+        .filter_map(|s| serde_json::from_str::<Value>(s).ok())
+        .collect())
+}
+
+/// Turn one session's chat messages into funes turns. `seq` counts only retained turns (those with
+/// at least one block), and `parent_uuid` chains them — mirroring the JSONL parser.
+fn turns_from_messages(msgs: &[Value], session_id: &str, project: &str, ts: &str, source: &str) -> Vec<Turn> {
+    let mut turns = Vec::new();
+    let mut seq = 0i64;
+    let mut parent: Option<String> = None;
+    for m in msgs {
+        let blocks = blocks_from_message(m);
+        if blocks.is_empty() {
+            continue;
+        }
+        let role = m.get("role").and_then(Value::as_str).unwrap_or("").to_string();
+        let turn_uuid = format!("{session_id}-{seq}");
+        turns.push(Turn {
+            session_id: session_id.to_string(),
+            project: project.to_string(),
+            turn_uuid: turn_uuid.clone(),
+            parent_uuid: parent.take(),
+            seq,
+            ts: ts.to_string(),
+            role,
+            blocks,
+            source_path: source.to_string(),
+        });
+        parent = Some(turn_uuid);
+        seq += 1;
+    }
+    turns
+}
+
+/// Blocks for one OpenAI-style chat message: thinking (`reasoning_content`) → text (`content`) →
+/// a tool_use per `tool_calls` entry. Blank fields are dropped, matching `normalize_blocks`.
+fn blocks_from_message(m: &Value) -> Vec<Block> {
+    let mut blocks = Vec::new();
+    let text_block = |block_type: &str, text: &str| Block {
+        block_type: block_type.to_string(),
+        text: text.to_string(),
+        tool_name: None,
+        tool_use_id: None,
+    };
+
+    if let Some(t) = m.get("reasoning_content").and_then(Value::as_str) {
+        if !t.trim().is_empty() {
+            blocks.push(text_block("thinking", t));
+        }
+    }
+    if let Some(t) = m.get("content").and_then(Value::as_str) {
+        if !t.trim().is_empty() {
+            blocks.push(text_block("text", t));
+        }
+    }
+    if let Some(calls) = m.get("tool_calls").and_then(Value::as_array) {
+        for call in calls {
+            let func = call.get("function");
+            let name = func
+                .and_then(|f| f.get("name"))
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            // `arguments` is usually a JSON string already; an object is re-serialized compactly.
+            let args = match func.and_then(|f| f.get("arguments")) {
+                Some(Value::String(s)) => s.clone(),
+                Some(v) => serde_json::to_string(v).unwrap_or_default(),
+                // Match the JSONL path, which defaults a missing tool input to an empty object.
+                None => "{}".to_string(),
+            };
+            blocks.push(Block {
+                block_type: "tool_use".to_string(),
+                text: args,
+                tool_name: name,
+                tool_use_id: None,
+            });
+        }
+    }
+    blocks
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_array::{builder::ListBuilder, builder::StringBuilder, RecordBatch};
+    use arrow_schema::{DataType, Field, Schema};
+    use parquet::arrow::ArrowWriter;
+    use std::sync::Arc;
+
+    /// Write a tiny parquet with the same shape as the HF auto-parquet: `session_id`/`sent_at`
+    /// Utf8 columns and a `messages` list-of-Utf8 column holding JSON-encoded chat messages.
+    fn write_parquet(rows: &[(&str, &str, Vec<&str>)]) -> tempfile::NamedTempFile {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("session_id", DataType::Utf8, false),
+            Field::new("sent_at", DataType::Utf8, true),
+            Field::new(
+                "messages",
+                DataType::List(Arc::new(Field::new("item", DataType::Utf8, true))),
+                false,
+            ),
+        ]));
+        let mut sid = StringBuilder::new();
+        let mut sent = StringBuilder::new();
+        let mut msgs = ListBuilder::new(StringBuilder::new());
+        for (s, t, ms) in rows {
+            sid.append_value(s);
+            sent.append_value(t);
+            for m in ms {
+                msgs.values().append_value(m);
+            }
+            msgs.append(true);
+        }
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(sid.finish()), Arc::new(sent.finish()), Arc::new(msgs.finish())],
+        )
+        .unwrap();
+        let f = tempfile::Builder::new().suffix(".parquet").tempfile().unwrap();
+        let mut w = ArrowWriter::try_new(f.reopen().unwrap(), schema, None).unwrap();
+        w.write(&batch).unwrap();
+        w.close().unwrap();
+        f
+    }
+
+    #[test]
+    fn maps_messages_into_thinking_text_and_tool_use_blocks() {
+        let user = r#"{"role":"user","content":"build a parser"}"#;
+        let asst = r#"{"role":"assistant","content":"on it","reasoning_content":"plan the parse","tool_calls":[{"type":"function","function":{"name":"Bash","arguments":"{\"command\":\"cargo test\"}"}}]}"#;
+        let f = write_parquet(&[("sess-1", "2026-06-19T00:00:02.000Z", vec![user, asst])]);
+
+        let turns = turns_from_parquet(f.path(), "Fable-5-traces", None).unwrap();
+        assert_eq!(turns.len(), 2);
+
+        let u = &turns[0];
+        assert_eq!(u.session_id, "sess-1");
+        assert_eq!(u.role, "user");
+        assert_eq!(u.project, "Fable-5-traces");
+        assert_eq!(u.seq, 0);
+        assert_eq!(u.ts, "2026-06-19T00:00:02.000Z");
+        assert_eq!(u.blocks.len(), 1);
+        assert_eq!(u.blocks[0].block_type, "text");
+
+        let a = &turns[1];
+        assert_eq!(a.role, "assistant");
+        assert_eq!(a.parent_uuid.as_deref(), Some("sess-1-0"));
+        // thinking, then text, then tool_use.
+        let kinds: Vec<&str> = a.blocks.iter().map(|b| b.block_type.as_str()).collect();
+        assert_eq!(kinds, vec!["thinking", "text", "tool_use"]);
+        let tool = a.blocks.iter().find(|b| b.block_type == "tool_use").unwrap();
+        assert_eq!(tool.tool_name.as_deref(), Some("Bash"));
+        assert_eq!(tool.text, r#"{"command":"cargo test"}"#);
+    }
+
+    #[test]
+    fn limit_caps_sessions_and_blank_messages_are_dropped() {
+        let blank = r#"{"role":"assistant","content":"   "}"#; // no indexable block
+        let real = r#"{"role":"user","content":"hello"}"#;
+        let f = write_parquet(&[
+            ("s1", "t", vec![real]),
+            ("s2", "t", vec![blank]), // produces no turns → not emitted
+            ("s3", "t", vec![real]),
+        ]);
+
+        // distinct session_ids in the returned (flat) turns, in order.
+        let sids = |turns: Vec<Turn>| {
+            let mut v: Vec<String> = turns.into_iter().map(|t| t.session_id).collect();
+            v.dedup();
+            v
+        };
+        // limit stops after the first emitted session.
+        assert_eq!(sids(turns_from_parquet(f.path(), "p", Some(1)).unwrap()), vec!["s1"]);
+        // without a limit, the all-blank session is skipped, leaving two.
+        assert_eq!(sids(turns_from_parquet(f.path(), "p", None).unwrap()), vec!["s1", "s3"]);
+    }
+
+    #[test]
+    fn malformed_message_json_is_skipped_not_fatal() {
+        // A non-JSON message element must not abort the run: the bad element is dropped (like the
+        // JSONL parser drops a bad line), and a session whose every message is bad is not emitted.
+        let good = r#"{"role":"user","content":"hello"}"#;
+        let bad = "this is not json{";
+        let f = write_parquet(&[("s1", "t", vec![bad, good]), ("s2", "t", vec![bad])]);
+
+        let turns = turns_from_parquet(f.path(), "p", None).unwrap();
+        // s1: bad element skipped, good kept (1 turn); s2: all bad → no turns → dropped.
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].session_id, "s1");
+        assert_eq!(turns[0].blocks[0].text, "hello");
+    }
+}

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,9 +1,12 @@
-//! The `index` command: walk transcripts → parse → chunk → embed → write to a local Lance dataset.
-//! Incremental on two levels: skip unchanged files (size:mtime in state.json), and within a
-//! changed session add only chunks whose id is new — a grown session (the same memory)
+//! The `index` command: read a [`crate::source::TraceSource`] → parse → chunk → embed → write to a
+//! local Lance dataset. One generic loop drives every source — a JSONL tree today, new formats by
+//! implementing the trait — indexing each of its units in a single append.
+//!
+//! Incremental on two levels: skip a unit whose signature is unchanged (size:mtime in state.json),
+//! and within a re-read unit add only chunks whose id is new — a grown session (the same memory)
 //! contributes just its new turns, nothing is re-embedded or deleted.
 
-use crate::{chunk, dataset, parse, scan};
+use crate::{chunk, dataset, scan, source, trace};
 use anyhow::{anyhow, Result};
 use arrow_array::types::Float32Type;
 use arrow_array::{Array, FixedSizeListArray, Int64Array, RecordBatch, RecordBatchIterator, StringArray};
@@ -14,7 +17,7 @@ use std::collections::{HashMap, HashSet};
 use std::io::Write as _;
 use std::path::Path;
 use std::sync::Arc;
-use std::time::{Instant, UNIX_EPOCH};
+use std::time::Instant;
 
 pub const MODEL: &str = "BAAI/bge-small-en-v1.5";
 pub const DIM: i32 = 384;
@@ -96,12 +99,12 @@ pub(crate) fn embed_batched(
     Ok(vectors)
 }
 
-/// The chunk ids already stored for `session_id`. Re-indexing keeps only the chunks whose id
-/// isn't here, so a grown session (the same memory) contributes just its new turns — nothing is
-/// re-embedded or deleted. (A rewritten turn arrives under new ids, i.e. as another memory.)
-async fn existing_ids(ds: &Dataset, session_id: &str) -> Result<HashSet<String>> {
-    let filter = format!("session_id = '{}'", session_id.replace('\'', "''"));
-    let batches = dataset::scan_rows(ds, &["id"], Some(filter.as_str()), None).await?;
+/// Every chunk id already stored. Re-indexing keeps only the chunks whose id isn't here, so a grown
+/// session (the same memory) contributes just its new turns — nothing is re-embedded or deleted. (A
+/// rewritten turn arrives under new ids, i.e. as another memory.) Chunk ids are global, so one
+/// unfiltered scan dedups any unit, whether it holds one session or thousands.
+async fn stored_ids(ds: &Dataset) -> Result<HashSet<String>> {
+    let batches = dataset::scan_rows(ds, &["id"], None, None).await?;
     let mut ids = HashSet::new();
     for batch in batches {
         if let Some(col) = batch
@@ -121,7 +124,7 @@ async fn existing_ids(ds: &Dataset, session_id: &str) -> Result<HashSet<String>>
 /// (via push) the Hub. Best-effort: removes a secret whose value byte-matches the stored text (the
 /// common case, real newlines); anything that resists is caught downstream by the fail-closed push
 /// gate. Reports to stderr what it removed.
-fn redact_turns(turns: &mut [parse::Turn], scanner: &dyn scan::SecretScanner) -> Result<()> {
+fn redact_turns(turns: &mut [trace::Turn], scanner: &dyn scan::SecretScanner) -> Result<()> {
     let texts: Vec<String> = turns
         .iter()
         .flat_map(|t| t.blocks.iter().map(|b| b.text.clone()))
@@ -160,20 +163,110 @@ fn redact_turns(turns: &mut [parse::Turn], scanner: &dyn scan::SecretScanner) ->
     Ok(())
 }
 
-/// "size:mtime_secs" for incremental skip, or None if the file can't be stat'd.
-fn file_sig(p: &Path) -> Option<String> {
-    let md = std::fs::metadata(p).ok()?;
-    let mtime = md.modified().ok()?.duration_since(UNIX_EPOCH).ok()?.as_secs();
-    Some(format!("{}:{}", md.len(), mtime))
+/// A unit's distinct-session count and a log label: `"<sid> (<project>)"` for a single session (a
+/// JSONL file), `"<n> sessions"` for a bulk unit (many sessions in one artifact), and the unit's `key` (its
+/// path) when it has no turns at all. The borrow of `turns` is confined here so callers keep it mutable.
+fn unit_summary(turns: &[trace::Turn], key: &str) -> (u64, String) {
+    let mut sids: Vec<&str> = turns.iter().map(|t| t.session_id.as_str()).collect();
+    sids.sort_unstable();
+    sids.dedup();
+    let label = match (sids.len(), turns.first()) {
+        (0, _) => key.to_string(),
+        (1, Some(t)) => format!("{} ({})", t.session_id, t.project),
+        (n, _) => format!("{n} sessions"),
+    };
+    (sids.len() as u64, label)
 }
 
-pub async fn run_index(source: &Path, no_thinking: bool) -> Result<()> {
+/// The run-wide indexing state: the local store uri, the dataset (created on the first write), the
+/// embedder, and the optional redaction scanner. Bundling it lets each unit be indexed by a method
+/// instead of threading the same handles through every call.
+struct Indexer<'a> {
+    uri: &'a str,
+    ds: Option<Dataset>,
+    embedder: TextEmbedding,
+    scanner: Option<&'a dyn scan::SecretScanner>,
+    include_thinking: bool,
+}
+
+impl Indexer<'_> {
+    /// Index one unit's turns: redact, chunk, keep only chunks whose id isn't already stored, and
+    /// embed those in a single append. Returns `(sessions read, new chunks added)`. `key` names the
+    /// unit in logs (and is the label when the unit has no sessions).
+    ///
+    /// Add-only-new: a grown session is the same memory — embed and add only its new turns, never
+    /// re-embedding or deleting what's unchanged. (A rewritten turn lands under new ids.) A unit's
+    /// turns are written in one append, so a bulk source (many sessions in one unit) stays a
+    /// single Lance fragment rather than one per session.
+    async fn index_unit(&mut self, progress: &str, key: &str, mut turns: Vec<trace::Turn>) -> Result<(u64, u64)> {
+        let (sessions, label) = unit_summary(&turns, key);
+
+        if let Some(scanner) = self.scanner {
+            redact_turns(&mut turns, scanner)?;
+        }
+        let chunks = chunk::chunks_from_turns(&turns, self.include_thinking);
+        let total_chunks = chunks.len();
+        if total_chunks == 0 {
+            eprintln!("{progress} {label} — no indexable content");
+            return Ok((sessions, 0));
+        }
+
+        let existing = match &self.ds {
+            Some(d) => stored_ids(d).await?,
+            None => HashSet::new(),
+        };
+        let new_chunks: Vec<chunk::Chunk> = chunks.into_iter().filter(|c| !existing.contains(&c.id)).collect();
+        if new_chunks.is_empty() {
+            eprintln!("{progress} {label} — {total_chunks} chunks, all already indexed");
+            return Ok((sessions, 0));
+        }
+
+        eprintln!("{progress} {label} — {} new of {total_chunks} chunks", new_chunks.len());
+        let added = self.embed_and_write(&new_chunks).await?;
+        Ok((sessions, added))
+    }
+
+    /// Embed `new_chunks` and add them — appending to the dataset, or creating it at `uri` on the
+    /// first write. Returns the count.
+    async fn embed_and_write(&mut self, new_chunks: &[chunk::Chunk]) -> Result<u64> {
+        let n = new_chunks.len();
+        let texts: Vec<&str> = new_chunks.iter().map(|c| c.text.as_str()).collect();
+        let t0 = Instant::now();
+        let vectors = embed_batched(&mut self.embedder, &texts, |done| {
+            let secs = t0.elapsed().as_secs_f64().max(0.001);
+            eprint!("\r    embedded {done}/{n}  ({:.0}/s)   ", done as f64 / secs);
+            let _ = std::io::stderr().flush();
+        })?;
+        eprintln!(
+            "\r    embedded {n} chunks in {:.1}s          ",
+            t0.elapsed().as_secs_f64()
+        );
+
+        let batch = build_batch(new_chunks, &vectors)?;
+        let reader = RecordBatchIterator::new(vec![Ok(batch)], schema());
+        let uri = self.uri;
+        match &mut self.ds {
+            Some(d) => {
+                d.append(reader, None).await?;
+            }
+            None => {
+                self.ds = Some(Dataset::write(reader, uri, Some(WriteParams::default())).await?);
+            }
+        }
+        Ok(n as u64)
+    }
+}
+
+/// Build/update the local index from `path` (a JSONL tree, or another `TraceSource`). Writes only
+/// locally — publishing is the separate `push`. `max_sessions` caps how many sessions are indexed
+/// (`None` = all) — the CLI passes `None`; a benchmark passes a cap to bound build time.
+pub async fn run_index(path: &Path, no_thinking: bool, max_sessions: Option<usize>) -> Result<()> {
     let include_thinking = !no_thinking;
     let dir = dataset::funes_dir();
     std::fs::create_dir_all(&dir)?;
 
     let uri = dataset::table_uri(&dataset::local_store_dir());
-    let mut ds = dataset::open(&uri, HashMap::new()).await.ok();
+    let ds = dataset::open(&uri, HashMap::new()).await.ok();
 
     // Model-pin: refuse to add to a store built with a different embedding model. The id rides
     // in the dataset's schema metadata; a pre-metadata store (no id) is tolerated and guarded only
@@ -194,18 +287,7 @@ pub async fn run_index(source: &Path, no_thinking: bool) -> Result<()> {
         .and_then(|s| serde_json::from_str(&s).ok())
         .unwrap_or_default();
 
-    let files = parse::iter_jsonl_files(source);
-    let total = files.len();
-    let cached = files
-        .iter()
-        .filter(|p| file_sig(p).is_some_and(|s| state.get(&p.to_string_lossy().into_owned()) == Some(&s)))
-        .count();
-    eprintln!(
-        "scanning {total} transcripts under {} — {cached} cached, {} to index",
-        source.display(),
-        total - cached
-    );
-    let mut embedder = TextEmbedding::try_new(InitOptions::new(EmbeddingModel::BGESmallENV15))?;
+    let embedder = TextEmbedding::try_new(InitOptions::new(EmbeddingModel::BGESmallENV15))?;
     // Best-effort secret redaction: if the scanner isn't installed, indexing continues unredacted —
     // the push gate still scans, fail-closed, before any upload, so a secret can't reach the Hub.
     let scanner = match scan::Trufflehog::find() {
@@ -215,100 +297,68 @@ pub async fn run_index(source: &Path, no_thinking: bool) -> Result<()> {
             None
         }
     };
+    let scanner = scanner.as_ref().map(|s| s as &dyn scan::SecretScanner);
 
-    let (mut n_files, mut n_skipped, mut n_chunks) = (0u64, 0u64, 0u64);
-    for (idx, p) in files.iter().enumerate() {
-        let sig = match file_sig(p) {
-            Some(s) => s,
-            None => continue,
-        };
-        let key = p.to_string_lossy().into_owned();
-        if state.get(&key) == Some(&sig) {
-            n_skipped += 1;
-            continue;
-        }
+    let src = source::open(path, max_sessions);
+    let units = src.units()?;
+    let total = units.len();
+    let cached = units
+        .iter()
+        .filter(|u| u.signature.as_ref().is_some_and(|s| state.get(&u.key) == Some(s)))
+        .count();
+    eprintln!("{} — {} to index, {cached} cached", src.describe(), total - cached);
 
-        let sid = parse::session_id_of(p);
-        let project = parse::project_of(p);
-        let mut turns = match parse::turns_from_jsonl_file(p, &sid, &project) {
-            Ok(t) => t,
-            Err(e) => {
-                // Don't record state, so a transient read failure is retried next run.
-                eprintln!("[{}/{}] {sid} — read failed, skipping: {e}", idx + 1, total);
+    let mut indexer = Indexer {
+        uri: &uri,
+        ds,
+        embedder,
+        scanner,
+        include_thinking,
+    };
+    let (mut n_sessions, mut n_skipped, mut n_chunks) = (0u64, 0u64, 0u64);
+    for (idx, unit) in units.iter().enumerate() {
+        // Skip a unit only if it carries a signature that still matches what's recorded; a
+        // signature-less (bulk) unit has none, so it's never skipped here — always re-read (its
+        // chunk-id dedup makes a re-run a no-op).
+        if let Some(sig) = &unit.signature {
+            if state.get(&unit.key) == Some(sig) {
+                n_skipped += 1;
                 continue;
             }
-        };
-        if let Some(scanner) = &scanner {
-            redact_turns(&mut turns, scanner)?;
         }
-        let chunks = chunk::chunks_from_turns(&turns, include_thinking);
-        let total_chunks = chunks.len();
-
-        if total_chunks == 0 {
-            eprintln!("[{}/{}] {sid} — no indexable content", idx + 1, total);
-        } else {
-            // Add-only-new: keep just the chunks whose id isn't already stored for this session.
-            // A grown session is the same memory — embed and add only its new turns, never
-            // re-embedding or deleting what's unchanged. (A rewritten turn lands under new ids.)
-            let existing = match &ds {
-                Some(d) => existing_ids(d, &sid).await?,
-                None => HashSet::new(),
-            };
-            let new_chunks: Vec<chunk::Chunk> = chunks.into_iter().filter(|c| !existing.contains(&c.id)).collect();
-
-            if new_chunks.is_empty() {
-                eprintln!(
-                    "[{}/{}] {sid} ({project}) — {total_chunks} chunks, all already indexed",
-                    idx + 1,
-                    total
-                );
-            } else {
-                let n = new_chunks.len();
-                eprintln!(
-                    "[{}/{}] {sid} ({project}) — {n} new of {total_chunks} chunks",
-                    idx + 1,
-                    total
-                );
-                let texts: Vec<&str> = new_chunks.iter().map(|c| c.text.as_str()).collect();
-                let t0 = Instant::now();
-                let vectors = embed_batched(&mut embedder, &texts, |done| {
-                    let secs = t0.elapsed().as_secs_f64().max(0.001);
-                    eprint!("\r    embedded {done}/{n}  ({:.0}/s)   ", done as f64 / secs);
-                    let _ = std::io::stderr().flush();
-                })?;
-                eprintln!(
-                    "\r    embedded {n} chunks in {:.1}s          ",
-                    t0.elapsed().as_secs_f64()
-                );
-
-                let batch = build_batch(&new_chunks, &vectors)?;
-                let reader = RecordBatchIterator::new(vec![Ok(batch)], schema());
-                match &mut ds {
-                    Some(d) => {
-                        d.append(reader, None).await?;
-                    }
-                    None => {
-                        ds = Some(Dataset::write(reader, &uri, Some(WriteParams::default())).await?);
-                    }
-                }
-                n_chunks += n as u64;
+        let progress = format!("[{}/{}]", idx + 1, total);
+        let turns = match src.read(unit) {
+            Ok(t) => t,
+            // Best-effort sources retry a failed read next run (no state recorded); a fatal source
+            // aborts rather than silently dropping data.
+            Err(e) if !src.fatal_on_read_error() => {
+                eprintln!("{progress} {} — read failed, skipping: {e}", unit.key);
+                continue;
             }
+            Err(e) => return Err(e),
+        };
+        let (sessions, added) = indexer.index_unit(&progress, &unit.key, turns).await?;
+        n_sessions += sessions;
+        n_chunks += added;
+
+        // Record state only for signed units, even when they produced no chunks ("remembered when
+        // empty"), and persist after each so an interrupted run is resumable. Signature-less (bulk)
+        // units are never recorded: a re-run re-reads and dedups to a no-op.
+        if let Some(sig) = &unit.signature {
+            state.insert(unit.key.clone(), sig.clone());
+            std::fs::write(&state_path, serde_json::to_string_pretty(&state)?)?;
         }
-        state.insert(key, sig); // remembered even when empty
-                                // Persist after each file so progress survives interruption (a kill is resumable).
-        std::fs::write(&state_path, serde_json::to_string_pretty(&state)?)?;
-        n_files += 1;
     }
 
     // Build the FTS + IVF_PQ indexes (best-effort). The vector index bounds how much a query reads,
     // which is what makes recall over a remote (hf://) tier lazy instead of a full-column scan; lance
     // enforces its own training minimum (256 rows for default IVF_PQ) and skips below it, so recall
     // falls back to brute-force vector search.
-    if let Some(d) = &mut ds {
+    if let Some(d) = &mut indexer.ds {
         dataset::build_indexes(d, |phase| eprintln!("building {phase}…")).await;
     }
 
-    println!("indexed files={n_files} skipped={n_skipped} chunks={n_chunks}");
+    println!("indexed sessions={n_sessions} skipped={n_skipped} chunks={n_chunks}");
 
     Ok(())
 }
@@ -316,23 +366,6 @@ pub async fn run_index(source: &Path, no_thinking: bool) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Write;
-
-    #[test]
-    fn file_sig_is_len_colon_mtime() {
-        let mut f = tempfile::NamedTempFile::new().unwrap();
-        f.write_all(b"hello").unwrap();
-        f.flush().unwrap();
-        let sig = file_sig(f.path()).expect("stat-able file has a signature");
-        let (len, mtime) = sig.split_once(':').expect("sig is len:mtime");
-        assert_eq!(len, "5");
-        assert!(mtime.parse::<u64>().is_ok());
-    }
-
-    #[test]
-    fn file_sig_is_none_for_missing_file() {
-        assert!(file_sig(Path::new("/no/such/file")).is_none());
-    }
 
     #[test]
     fn schema_column_order_is_load_bearing() {
@@ -384,7 +417,7 @@ mod tests {
                 decoder: "PLAIN".into(),
             },
         ]);
-        let mut turns = vec![parse::Turn {
+        let mut turns = vec![trace::Turn {
             session_id: "sess".into(),
             project: "proj".into(),
             turn_uuid: "turn".into(),
@@ -392,7 +425,7 @@ mod tests {
             seq: 0,
             ts: String::new(),
             role: "user".into(),
-            blocks: vec![parse::Block {
+            blocks: vec![trace::Block {
                 block_type: "text".into(),
                 text: "key=TOPSECRET hash=cafef00d".into(),
                 tool_name: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod config;
 pub mod dataset;
 pub mod hello;
 pub mod hf_dataset;
+pub mod hf_traces;
 pub mod hub;
 pub mod index;
 pub mod mcp;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub mod capture_store;
 pub mod chunk;
+pub mod claude_traces;
 pub mod config;
 pub mod dataset;
 pub mod hello;
@@ -14,8 +15,9 @@ pub mod hf_dataset;
 pub mod hub;
 pub mod index;
 pub mod mcp;
-pub mod parse;
 pub mod push;
 pub mod recall;
 pub mod scan;
 pub mod scrub;
+pub mod source;
+pub mod trace;

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,7 +165,7 @@ async fn main() -> Result<()> {
                 let home = std::env::var("HOME").unwrap_or_default();
                 PathBuf::from(home).join(".claude").join("projects")
             });
-            index::run_index(&dir, no_thinking).await
+            index::run_index(&dir, no_thinking, None).await
         }
         Cmd::Status { store } => {
             print!("{}", recall::status(store.resolve()).await?);

--- a/src/push.rs
+++ b/src/push.rs
@@ -404,7 +404,7 @@ mod tests {
         assert!(!is_read_only(&anyhow::anyhow!("no HF token")));
     }
 
-    use crate::parse::{Block, Turn};
+    use crate::trace::{Block, Turn};
     use std::process::Command;
 
     /// Mint a throwaway key (never committed, so funes ships no secret) of the given type, or None

--- a/src/source.rs
+++ b/src/source.rs
@@ -5,9 +5,10 @@
 //!
 //! A unit is both the incremental-tracking granule (skipped when its [`Unit::signature`] still
 //! matches `state.json`) and the single-append granule (all of a unit's turns are written in one
-//! commit). A JSONL tree is one session per file.
+//! commit). JSONL is one session per file; a parquet dataset is many sessions in one file.
 
 use crate::claude_traces;
+use crate::hf_traces;
 use crate::trace::Turn;
 
 use anyhow::Result;
@@ -36,20 +37,32 @@ pub trait TraceSource {
     fn read(&self, unit: &Unit) -> Result<Vec<Turn>>;
 
     /// Whether a `read` error aborts the whole index. Best-effort sources (a JSONL tree, where one
-    /// unreadable file shouldn't sink the run) return `false`; a single-artifact source returns
-    /// `true`, so a corrupt file is a hard failure rather than a silent skip.
+    /// unreadable file shouldn't sink the run) return `false`; a single-artifact source (a parquet
+    /// dataset) returns `true`, so a corrupt file is a hard failure rather than a silent skip.
     fn fatal_on_read_error(&self) -> bool {
         false
     }
 }
 
-/// Open the source for `path`. Today a path is a tree of Claude Code JSONL transcripts. `limit`
-/// caps how many sessions are read (`None` = all) — used to bound a benchmark's build time.
+/// Pick the source for `path`: a `*.parquet` file is a parquet trace dataset; anything else is a
+/// tree of Claude Code JSONL transcripts. `limit` caps how many sessions are read (`None` = all) —
+/// used to bound a benchmark's build time.
 pub fn open(path: &Path, limit: Option<usize>) -> Box<dyn TraceSource> {
-    Box::new(JsonlTree {
-        root: path.to_path_buf(),
-        limit,
-    })
+    let is_parquet = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .is_some_and(|e| e.eq_ignore_ascii_case("parquet"));
+    if is_parquet {
+        Box::new(ParquetDataset {
+            path: path.to_path_buf(),
+            limit,
+        })
+    } else {
+        Box::new(JsonlTree {
+            root: path.to_path_buf(),
+            limit,
+        })
+    }
 }
 
 /// "size:mtime_secs" for a file's incremental change-stamp, or `None` if it can't be stat'd.
@@ -93,6 +106,39 @@ impl TraceSource for JsonlTree {
     }
 }
 
+/// A parquet agent-trace dataset — many sessions in one file, indexed as a single bulk import.
+/// `signature: None` so it's never skipped on stats and never recorded: a re-run always re-reads
+/// and dedups by chunk id to a no-op, which also means a wiped store is never silently skipped.
+/// `limit` caps how many of its sessions (rows) are read.
+struct ParquetDataset {
+    path: PathBuf,
+    limit: Option<usize>,
+}
+
+impl TraceSource for ParquetDataset {
+    fn describe(&self) -> String {
+        format!("indexing parquet dataset {}", self.path.display())
+    }
+
+    fn units(&self) -> Result<Vec<Unit>> {
+        Ok(vec![Unit {
+            key: self.path.to_string_lossy().into_owned(),
+            signature: None,
+        }])
+    }
+
+    fn read(&self, unit: &Unit) -> Result<Vec<Turn>> {
+        let p = Path::new(&unit.key);
+        // The project facet for a parquet dataset is its file stem.
+        let project = p.file_stem().and_then(|s| s.to_str()).unwrap_or("parquet").to_string();
+        hf_traces::turns_from_parquet(p, &project, self.limit)
+    }
+
+    fn fatal_on_read_error(&self) -> bool {
+        true
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -115,13 +161,16 @@ mod tests {
     }
 
     #[test]
-    fn open_builds_a_jsonl_source() {
+    fn open_dispatches_by_extension() {
+        assert!(open(Path::new("/x/data.parquet"), None).describe().contains("parquet"));
+        assert!(open(Path::new("/x/DATA.PARQUET"), None).describe().contains("parquet"));
         assert!(open(Path::new("/x/projects"), None).describe().contains("transcripts"));
     }
 
     #[test]
     fn jsonl_tree_units_are_files_with_signatures() {
-        // A *.jsonl file under the tree becomes a unit keyed by its path, with a size:mtime stamp.
+        // A *.jsonl file under the tree becomes a unit keyed by its path, with a size:mtime stamp;
+        // a parquet dataset is a single signature-less unit (never skipped/recorded).
         let dir = tempfile::tempdir().unwrap();
         let f = dir.path().join("sess.jsonl");
         std::fs::write(&f, b"{}\n").unwrap();
@@ -130,6 +179,10 @@ mod tests {
         assert_eq!(units.len(), 1);
         assert_eq!(units[0].key, f.to_string_lossy());
         assert!(units[0].signature.is_some());
+
+        let pq = open(Path::new("/x/data.parquet"), None).units().unwrap();
+        assert_eq!(pq.len(), 1);
+        assert!(pq[0].signature.is_none());
     }
 
     #[test]

--- a/src/source.rs
+++ b/src/source.rs
@@ -1,0 +1,144 @@
+//! Trace sources: where the indexer reads agent sessions from. A [`TraceSource`] enumerates the
+//! discrete artifacts it indexes ([`Unit`]s — typically files) and parses one on demand into turns.
+//! The indexer ([`crate::index`]) drives any source through one generic loop, so adding a new
+//! transcript format is: implement [`TraceSource`] and add a branch to [`open`].
+//!
+//! A unit is both the incremental-tracking granule (skipped when its [`Unit::signature`] still
+//! matches `state.json`) and the single-append granule (all of a unit's turns are written in one
+//! commit). A JSONL tree is one session per file.
+
+use crate::claude_traces;
+use crate::trace::Turn;
+
+use anyhow::Result;
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
+
+/// One artifact a source indexes as a unit. `key` is its `state.json` identity (the path). A
+/// `Some` `signature` is a cheap change-stamp: the unit is skipped when it still matches what was
+/// recorded, and recorded after a successful index. `None` means "always read, never recorded" —
+/// for a bulk source whose idempotency comes from chunk-id dedup, not file stats.
+pub struct Unit {
+    pub key: String,
+    pub signature: Option<String>,
+}
+
+/// A source of agent-session transcripts. `units()` is cheap (enumerate + stat, no parsing);
+/// `read` parses one unit's turns and is called only for units that aren't skipped.
+pub trait TraceSource {
+    /// One-line description of what's being indexed (the scan banner's source-kind part).
+    fn describe(&self) -> String;
+
+    /// The units to consider, in deterministic order.
+    fn units(&self) -> Result<Vec<Unit>>;
+
+    /// Parse one unit into turns (each [`Turn`] already carries its `session_id` and `project`).
+    fn read(&self, unit: &Unit) -> Result<Vec<Turn>>;
+
+    /// Whether a `read` error aborts the whole index. Best-effort sources (a JSONL tree, where one
+    /// unreadable file shouldn't sink the run) return `false`; a single-artifact source returns
+    /// `true`, so a corrupt file is a hard failure rather than a silent skip.
+    fn fatal_on_read_error(&self) -> bool {
+        false
+    }
+}
+
+/// Open the source for `path`. Today a path is a tree of Claude Code JSONL transcripts. `limit`
+/// caps how many sessions are read (`None` = all) — used to bound a benchmark's build time.
+pub fn open(path: &Path, limit: Option<usize>) -> Box<dyn TraceSource> {
+    Box::new(JsonlTree {
+        root: path.to_path_buf(),
+        limit,
+    })
+}
+
+/// "size:mtime_secs" for a file's incremental change-stamp, or `None` if it can't be stat'd.
+pub(crate) fn file_sig(p: &Path) -> Option<String> {
+    let md = std::fs::metadata(p).ok()?;
+    let mtime = md.modified().ok()?.duration_since(UNIX_EPOCH).ok()?.as_secs();
+    Some(format!("{}:{}", md.len(), mtime))
+}
+
+/// A directory tree of Claude Code `*.jsonl` transcripts — one session per file, indexed
+/// incrementally (each file skipped while unchanged). `limit` caps the number of files (sessions).
+struct JsonlTree {
+    root: PathBuf,
+    limit: Option<usize>,
+}
+
+impl TraceSource for JsonlTree {
+    fn describe(&self) -> String {
+        format!("scanning transcripts under {}", self.root.display())
+    }
+
+    fn units(&self) -> Result<Vec<Unit>> {
+        let mut files = claude_traces::iter_jsonl_files(&self.root);
+        if let Some(n) = self.limit {
+            files.truncate(n);
+        }
+        Ok(files
+            .into_iter()
+            .map(|p| Unit {
+                signature: file_sig(&p),
+                key: p.to_string_lossy().into_owned(),
+            })
+            .collect())
+    }
+
+    fn read(&self, unit: &Unit) -> Result<Vec<Turn>> {
+        let p = Path::new(&unit.key);
+        let sid = claude_traces::session_id_of(p);
+        let project = claude_traces::project_of(p);
+        Ok(claude_traces::turns_from_jsonl_file(p, &sid, &project)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn file_sig_is_len_colon_mtime() {
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        f.write_all(b"hello").unwrap();
+        f.flush().unwrap();
+        let sig = file_sig(f.path()).expect("stat-able file has a signature");
+        let (len, mtime) = sig.split_once(':').expect("sig is len:mtime");
+        assert_eq!(len, "5");
+        assert!(mtime.parse::<u64>().is_ok());
+    }
+
+    #[test]
+    fn file_sig_is_none_for_missing_file() {
+        assert!(file_sig(Path::new("/no/such/file")).is_none());
+    }
+
+    #[test]
+    fn open_builds_a_jsonl_source() {
+        assert!(open(Path::new("/x/projects"), None).describe().contains("transcripts"));
+    }
+
+    #[test]
+    fn jsonl_tree_units_are_files_with_signatures() {
+        // A *.jsonl file under the tree becomes a unit keyed by its path, with a size:mtime stamp.
+        let dir = tempfile::tempdir().unwrap();
+        let f = dir.path().join("sess.jsonl");
+        std::fs::write(&f, b"{}\n").unwrap();
+
+        let units = open(dir.path(), None).units().unwrap();
+        assert_eq!(units.len(), 1);
+        assert_eq!(units[0].key, f.to_string_lossy());
+        assert!(units[0].signature.is_some());
+    }
+
+    #[test]
+    fn jsonl_limit_caps_units() {
+        let dir = tempfile::tempdir().unwrap();
+        for i in 0..5 {
+            std::fs::write(dir.path().join(format!("s{i}.jsonl")), b"{}\n").unwrap();
+        }
+        assert_eq!(open(dir.path(), Some(2)).units().unwrap().len(), 2);
+        assert_eq!(open(dir.path(), None).units().unwrap().len(), 5);
+    }
+}

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -1,0 +1,23 @@
+//! The parsed-trace model. A transcript becomes a sequence of [`Turn`]s, each carrying typed
+//! [`Block`]s. Every source parser produces this shape, and everything downstream —
+//! chunk → embed → store → recall — operates on it, so the model is source-agnostic and lives on
+//! its own here.
+
+pub struct Block {
+    pub block_type: String, // "text" | "thinking" | "tool_use" | "tool_result"
+    pub text: String,
+    pub tool_name: Option<String>,
+    pub tool_use_id: Option<String>,
+}
+
+pub struct Turn {
+    pub session_id: String,
+    pub project: String,
+    pub turn_uuid: String,
+    pub parent_uuid: Option<String>,
+    pub seq: i64,
+    pub ts: String,
+    pub role: String,
+    pub blocks: Vec<Block>,
+    pub source_path: String,
+}

--- a/tests/index_recall.rs
+++ b/tests/index_recall.rs
@@ -33,7 +33,7 @@ async fn index_then_read_surface() {
     let (session, project) = write_transcript(source.path());
 
     // Build the index for real: parse → chunk → embed → Lance + FTS.
-    funes::index::run_index(source.path(), false).await.unwrap();
+    funes::index::run_index(source.path(), false, None).await.unwrap();
 
     // status: non-empty chunk count.
     let status = funes::recall::status(funes::hub::Store::local()).await.unwrap();

--- a/tests/push_round_trip.rs
+++ b/tests/push_round_trip.rs
@@ -75,7 +75,7 @@ async fn push_round_trip_create_append_recall() {
     let src = tempfile::tempdir().unwrap();
     std::env::set_var("FUNES_HOME", db_dir.path());
     write_session(src.path(), &[("s1", "SYNCSMOKE parsing transcripts into turns")]);
-    funes::index::run_index(src.path(), false).await.unwrap();
+    funes::index::run_index(src.path(), false, None).await.unwrap();
 
     // create (first publish) → grow → append (data-only, no reindex) → recall both. The appended
     // turn is left unindexed, so recalling it back exercises Lance's brute-force fallback. Then
@@ -88,7 +88,7 @@ async fn push_round_trip_create_append_recall() {
             ("s2", "SYNCSMOKE2 the continuation adds only this new turn"),
         ],
     );
-    funes::index::run_index(src.path(), false).await.unwrap();
+    funes::index::run_index(src.path(), false, None).await.unwrap();
     let append = funes::push::run_push(Store::parse(&uri), false).await;
     let recall_base = recall_remote(&uri, "SYNCSMOKE parsing").await;
     let recall_new = recall_remote(&uri, "SYNCSMOKE2 continuation").await;

--- a/tests/redact_on_index.rs
+++ b/tests/redact_on_index.rs
@@ -49,7 +49,7 @@ async fn planted_key_is_redacted_at_index_time() {
     writeln!(f, "{line}").unwrap();
 
     // Index for real — redaction runs over the block text before chunking/embedding/storing.
-    funes::index::run_index(source.path(), false).await.unwrap();
+    funes::index::run_index(source.path(), false, None).await.unwrap();
 
     // Read the stored turn back: the marker is present, the key body is gone.
     let got = funes::recall::get(funes::hub::Store::local(), session.into(), "t1".into(), 3)

--- a/tests/reindex_incremental.rs
+++ b/tests/reindex_incremental.rs
@@ -33,12 +33,12 @@ async fn incremental_reindex_matches_from_scratch() {
     let inc_db = tempfile::tempdir().unwrap();
     std::env::set_var("FUNES_HOME", inc_db.path());
     write_session(inc_src.path(), 4);
-    funes::index::run_index(inc_src.path(), false).await.unwrap();
+    funes::index::run_index(inc_src.path(), false, None).await.unwrap();
     let after_first = chunk_count().await;
     assert!(after_first > 0, "first index produced no chunks");
 
     write_session(inc_src.path(), 6); // append 2 turns
-    funes::index::run_index(inc_src.path(), false).await.unwrap();
+    funes::index::run_index(inc_src.path(), false, None).await.unwrap();
     let incremental = chunk_count().await;
     assert!(
         incremental > after_first,
@@ -50,7 +50,7 @@ async fn incremental_reindex_matches_from_scratch() {
     let scratch_db = tempfile::tempdir().unwrap();
     write_session(scratch_src.path(), 6);
     std::env::set_var("FUNES_HOME", scratch_db.path());
-    funes::index::run_index(scratch_src.path(), false).await.unwrap();
+    funes::index::run_index(scratch_src.path(), false, None).await.unwrap();
     let from_scratch = chunk_count().await;
 
     assert_eq!(

--- a/tests/scrub.rs
+++ b/tests/scrub.rs
@@ -55,7 +55,7 @@ async fn scrub_redacts_an_existing_secret_in_place() {
 
     // Index with a no-op scanner so the secret lands in the store unredacted.
     std::env::set_var("FUNES_TRUFFLEHOG", "/usr/bin/true");
-    funes::index::run_index(source.path(), false).await.unwrap();
+    funes::index::run_index(source.path(), false, None).await.unwrap();
     let dirty = funes::recall::get(funes::hub::Store::local(), session.into(), "t1".into(), 3)
         .await
         .unwrap();

--- a/tests/scrub_drops_all.rs
+++ b/tests/scrub_drops_all.rs
@@ -59,7 +59,7 @@ async fn scrub_dropping_every_block_leaves_a_valid_empty_store() {
 
     // Index with a no-op scanner so the escaped key lands in the store unredacted.
     std::env::set_var("FUNES_TRUFFLEHOG", "/usr/bin/true");
-    funes::index::run_index(source.path(), false).await.unwrap();
+    funes::index::run_index(source.path(), false, None).await.unwrap();
 
     // Scrub with the real scanner: every block is unredactable, so the store is rewritten empty.
     std::env::remove_var("FUNES_TRUFFLEHOG");

--- a/tests/scrub_drops_escaped_key.rs
+++ b/tests/scrub_drops_escaped_key.rs
@@ -63,7 +63,7 @@ async fn scrub_redacts_an_escaped_key_in_place() {
 
     // Index with a no-op scanner so the escaped key lands in the store unredacted.
     std::env::set_var("FUNES_TRUFFLEHOG", "/usr/bin/true");
-    funes::index::run_index(source.path(), false).await.unwrap();
+    funes::index::run_index(source.path(), false, None).await.unwrap();
     let dirty = funes::recall::get(funes::hub::Store::local(), session.into(), "t2".into(), 0)
         .await
         .unwrap();


### PR DESCRIPTION
This adds another source indexer for Hugging Face hub parquet traces datasets.

It also adds two small benchmark applications to evaluate `recall` and `indx` performances.