### PR TITLE
fix(pi): unref the funes mcp child so the agent turn can exit

### DIFF
--- a/integrations/pi/index.ts
+++ b/integrations/pi/index.ts
@@ -37,6 +37,14 @@ class FunesMcp {
     if (this.child && this.ready) return this.ready;
     const child = spawn(FUNES_BIN, ["mcp"], { stdio: ["pipe", "pipe", "pipe"] });
     this.child = child;
+    // The server is kept warm for the whole session, so unref it (and its pipes)
+    // — an in-flight call's timer keeps the loop alive, but once the agent's turn
+    // is done nothing should. Without this the idle child pins the host's event
+    // loop open and the turn never exits.
+    child.unref();
+    child.stdin.unref();
+    child.stdout.unref();
+    child.stderr.unref();
     child.stdout.setEncoding("utf8");
     child.stdout.on("data", (chunk: string) => this.onData(chunk));
     child.stderr.resume(); // drain logs so the pipe never blocks


### PR DESCRIPTION
## Problem

The pi bridge extension (`integrations/pi/index.ts`) keeps one `funes mcp`
child warm for the whole session but never `unref`'d it. The idle child pins
the host (node) event loop open, so after the agent produces its final answer
the turn **hangs** until an external timeout kills it.

Observed while wiring funes into the agentcap funes-recall example: ~11 min
wall-clock for a turn that did ~90s of real work; killing the lingering
`funes mcp` child finalized the run instantly (`rc=0`).

## Fix

`unref()` the child and its stdio pipes. An in-flight call's timeout keeps the
loop alive, so nothing changes during a call; once the turn is done the loop
drains and the process exits, tearing the child down with it.

## Test

Verified end-to-end via agentcap (`--agent pi`, GLM-4.5-Air): with the fix the
`recall → get → answer` turn self-terminates in ~90s instead of hanging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)