### PR TITLE
Add pi recall extension and `funes install pi`

### DIFF
--- a/integrations/pi/README.md
+++ b/integrations/pi/README.md
@@ -1,0 +1,40 @@
+# funes-pi
+
+A [pi](https://github.com/badlogic/pi-mono) extension that exposes funes recall
+as first-class `recall` / `get` tools.
+
+pi has no MCP client, so the extension *is* one: it spawns `funes mcp` once over
+stdio, keeps it warm for the session, and forwards each call as an MCP
+`tools/call`. Same `funes mcp` surface every other agent integration consumes —
+just fronted by a thin pi tool.
+
+## Install
+
+Once `funes` is on your PATH, one command extracts this extension and registers
+it with pi. Like `hf skills add`, it installs into the current project by
+default; add `-g` to make it available in every project:
+
+```sh
+funes install pi        # this project (.pi/settings.json)
+funes install pi -g     # all projects (user-wide)
+```
+
+funes embeds the extension in its binary, so this always matches the installed
+funes version — no separate package to fetch. (`--dest` extracts elsewhere;
+`--force` refreshes after a funes upgrade.)
+
+For development from a funes checkout you can also install the package directly
+with `pi install ./integrations/pi`, drop it under `<cwd>/.pi/extensions/` for
+zero-config discovery, or load it for a single run with `pi -e ./integrations/pi`.
+
+> There's no `pi install git:…/funes`: pi has no subdir/monorepo install syntax,
+> and the funes repo root is a Cargo project rather than a pi package.
+
+## Requirements
+
+- `funes` on `PATH` (set `FUNES_BIN` to override the binary path).
+- A funes store the binary can read — local, or a live `hf://` remote configured
+  via `FUNES_HOME`/`funes.json` (needs network + an HF token for a private remote).
+
+`typebox` and the pi SDK are provided by pi's loader, so the extension declares
+no dependencies.

--- a/integrations/pi/README.md
+++ b/integrations/pi/README.md
@@ -11,8 +11,8 @@ just fronted by a thin pi tool.
 ## Install
 
 Once `funes` is on your PATH, one command extracts this extension and registers
-it with pi. Like `hf skills add`, it installs into the current project by
-default; add `-g` to make it available in every project:
+it with pi. It installs into the current project by default; add `-g` to make
+it available in every project:
 
 ```sh
 funes install pi        # this project (.pi/settings.json)

--- a/integrations/pi/index.ts
+++ b/integrations/pi/index.ts
@@ -1,0 +1,159 @@
+// funes-owned pi extension: expose recall over past AI-assistant sessions as
+// first-class pi tools (`recall`, `get`).
+//
+// pi has no MCP client, so this extension *is* the client: it spawns `funes mcp`
+// once over stdio, keeps it warm for the session, and forwards each call as an
+// MCP `tools/call`. That keeps the embedder + reranker loaded across calls
+// (unlike shelling out to `funes recall`, which reloads both every time), and
+// it consumes the same `funes mcp` surface every other agent integration uses.
+//
+// Install:  funes install pi   — or, from a funes checkout, `pi install
+// ./integrations/pi`, or drop this dir under <cwd>/.pi/extensions/ for
+// zero-config discovery.
+//
+// `funes` is taken from PATH; set FUNES_BIN to override — e.g. inside an
+// agentcap sandbox, --tool-dir puts the bundle's `funes` wrapper on PATH (which
+// also points FASTEMBED_CACHE_DIR at the prewarmed cache and FUNES_HOME at the
+// live-remote config).
+import { Type } from "typebox";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+
+const FUNES_BIN = process.env.FUNES_BIN || "funes";
+const PROTOCOL_VERSION = "2024-11-05"; // matches funes' rmcp server
+const CALL_TIMEOUT_MS = 120_000;
+
+type Pending = { resolve: (v: any) => void; reject: (e: Error) => void; timer: ReturnType<typeof setTimeout> };
+
+// A minimal MCP stdio client for a single `funes mcp` child. stdout is the
+// JSON-RPC channel (newline-delimited messages); stderr is logs.
+class FunesMcp {
+  private child?: ChildProcessWithoutNullStreams;
+  private ready?: Promise<void>;
+  private nextId = 1;
+  private pending = new Map<number, Pending>();
+  private buf = "";
+
+  private ensureStarted(): Promise<void> {
+    if (this.child && this.ready) return this.ready;
+    const child = spawn(FUNES_BIN, ["mcp"], { stdio: ["pipe", "pipe", "pipe"] });
+    this.child = child;
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => this.onData(chunk));
+    child.stderr.resume(); // drain logs so the pipe never blocks
+    const die = (err: Error) => {
+      this.child = undefined;
+      this.ready = undefined;
+      for (const p of this.pending.values()) {
+        clearTimeout(p.timer);
+        p.reject(err);
+      }
+      this.pending.clear();
+    };
+    child.on("exit", (code) => die(new Error(`funes mcp exited (code ${code})`)));
+    child.on("error", (e) => die(new Error(`funes mcp failed to start: ${e.message}`)));
+
+    this.ready = (async () => {
+      await this.request("initialize", {
+        protocolVersion: PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: { name: "pi-funes-bridge", version: "0.1.0" },
+      });
+      this.send({ jsonrpc: "2.0", method: "notifications/initialized", params: {} });
+    })();
+    return this.ready;
+  }
+
+  private onData(chunk: string) {
+    this.buf += chunk;
+    let nl: number;
+    while ((nl = this.buf.indexOf("\n")) >= 0) {
+      const line = this.buf.slice(0, nl).trim();
+      this.buf = this.buf.slice(nl + 1);
+      if (!line) continue;
+      let msg: any;
+      try {
+        msg = JSON.parse(line);
+      } catch {
+        continue; // not a JSON-RPC frame (stray output)
+      }
+      const p = typeof msg.id === "number" ? this.pending.get(msg.id) : undefined;
+      if (!p) continue;
+      this.pending.delete(msg.id);
+      clearTimeout(p.timer);
+      if (msg.error) p.reject(new Error(msg.error.message || JSON.stringify(msg.error)));
+      else p.resolve(msg.result);
+    }
+  }
+
+  private send(obj: any) {
+    if (!this.child) throw new Error("funes mcp not running");
+    this.child.stdin.write(JSON.stringify(obj) + "\n");
+  }
+
+  private request(method: string, params: any): Promise<any> {
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`funes ${method} timed out`));
+      }, CALL_TIMEOUT_MS);
+      this.pending.set(id, { resolve, reject, timer });
+      this.send({ jsonrpc: "2.0", id, method, params });
+    });
+  }
+
+  // Call an MCP tool and flatten its text content to a string.
+  async callTool(name: string, args: Record<string, unknown>): Promise<string> {
+    await this.ensureStarted();
+    const result = await this.request("tools/call", { name, arguments: args });
+    const content: any[] = result?.content ?? [];
+    return content
+      .filter((c) => c?.type === "text")
+      .map((c) => c.text)
+      .join("\n");
+  }
+}
+
+const funes = new FunesMcp();
+
+async function call(name: string, args: Record<string, unknown>) {
+  try {
+    return { content: [{ type: "text", text: await funes.callTool(name, args) }] };
+  } catch (e: any) {
+    return { content: [{ type: "text", text: `${name} error: ${e?.message || String(e)}` }] };
+  }
+}
+
+export default function (pi: any) {
+  pi.registerTool({
+    name: "recall",
+    label: "Recall",
+    description:
+      "Recall decisions, rationale, and context from the user's past AI-assistant sessions. " +
+      "Returns ranked passages with provenance (timestamp, session, block type); each hit " +
+      "carries a `→ get <session_id> <turn_uuid>` line you can pass to `get` to read the full " +
+      "surrounding turns. Use it when a question concerns something decided or discussed in an " +
+      "earlier session rather than the current files, or before asserting the history of anything.",
+    parameters: Type.Object({
+      query: Type.String({ description: "Natural-language search query" }),
+      k: Type.Optional(Type.Number({ description: "Number of results (default 8)" })),
+    }),
+    execute: (_id: string, params: { query: string; k?: number }) =>
+      call("recall", params.k ? { query: params.query, k: params.k } : { query: params.query }),
+  });
+
+  pi.registerTool({
+    name: "get",
+    label: "Recall: get",
+    description:
+      "Drill down on a recall hit: fetch the named turn plus the turns around it, reassembled " +
+      "into readable text. Pass the `session_id` and `turn_uuid` from a recall hit's `→ get` line.",
+    parameters: Type.Object({
+      session_id: Type.String({ description: "Session id from a recall hit's `→ get` line" }),
+      turn_uuid: Type.String({ description: "Turn uuid from a recall hit's `→ get` line" }),
+      window: Type.Optional(Type.Number({ description: "Turns within this window are included (default 3)" })),
+    }),
+    execute: (_id: string, params: { session_id: string; turn_uuid: string; window?: number }) =>
+      call("get", params.window ? params : { session_id: params.session_id, turn_uuid: params.turn_uuid }),
+  });
+}

