### PR TITLE
docs(recall): surface the investigation/subject-matter mode in recall instructions

### DIFF
--- a/integrations/pi/index.ts
+++ b/integrations/pi/index.ts
@@ -155,11 +155,14 @@ export default function (pi: any) {
     name: "recall",
     label: "Recall",
     description:
-      "Recall decisions, rationale, and context from the user's past AI-assistant sessions. " +
-      "Returns ranked passages with provenance (timestamp, session, block type); each hit " +
-      "carries a `→ get <session_id> <turn_uuid>` line you can pass to `get` to read the full " +
-      "surrounding turns. Use it when a question concerns something decided or discussed in an " +
-      "earlier session rather than the current files, or before asserting the history of anything.",
+      "Recall decisions, rationale, context, and subject-matter findings from the user's past " +
+      "AI-assistant sessions. Returns ranked passages with provenance (timestamp, session, block " +
+      "type); each hit carries a `→ get <session_id> <turn_uuid>` line you can pass to `get` to " +
+      "read the full surrounding turns. Use it when a question concerns something decided or " +
+      "discussed in an earlier session rather than the current files, or before asserting the " +
+      "history of anything. Recall subject-matter too, not only decisions: before re-deriving how " +
+      "an API or system behaves — or anything a past session (often a research subagent) " +
+      "investigated — query the topic itself; recall surfaces those findings.",
     parameters: Type.Object({
       query: Type.String({ description: "Natural-language search query" }),
       k: Type.Optional(Type.Number({ description: "Number of results (default 8)" })),

--- a/skills/funes/SKILL.md
+++ b/skills/funes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: funes
-description: Recall decisions, rationale, and context from the user's past Claude Code sessions. Use when the user refers to earlier work ("what did we decide", "why did we", "last time", "we discussed"), when you lack context the user assumes you already have, or before re-deriving something that may already have been figured out in a prior session. Also recall before asserting the history of anything — that it was never built, was dropped, is out of scope, or was never discussed; a confident claim about a past decision is the cue you're missing the context recall holds.
+description: Recall decisions, rationale, context, and subject-matter findings from the user's past Claude Code sessions. Use when the user refers to earlier work ("what did we decide", "why did we", "last time", "we discussed"), when you lack context the user assumes you already have, or before re-deriving a technical fact or re-investigating a subject (how an API/library/system behaves) that a prior session — often a research subagent — may already have figured out; query the subject, not just "what did we decide". Also recall before asserting the history of anything — that it was never built, was dropped, is out of scope, or was never discussed; a confident claim about a past decision is the cue you're missing the context recall holds.
 ---
 
 # funes — recall past sessions
@@ -11,6 +11,10 @@ description: Recall decisions, rationale, and context from the user's past Claud
 ## When to use
 - The user references prior decisions, discussions, or work not in the current context.
 - You are about to re-investigate or re-decide something that may already be settled.
+- **You're about to investigate a technical subject** — how a library/API/codebase behaves, what
+  some internals do — that a prior session may already have nailed. Research subagents accumulate
+  exactly this, and recall surfaces it (often as the top hit). Query the *subject* ("how does X's
+  read path work"), not just "what did we decide" — this is the easy mode to forget.
 - You need the user's previously stated preferences or the rationale behind a past choice.
 - You're about to claim something about the *past*: "this was never built", "we didn't do
   X", "that's out of scope", "I don't think we discussed Y". That phrasing is the trigger —
@@ -40,9 +44,10 @@ The full surface:
 Results are ~400-char previews. If a hit is fuzzy or dated, don't settle for it. Either
 re-query with a sharper phrase, or use the hit's `→ get <session_id> <turn_uuid>` line to
 pull the full surrounding turns (`funes get …`, or the `get` tool) — that's the second half
-of the drill-down, not optional. Treat tool-result hits (file reads, command output) as
-possibly **stale** — re-verify against the live source rather than trusting the recalled
-copy, even if recent.
+of the drill-down, not optional. A recalled finding still beats re-deriving from scratch — it
+hands you the answer *and* where to look — but treat tool-result hits (file reads, command
+output) as possibly **stale**: confirm the specific fact against the live source rather than
+trusting the recalled copy, even if recent.
 
 ## Freshness
 The index updates only when `funes index` runs; the latest turns of the current session may

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -48,7 +48,7 @@ impl Funes {
     }
 
     #[tool(
-        description = "Recall decisions, rationale, and context from the user's past AI agent sessions. Returns ranked passages with provenance (timestamp, session, block type) plus surrounding neighbor chunks. Each hit carries a `→ get <session_id> <turn_uuid>` line — call `get` with those to read the full surrounding turns. Use when the user references earlier work, or when you lack context that may exist in a prior session. Also recall before asserting the history of anything — that it was never built, was dropped, is out of scope, or was never discussed; a confident claim about a past decision is the cue you're missing context this holds."
+        description = "Recall decisions, rationale, and context from the user's past AI agent sessions. Returns ranked passages with provenance (timestamp, session, block type) plus surrounding neighbor chunks. Each hit carries a `→ get <session_id> <turn_uuid>` line — call `get` with those to read the full surrounding turns. Use when the user references earlier work, or when you lack context that may exist in a prior session. Recall subject-matter, not only decisions: before re-deriving how an API, library, or system behaves — or anything a past session already investigated — query the topic itself; research subagents accumulate exactly these findings and recall surfaces them, often as the top hit, so check before re-investigating from scratch. Also recall before asserting the history of anything — that it was never built, was dropped, is out of scope, or was never discussed; a confident claim about a past decision is the cue you're missing context this holds."
     )]
     async fn recall(
         &self,
@@ -117,7 +117,10 @@ impl ServerHandler for Funes {
                  rerank + recency). Call `recall` with a natural-language query when you need prior \
                  decisions, rationale, or context — and before asserting the history of anything \
                  (that it was never built, was dropped, or is out of scope): a confident claim \
-                 about a past decision is the cue to recall first. Drill into a hit with `get`."
+                 about a past decision is the cue to recall first. Recall subject-matter too, not \
+                 only decisions: before re-deriving how an API, library, or system behaves — or \
+                 anything a prior session (often a research subagent) investigated — query the \
+                 topic itself; recall surfaces those findings. Drill into a hit with `get`."
                     .to_string(),
             )
     }


### PR DESCRIPTION
## What

Adds the **investigation / subject-matter** recall mode to every place that documents how to use recall:

- `recall` MCP tool description (`src/mcp.rs`)
- MCP server instructions (`src/mcp.rs`)
- the funes skill (`skills/funes/SKILL.md`) — description, a new *When to use* bullet, and a reframed tool-result staleness note (recall-then-verify, not don't-bother)
- the pi extension (`integrations/pi/index.ts`)

## Why

All four surfaces framed recall as **decision-history only** ("what did we decide", "why did we", "before asserting the history of anything"). None signalled the mode where recall pays off most: retrieving **subject-matter findings** — how an API/library/system behaves, a codebase's internals — that a prior session (often a research subagent) already nailed.

In practice those are the *top* hits on a subject query (observed 0.94+ for *"lance hf:// object store internals: read-only vs writable, the WrappingObjectStore seam…"*), yet the instructions point only at decision queries — so an agent stays in decision-history mode and re-derives facts recall would have handed it.

No logic changes; instruction/description text only. `cargo check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)