### PR TITLE
fix(pi): bridge robustness and stale-install fixes (#34 follow-up)

### DIFF
--- a/integrations/pi/README.md
+++ b/integrations/pi/README.md
@@ -20,8 +20,9 @@ funes install pi -g     # all projects (user-wide)
 ```
 
 funes embeds the extension in its binary, so this always matches the installed
-funes version — no separate package to fetch. (`--dest` extracts elsewhere;
-`--force` refreshes after a funes upgrade.)
+funes version — no separate package to fetch, and a re-run after an upgrade
+re-extracts the refreshed copy automatically. (`--dest` extracts elsewhere;
+`--force` rewrites even when the on-disk copy is already current.)
 
 For development from a funes checkout you can also install the package directly
 with `pi install ./integrations/pi`, drop it under `<cwd>/.pi/extensions/` for

--- a/integrations/pi/index.ts
+++ b/integrations/pi/index.ts
@@ -52,15 +52,27 @@ class FunesMcp {
     child.on("exit", (code) => die(new Error(`funes mcp exited (code ${code})`)));
     child.on("error", (e) => die(new Error(`funes mcp failed to start: ${e.message}`)));
 
-    this.ready = (async () => {
-      await this.request("initialize", {
-        protocolVersion: PROTOCOL_VERSION,
-        capabilities: {},
-        clientInfo: { name: "pi-funes-bridge", version: "0.1.0" },
-      });
-      this.send({ jsonrpc: "2.0", method: "notifications/initialized", params: {} });
+    const start = (async () => {
+      try {
+        await this.request("initialize", {
+          protocolVersion: PROTOCOL_VERSION,
+          capabilities: {},
+          clientInfo: { name: "pi-funes-bridge", version: "0.1.0" },
+        });
+        this.send({ jsonrpc: "2.0", method: "notifications/initialized", params: {} });
+      } catch (err: any) {
+        // Initialize failed while the child may still be alive (e.g. it timed out): tear it
+        // down so the next call respawns instead of re-awaiting this rejected promise forever.
+        if (this.ready === start) {
+          this.child?.kill();
+          this.child = undefined;
+          this.ready = undefined;
+        }
+        throw err;
+      }
     })();
-    return this.ready;
+    this.ready = start;
+    return start;
   }
 
   private onData(chunk: string) {
@@ -98,7 +110,13 @@ class FunesMcp {
         reject(new Error(`funes ${method} timed out`));
       }, CALL_TIMEOUT_MS);
       this.pending.set(id, { resolve, reject, timer });
-      this.send({ jsonrpc: "2.0", id, method, params });
+      try {
+        this.send({ jsonrpc: "2.0", id, method, params });
+      } catch (err: any) {
+        clearTimeout(timer);
+        this.pending.delete(id);
+        reject(err);
+      }
     });
   }
 
@@ -139,7 +157,7 @@ export default function (pi: any) {
       k: Type.Optional(Type.Number({ description: "Number of results (default 8)" })),
     }),
     execute: (_id: string, params: { query: string; k?: number }) =>
-      call("recall", params.k ? { query: params.query, k: params.k } : { query: params.query }),
+      call("recall", { query: params.query, k: params.k }),
   });
 
   pi.registerTool({
@@ -154,6 +172,6 @@ export default function (pi: any) {
       window: Type.Optional(Type.Number({ description: "Turns within this window are included (default 3)" })),
     }),
     execute: (_id: string, params: { session_id: string; turn_uuid: string; window?: number }) =>
-      call("get", params.window ? params : { session_id: params.session_id, turn_uuid: params.turn_uuid }),
+      call("get", { session_id: params.session_id, turn_uuid: params.turn_uuid, window: params.window }),
   });
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,7 +119,7 @@ enum InstallAgent {
         /// Extract the extension here instead of under funes's home.
         #[arg(long, value_name = "PATH")]
         dest: Option<PathBuf>,
-        /// Re-extract the bundled extension even if it already exists at the destination.
+        /// Rewrite the bundled extension even when the on-disk copy already matches (a stale copy is refreshed automatically).
         #[arg(long)]
         force: bool,
     },

--- a/src/pi.rs
+++ b/src/pi.rs
@@ -129,13 +129,11 @@ mod tests {
 
     #[test]
     fn file_matches_detects_drift() {
-        let dir = std::env::temp_dir().join(format!("funes-pi-test-{}", std::process::id()));
-        std::fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("index.ts");
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("index.ts");
         std::fs::write(&path, "embedded").unwrap();
         assert!(file_matches(&path, "embedded")); // unchanged → skip rewrite
         assert!(!file_matches(&path, "embedded v2")); // drifted after upgrade → rewrite
-        assert!(!file_matches(&dir.join("missing.ts"), "embedded")); // absent → extract
-        std::fs::remove_dir_all(&dir).ok();
+        assert!(!file_matches(&dir.path().join("missing.ts"), "embedded")); // absent → extract
     }
 }

--- a/src/pi.rs
+++ b/src/pi.rs
@@ -8,7 +8,7 @@
 
 use crate::dataset;
 use anyhow::{Context, Result};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 const INDEX_TS: &str = include_str!("../integrations/pi/index.ts");
@@ -20,16 +20,18 @@ const MIN_PI: (u32, u32, u32) = (0, 73, 0);
 
 /// Extract the embedded pi extension and register it with pi. Defaults to the
 /// current project; `global` installs it user-wide. `dest` overrides where the
-/// extension is extracted (default: funes's home); `force` re-extracts even when
-/// it's already there.
+/// extension is extracted (default: funes's home). A copy that differs from this
+/// binary's embedded extension (e.g. after an upgrade) is refreshed automatically;
+/// `force` rewrites even when it already matches.
 pub fn install(global: bool, dest: Option<PathBuf>, force: bool) -> Result<()> {
     let dir = dest.unwrap_or_else(|| dataset::funes_dir().join("integrations").join("pi"));
-    let present = dir.join("index.ts").exists() && dir.join("package.json").exists();
-    if present && !force {
-        println!(
-            "funes pi extension already at {} (use --force to refresh)",
-            dir.display()
-        );
+    // Compare embedded bytes against the on-disk copy (not just existence) so an upgraded
+    // binary refreshes a stale extension; `force` rewrites even when they already match.
+    let current = !force
+        && file_matches(&dir.join("index.ts"), INDEX_TS)
+        && file_matches(&dir.join("package.json"), PACKAGE_JSON);
+    if current {
+        println!("funes pi extension already current at {}", dir.display());
     } else {
         std::fs::create_dir_all(&dir).with_context(|| format!("creating {}", dir.display()))?;
         std::fs::write(dir.join("index.ts"), INDEX_TS).context("writing index.ts")?;
@@ -85,6 +87,11 @@ pub fn install(global: bool, dest: Option<PathBuf>, force: bool) -> Result<()> {
     }
 }
 
+/// True if `path` exists and already holds exactly `want`, so re-extraction can be skipped.
+fn file_matches(path: &Path, want: &str) -> bool {
+    std::fs::read_to_string(path).map(|got| got == want).unwrap_or(false)
+}
+
 /// Parse a leading `MAJOR.MINOR.PATCH` from pi's `--version` output (tolerates a `v`
 /// prefix, extra tokens, and a pre-release/build suffix on the patch).
 fn parse_semver(s: &str) -> Option<(u32, u32, u32)> {
@@ -102,7 +109,7 @@ fn parse_semver(s: &str) -> Option<(u32, u32, u32)> {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_semver, MIN_PI};
+    use super::{file_matches, parse_semver, MIN_PI};
 
     #[test]
     fn parses_versions_and_compares_to_min() {
@@ -118,5 +125,17 @@ mod tests {
         assert!(parse_semver("0.72.9").unwrap() < MIN_PI);
         assert!(parse_semver("0.73.0").unwrap() >= MIN_PI);
         assert!(parse_semver("1.0.0").unwrap() >= MIN_PI);
+    }
+
+    #[test]
+    fn file_matches_detects_drift() {
+        let dir = std::env::temp_dir().join(format!("funes-pi-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("index.ts");
+        std::fs::write(&path, "embedded").unwrap();
+        assert!(file_matches(&path, "embedded")); // unchanged → skip rewrite
+        assert!(!file_matches(&path, "embedded v2")); // drifted after upgrade → rewrite
+        assert!(!file_matches(&dir.join("missing.ts"), "embedded")); // absent → extract
+        std::fs::remove_dir_all(&dir).ok();
     }
 }


### PR DESCRIPTION
Follow-up fixes for the pi recall extension and `funes install pi` (#34), addressing four issues found while reviewing that PR.

## Fixes

**1. Bridge wedged for the whole session if `initialize` fails** (`integrations/pi/index.ts`)
`ensureStarted` cached the init promise even when it rejected (e.g. the `initialize` request times out while the child stays alive). The guard then re-handed that rejected promise to every later call, so `recall`/`get` stayed dead for the rest of the pi session with no retry. A failed init now tears the child down so the next call respawns.

**2. `funes install pi` shipped a stale bridge after an upgrade** (`src/pi.rs`)
Re-extraction was gated on file *existence*, not content. After upgrading the funes binary (whose embedded extension changed), re-running `funes install pi` reported "already installed" and kept the old on-disk extension — contradicting the README's "always matches the installed funes version". It now compares the embedded bytes against the on-disk copy and rewrites on mismatch; `--force` means "rewrite even when already current".

**3. `window: 0` / `k: 0` were silently dropped** (`integrations/pi/index.ts`)
The args were forwarded under a truthiness check, so a `0` was omitted and `funes mcp` substituted its default (`window`→3, `k`→8). A `get` for just the target turn (`window: 0`) was silently widened to ±3. The values are now forwarded directly — `JSON.stringify` still omits `undefined`, so the conditional was also redundant.

**4. Leaked 120s timer if the stdin write throws** (`integrations/pi/index.ts`)
If the child died just before a `request`, `send` threw after the timeout and pending entry were registered, leaking both until the timer self-fired. The write is now wrapped so a throw clears the timer and pending entry.

## Testing
- `cargo build`, `cargo test --lib pi::` (incl. a new `file_matches` test), `cargo fmt --check`, `cargo clippy` — all clean.
- `index.ts` type-stripped and syntax-checked; verified the new payloads forward `0` and still drop `undefined`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