--- a/integrations/pi/package.json
+++ b/integrations/pi/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "funes-pi",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "pi extension: recall over past AI-assistant sessions, bridged to `funes mcp`.",
+  "scripts": {
+    "clean": "echo 'nothing to clean'",
+    "build": "echo 'nothing to build'",
+    "check": "echo 'nothing to check'"
+  },
+  "pi": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod hf_traces;
 pub mod hub;
 pub mod index;
 pub mod mcp;
+pub mod pi;
 pub mod push;
 pub mod recall;
 pub mod scan;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@
 //! `recall` reads the index (hybrid → rerank → recency); `index` builds/updates it
 //! from `~/.claude/projects/**/*.jsonl`. funes's home is `$FUNES_HOME` or `~/.funes`.
 
-use funes::{config, hub, index, mcp, push, recall, scrub};
+use funes::{config, hub, index, mcp, pi, push, recall, scrub};
 
 use anyhow::{anyhow, Result};
 use clap::{Args, Parser, Subcommand};
@@ -101,6 +101,28 @@ enum Cmd {
     Scrub,
     /// Run as an MCP server over stdio (for Claude Code, Cursor, …).
     Mcp,
+    /// Install funes into a coding agent.
+    Install {
+        #[command(subcommand)]
+        agent: InstallAgent,
+    },
+}
+
+#[derive(Subcommand)]
+enum InstallAgent {
+    /// pi: extract the bundled bridge extension and register it with pi (pi has no MCP client of
+    /// its own). Defaults to this project (`.pi/settings.json`); `-g` installs it user-wide.
+    Pi {
+        /// Install user-wide (all projects) instead of just the current one.
+        #[arg(short, long)]
+        global: bool,
+        /// Extract the extension here instead of under funes's home.
+        #[arg(long, value_name = "PATH")]
+        dest: Option<PathBuf>,
+        /// Re-extract the bundled extension even if it already exists at the destination.
+        #[arg(long)]
+        force: bool,
+    },
 }
 
 /// Which store the read commands act on. Shared by `recall`/`list`/`get`/`status`.
