### PR TITLE
Add release bucket

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -253,6 +253,21 @@ jobs:
             --title "$TAG" \
             --generate-notes
 
+      # Publish the same binaries to the huggingface/funes storage bucket, which install.sh fetches
+      # from. The bucket root holds the latest binaries; each release also keeps a pinned copy under
+      # its tag, so `funes -v <tag>` resolves to it. Bucket support landed in huggingface_hub 1.21 —
+      # newer than the system package — so install it into a throwaway venv.
+      - name: Publish binaries to the Hugging Face bucket
+        env:
+          HF_TOKEN: ${{ secrets.HF_FUNES_RELEASE_TOKEN }}
+        run: |
+          TAG="${{ needs.compute.outputs.tag || github.ref_name }}"
+          python3 -m venv "$RUNNER_TEMP/hfvenv"
+          "$RUNNER_TEMP/hfvenv/bin/pip" install -q -U "huggingface_hub>=1.21"
+          HF="$RUNNER_TEMP/hfvenv/bin/hf"
+          "$HF" buckets sync ./artifacts hf://buckets/huggingface/funes
+          "$HF" buckets sync ./artifacts "hf://buckets/huggingface/funes/$TAG"
+
       # Dispatch only: push a branch advancing main's version marker to `<version>+dev`. The org
       # blocks Actions from opening PRs, so the workflow stops at the branch and surfaces a one-click
       # "create PR" link in the run summary; a maintainer opens that PR and merges it.

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@
 
 # protoc downloaded by scripts/bootstrap-protoc.sh
 /.tools/
+
+# Local-only files — never committed. Give any machine-local file (secrets,
+# scratch, personal config) a `.local` suffix, e.g. hf_funes_release_token.local.
+*.local

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ curl -fsSL https://raw.githubusercontent.com/huggingface/funes/main/scripts/inst
 ```
 
 Pass `-b <dir>` to change the install dir or `-v <tag>` to pin a release, after `sh -s --`.
-Or grab a [binary](https://github.com/huggingface/funes/releases) by hand:
+Or grab a [binary](https://huggingface.co/buckets/huggingface/funes) by hand:
 
 | Platform | Binary |
 | --- | --- |
@@ -72,7 +72,7 @@ Or grab a [binary](https://github.com/huggingface/funes/releases) by hand:
 | macOS Apple Silicon | `funes-arm64-apple-darwin` |
 
 ```bash
-curl -fsSL https://github.com/huggingface/funes/releases/latest/download/funes-x86_64-linux -o funes
+curl -fsSL https://huggingface.co/buckets/huggingface/funes/resolve/funes-x86_64-linux -o funes
 chmod +x funes && ./funes recall "how do I get started with funes"
 ```
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Install the funes binary from GitHub Releases.
+# Install the funes binary from the Hugging Face bucket (huggingface/funes).
 #
 #   curl -fsSL https://raw.githubusercontent.com/huggingface/funes/main/scripts/install.sh | sh
 #
@@ -10,6 +10,7 @@
 set -eu
 
 REPO="huggingface/funes"
+BUCKET="huggingface/funes"
 BINDIR="${FUNES_INSTALL_DIR:-$HOME/.local/bin}"
 VERSION="${FUNES_VERSION:-latest}"
 
@@ -40,10 +41,12 @@ case "$(uname -s)-$(uname -m)" in
         ;;
 esac
 
+# Bucket files have no revision: the root holds the latest binaries, and each release keeps a
+# pinned copy under its tag. Buckets are non-versioned, so the resolve path carries no `main`.
 if [ "$VERSION" = latest ]; then
-    url="https://github.com/$REPO/releases/latest/download/$asset"
+    url="https://huggingface.co/buckets/$BUCKET/resolve/$asset"
 else
-    url="https://github.com/$REPO/releases/download/$VERSION/$asset"
+    url="https://huggingface.co/buckets/$BUCKET/resolve/$VERSION/$asset"
 fi
 
 # Download to a temp file so a failed/partial fetch never lands on PATH.
@@ -62,7 +65,7 @@ fi
 echo "Downloading $asset ($VERSION)…"
 if ! fetch "$url" "$tmp"; then
     echo "funes: download failed: $url" >&2
-    echo "  (no matching release published yet? see https://github.com/$REPO/releases)" >&2
+    echo "  (no matching release published yet? see https://huggingface.co/buckets/$BUCKET)" >&2
     exit 1
 fi
 


### PR DESCRIPTION
The releases are now pushed to the huggingface/funes storage bucket.

The install script is modified accordingly.