@@ -193,6 +215,9 @@ async fn main() -> Result<()> {
         }
         Cmd::Scrub => scrub::run().await,
         Cmd::Mcp => mcp::run().await,
+        Cmd::Install { agent } => match agent {
+            InstallAgent::Pi { global, dest, force } => pi::install(global, dest, force),
+        },
     }
 }
 

--- a/src/pi.rs
+++ b/src/pi.rs
@@ -21,7 +21,7 @@ const MIN_PI: (u32, u32, u32) = (0, 73, 0);
 /// Extract the embedded pi extension and register it with pi. Defaults to the
 /// current project; `global` installs it user-wide. `dest` overrides where the
 /// extension is extracted (default: funes's home); `force` re-extracts even when
-/// it's already there. Flag vocabulary mirrors `hf skills add`.
+/// it's already there.
 pub fn install(global: bool, dest: Option<PathBuf>, force: bool) -> Result<()> {
     let dir = dest.unwrap_or_else(|| dataset::funes_dir().join("integrations").join("pi"));
     let present = dir.join("index.ts").exists() && dir.join("package.json").exists();

--- a/src/pi.rs
+++ b/src/pi.rs
@@ -1,0 +1,122 @@
+//! `funes install pi`: register funes recall as a first-class pi tool.
+//!
+//! pi has no MCP client, so funes ships a small pi extension (a bridge that
+//! spawns `funes mcp` over stdio — see `integrations/pi/`). The extension is
+//! embedded in the binary here, so once `funes` is on PATH a single
+//! `funes install pi` extracts it and registers it with pi — no separate
+//! package to fetch, and it always matches this binary's MCP surface.
+
+use crate::dataset;
+use anyhow::{Context, Result};
+use std::path::PathBuf;
+use std::process::Command;
+
+const INDEX_TS: &str = include_str!("../integrations/pi/index.ts");
+const PACKAGE_JSON: &str = include_str!("../integrations/pi/package.json");
+
+/// The pi version funes' extension API (the `pi.extensions` manifest + `registerTool`
+/// + provided `typebox`) was validated against. Older pi may not load the extension.
+const MIN_PI: (u32, u32, u32) = (0, 73, 0);
+
+/// Extract the embedded pi extension and register it with pi. Defaults to the
+/// current project; `global` installs it user-wide. `dest` overrides where the
+/// extension is extracted (default: funes's home); `force` re-extracts even when
+/// it's already there. Flag vocabulary mirrors `hf skills add`.
+pub fn install(global: bool, dest: Option<PathBuf>, force: bool) -> Result<()> {
+    let dir = dest.unwrap_or_else(|| dataset::funes_dir().join("integrations").join("pi"));
+    let present = dir.join("index.ts").exists() && dir.join("package.json").exists();
+    if present && !force {
+        println!(
+            "funes pi extension already at {} (use --force to refresh)",
+            dir.display()
+        );
+    } else {
+        std::fs::create_dir_all(&dir).with_context(|| format!("creating {}", dir.display()))?;
+        std::fs::write(dir.join("index.ts"), INDEX_TS).context("writing index.ts")?;
+        std::fs::write(dir.join("package.json"), PACKAGE_JSON).context("writing package.json")?;
+    }
+    let dir = dir.to_string_lossy().into_owned();
+    let scope = if global { "user" } else { "project" };
+
+    // Probe pi: this confirms it's on PATH (else extract-and-instruct) and lets us flag a
+    // version older than the one the extension API was validated against.
+    let version = match Command::new("pi").arg("--version").output() {
+        Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).trim().to_string(),
+        Ok(_) => String::new(), // pi present but odd --version; proceed without a version
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            let flag = if global { "" } else { "-l " };
+            println!("extracted the funes pi extension to {dir}");
+            println!("`pi` isn't on PATH — once it is, run:  pi install {flag}{dir}");
+            return Ok(());
+        }
+        Err(e) => return Err(anyhow::Error::new(e).context("running `pi --version`")),
+    };
+    if matches!(parse_semver(&version), Some(v) if v < MIN_PI) {
+        eprintln!(
+            "warning: pi {version} is older than the tested {}.{}.{} — if `recall` doesn't appear in pi, run `pi update`.",
+            MIN_PI.0, MIN_PI.1, MIN_PI.2
+        );
+    }
+
+    // Let pi resolve its own settings location. pi records the package as a path
+    // reference, so the extracted dir must persist — funes's home does.
+    let mut cmd = Command::new("pi");
+    cmd.arg("install");
+    if !global {
+        cmd.arg("-l");
+    }
+    cmd.arg(&dir);
+
+    match cmd.status() {
+        Ok(s) if s.success() => {
+            let v = if version.is_empty() {
+                String::new()
+            } else {
+                format!(" {version}")
+            };
+            println!("installed funes recall into pi{v} ({scope} scope) — `recall`/`get` are now available (restart pi if it's running).");
+            Ok(())
+        }
+        Ok(s) => anyhow::bail!(
+            "`pi install {dir}` failed (exit {:?}); the extension is extracted there — retry that command manually.",
+            s.code()
+        ),
+        Err(e) => Err(anyhow::Error::new(e).context("running `pi install`")),
+    }
+}
+
+/// Parse a leading `MAJOR.MINOR.PATCH` from pi's `--version` output (tolerates a `v`
+/// prefix, extra tokens, and a pre-release/build suffix on the patch).
+fn parse_semver(s: &str) -> Option<(u32, u32, u32)> {
+    let tok = s.trim().trim_start_matches('v').split_whitespace().next()?;
+    let mut parts = tok.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next().unwrap_or("0").parse().ok()?;
+    let patch = parts
+        .next()
+        .map(|p| p.chars().take_while(|c| c.is_ascii_digit()).collect::<String>())
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(0);
+    Some((major, minor, patch))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_semver, MIN_PI};
+
+    #[test]
+    fn parses_versions_and_compares_to_min() {
+        assert_eq!(parse_semver("0.73.0"), Some((0, 73, 0)));
+        assert_eq!(parse_semver("v1.2.3"), Some((1, 2, 3)));
+        assert_eq!(parse_semver("0.73.0-beta.1"), Some((0, 73, 0)));
+        assert_eq!(parse_semver("0.73"), Some((0, 73, 0)));
+        assert_eq!(parse_semver("1.0.0 (abc123)"), Some((1, 0, 0)));
+        assert_eq!(parse_semver("not-a-version"), None);
+        assert_eq!(parse_semver(""), None);
+
+        // the floor comparison the install warning hinges on
+        assert!(parse_semver("0.72.9").unwrap() < MIN_PI);
+        assert!(parse_semver("0.73.0").unwrap() >= MIN_PI);
+        assert!(parse_semver("1.0.0").unwrap() >= MIN_PI);
+    }
+}


### PR DESCRIPTION
pi has no MCP client, so funes ships a pi extension that bridges to `funes mcp` over stdio — spawned once, kept warm — exposing `recall` and `get` as first-class tools (the same MCP surface other agents consume).

It lives in integrations/pi/ as a pi.extensions package; the top-level integrations/ dir leaves room for opencode/, hermes/, and the like. funes embeds it, so `funes install pi` extracts and registers it in one command, with flags mirroring `hf skills add` (project by default, -g, --dest, --force). The install probes `pi --version` and warns when it predates the tested 0.73.0 (the extension API floor).

Also documents the pi/hermes/opencode recall study on GLM-4.5-Air: funes is reached when it's a first-class tool and no native session tool competes.