### PR TITLE
Speedup recall using Hugging Face local cache

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -28,10 +28,10 @@ timings.
 For each store the harness reports a single **cold** call followed by the min / median / max of
 `--iters` **warm** calls:
 
-- **remote cold** — the Xet chunk cache is empty (`--cold` gives it a fresh temp cache), so the
-  IVF_PQ/FTS index and the touched Lance fragments are downloaded over `hf://`.
-- **remote warm** — Xet-cached data, but `recall()` still re-opens the dataset each call (manifest +
-  index-descriptor round-trips), which dominates the warm remote cost.
+- **remote cold** — the hf-hub file cache is empty (`--cold` gives it a fresh temp cache), so the
+  IVF_PQ/FTS index and the touched Lance fragments are downloaded over `hf://` on first read.
+- **remote warm** — every file the query touches is now in the local hf-hub cache, so the reads are
+  served from disk and warm remote lands at ≈ local.
 - **local** — the same dataset on disk; there's no real cold/warm gap (the OS page cache is already
   warm and the models are loaded), so `local` is the floor the remote legs are measured against.
 
@@ -43,9 +43,9 @@ Build in release (a debug build is far slower and not representative):
 cargo run --release --example bench_recall -- "<query>" --remote dacorvo/funes-bench --iters 5 --cold
 ```
 
-The bench downloads `--remote` (via the `hf` CLI, using your logged-in token for a private repo) to
-a temp dir and benchmarks that local copy against the same dataset over `hf://` — both legs run
-identical data, so the gap is the I/O path, not the corpus.
+The bench downloads `--remote` (through the hf-hub crate, using the token from your environment for a
+private repo) to a temp dir and benchmarks that local copy against the same dataset over `hf://` —
+both legs run identical data, so the gap is the I/O path, not the corpus.
 
 ### Options
 
@@ -54,42 +54,49 @@ identical data, so the gap is the I/O path, not the corpus.
 | `<query>` (positional) | `"how does recall rerank candidates"` | the text to recall |
 | `--remote <spec>` | `dacorvo/funes-bench` | dataset to benchmark (`org/repo` or `hf://…`), used for both legs |
 | `--iters <N>` | `5` | warm iterations timed per store (after the one cold call) |
-| `--cold` | off | give the remote leg a throwaway `HF_XET_CACHE` temp dir so its cold call is a true download (your real cache is left untouched) |
+| `--cold` | off | give the remote leg a throwaway `HF_HUB_CACHE` temp dir so its cold call is a true download (your real cache is left untouched) |
 | `--k <N>` | `8` | results returned |
 | `--candidates <N>` | `30` | fused candidates reranked |
 | `--neighbors <N>` | `1` | adjacent chunks attached per hit |
 
-> `--cold` only relocates the Xet **cache** (via `HF_XET_CACHE`) to a temp dir for the run — it does
-> not touch your real `~/.cache/huggingface/xet`, your HF token, or `HF_HOME`. With `--cold` the
-> dataset is fetched twice: once by `hf download` for the local copy, once over Xet for the remote
+> `--cold` only relocates the hf-hub file **cache** (via `HF_HUB_CACHE`) to a temp dir for the run —
+> it does not touch your real `~/.cache/huggingface/hub`, your HF token, or `HF_HOME`. The local-leg
+> download writes straight to a temp dir (it bypasses the cache), so it never pre-warms the remote
 > cold call.
 
 ## Reading the output
 
 ```
-dataset: dacorvo/funes-bench   query: "ray traced multiplayer shooter with bots"   k=8 candidates=30 neighbors=1   warm iters=5
+dataset: dacorvo/funes-bench   query: "how does recall rerank candidates"   k=8 candidates=30 neighbors=1   warm iters=5
 
 store     cold(ms)   warm_lo  warm_med   warm_hi  hits
-local        896.9     796.1     814.6    4486.6     8
-remote      9804.5    8257.2    8796.7    8900.6     8
+local       5455.9    5682.6    5956.0    6093.4     8
+remote     10663.1    6504.0    6589.1    6668.6     8
 
-remote vs local:  10.9× slower cold,  10.8× slower warm (median),  10.4× warm best-case
+remote vs local:  2.0× slower cold,  1.1× slower warm (median),  1.1× warm best-case
 ```
 
-Both legs index the same ≈21.6k-chunk dataset (`hits` matches, confirming equal work). The headline
-line reports the slowdown over the local floor: remote **cold** (~10–14 s across runs, depending on
-download bandwidth) pays the full Xet download of the index + touched Lance fragments; even **warm** it's
-~10× local. `warm best-case` (`warm_lo`) is the most stable factor — the `warm_hi` spikes are
-page-cache/GC noise at low `--iters`. Most of the warm-remote cost is `recall()` re-opening the
-dataset on every call, which a long-lived process (the MCP server) that opens once would avoid.
+_Captured on a Mac M2 (24 GB), release build._
+
+Both legs run the same ≈21.6k-chunk dataset (`hits` matches, confirming equal work). Remote **cold**
+pays a one-time download of the index + touched Lance fragments into the hf-hub file cache (the
+premium over warm). Every **warm** call is then served from that local cache, so warm remote lands at
+**≈ local** (1.1×) — the per-call `hf://` I/O is gone. `warm best-case` (`warm_lo`) is the most stable
+factor; `warm_hi` spikes are page-cache/GC noise at low `--iters`.
+
+**Absolute numbers are host-dependent — read the ratio, not the floor.** Recall is dominated by the
+cross-encoder rerank (`--candidates` query/passage pairs), identical work on both legs: the Mac M2
+above reranks ~5–6 s for 30 candidates on CPU, whereas a Linux box with a GPU does it in well under a
+second (local ≈ remote-warm ≈ ~1.9 s). The floor moves with the hardware; the remote-vs-local
+**ratio** — warm ≈ local, cold a one-time download — is what the benchmark measures.
 
 ## Caveats
 
 - It times **one query string**, repeated. Rerank load is fixed (always `--candidates`), but embed
   and ANN/FTS selectivity vary by query — run a few representative queries (short/long, common/rare
   terms) for a sturdier picture.
-- Needs the `hf` CLI for the download (unless `--local` is given) and, for a private dataset, a
-  logged-in HF token.
+- For a private dataset, a token must be available (`HF_TOKEN` or the cached login) — the same one
+  recall uses.
 
 ## Building a benchmark store
 

--- a/benchmark/bench_recall.rs
+++ b/benchmark/bench_recall.rs
@@ -11,18 +11,18 @@
 //!     --remote dacorvo/funes-bench --iters 5 --cold
 //! ```
 //!
-//! `--cold` points the Xet cache (`HF_XET_CACHE`) at a throwaway temp dir so the remote cold call
-//! is a true download, leaving your real `~/.cache/huggingface/xet` untouched. (It does not, and
+//! `--cold` points the hf-hub file cache (`HF_HUB_CACHE`) at a throwaway temp dir so the remote cold
+//! call is a true download, leaving your real `~/.cache/huggingface/hub` untouched. (It does not, and
 //! cannot portably, drop the OS page cache, so the local cold figure is only as cold as the page
-//! cache happens to be.) Downloading the dataset needs the `hf` CLI and, for a private repo, a
-//! logged-in token (the same token recall uses).
+//! cache happens to be.) The dataset is fetched through the hf-hub crate — no external CLI — and a
+//! private repo authenticates with the token from the environment (the same one recall uses).
 
 use anyhow::{Context, Result};
 use clap::Parser;
 use funes::hub::Store;
 use funes::recall::recall;
+use hf_hub::HFClient;
 use std::path::Path;
-use std::process::Command;
 use std::time::Instant;
 use tempfile::TempDir;
 
@@ -38,8 +38,8 @@ struct Args {
     /// Warm iterations timed per store (after the one cold call).
     #[arg(long, default_value_t = 5)]
     iters: usize,
-    /// Give the remote leg a throwaway temp Xet cache so its cold call is a true download — your
-    /// real `~/.cache/huggingface/xet` is left untouched.
+    /// Give the remote leg a throwaway temp HF cache so its cold call is a true download — your real
+    /// `~/.cache/huggingface/hub` is left untouched.
     #[arg(long)]
     cold: bool,
     /// Results to return (recall `k`).
@@ -73,38 +73,40 @@ async fn time_recall(store: &Store, a: &Args) -> Result<(f64, usize)> {
     Ok((ms, hits))
 }
 
-/// Download the `--remote` dataset into `dest` (which then holds `chunks.lance`) so it can be opened
-/// as a local store. Shells out to the `hf` CLI; a private repo uses the logged-in token.
-///
-/// The download gets its OWN throwaway Xet cache: otherwise it would pre-warm the cache the remote
-/// leg reads (Xet reconstructs files through `HF_XET_CACHE`), and the remote "cold" call would hit
-/// chunks this very download just fetched — measuring a warm read, not a cold one.
-fn download_dataset(remote: &str, dest: &Path) -> Result<()> {
+/// Download the `--remote` dataset's files into `dest` via the hf-hub crate, so the same data can be
+/// opened as a local store for the local leg. `snapshot_download` with `local_dir` writes straight to
+/// `dest` and bypasses the hub cache, so it can't pre-warm the cache the remote leg reads — the
+/// remote "cold" call stays a true download. The client reads the token from the environment
+/// (`HF_TOKEN`, then the token file), the same source recall uses, so a private repo authenticates.
+async fn download_dataset(remote: &str, dest: &Path) -> Result<()> {
     let repo = remote.strip_prefix("hf://datasets/").unwrap_or(remote);
-    let dl_xet = tempfile::Builder::new().prefix("funes-bench-dl-xet-").tempdir()?;
-    eprintln!("downloading {repo} → {} (local leg)…", dest.display());
-    let ok = Command::new("hf")
-        .args(["download", repo, "--repo-type", "dataset", "--local-dir"])
-        .arg(dest)
-        .env("HF_XET_CACHE", dl_xet.path())
-        .status()
-        .context("run `hf download` (is the huggingface CLI installed?)")?
-        .success();
-    if !ok {
-        anyhow::bail!("`hf download {repo}` failed");
-    }
+    let mut seg = repo.split('/');
+    let (owner, name) = match (seg.next(), seg.next()) {
+        (Some(o), Some(n)) if !o.is_empty() && !n.is_empty() => (o, n),
+        _ => anyhow::bail!("--remote must be <owner>/<name>, got {remote}"),
+    };
+    eprintln!("downloading {owner}/{name} → {} (local leg)…", dest.display());
+    HFClient::builder()
+        .build()
+        .context("building hf-hub client")?
+        .dataset(owner, name)
+        .snapshot_download()
+        .local_dir(dest.to_path_buf())
+        .send()
+        .await
+        .with_context(|| format!("downloading {owner}/{name} via hf-hub"))?;
     Ok(())
 }
 
-/// Point the Xet chunk cache at a fresh temp dir so the first remote read is genuinely cold, without
-/// touching the user's real `~/.cache/huggingface/xet`. `HF_XET_CACHE` relocates only the chunk
-/// cache — the HF token and `HF_HOME` are untouched, so auth still works. The returned dir must stay
-/// alive for the run; dropping it removes the temp cache.
-fn isolate_xet_cache() -> Result<TempDir> {
-    let dir = tempfile::Builder::new().prefix("funes-bench-xet-").tempdir()?;
-    std::env::set_var("HF_XET_CACHE", dir.path());
+/// Point the hf-hub file cache at a fresh temp dir so the first remote read is a genuine download,
+/// without touching the user's real `~/.cache/huggingface/hub`. `HF_HUB_CACHE` relocates only the
+/// download cache — the token and `HF_HOME` are untouched, so auth still works. The returned dir must
+/// stay alive for the run; dropping it removes the temp cache.
+fn isolate_hub_cache() -> Result<TempDir> {
+    let dir = tempfile::Builder::new().prefix("funes-bench-hub-").tempdir()?;
+    std::env::set_var("HF_HUB_CACHE", dir.path());
     eprintln!(
-        "cold: isolated Xet cache at {} (real cache untouched)",
+        "cold: isolated HF cache at {} (real cache untouched)",
         dir.path().display()
     );
     Ok(dir)
@@ -146,15 +148,16 @@ async fn main() -> Result<()> {
     let a = Args::parse();
     let remote = Store::parse(a.remote.trim());
 
-    // With --cold, redirect the Xet cache to a temp dir for the whole run (held alive here) so the
-    // remote leg starts cold without disturbing the user's real cache. The local leg uses no Xet.
-    let _xet_guard = if a.cold { Some(isolate_xet_cache()?) } else { None };
+    // With --cold, redirect the hf-hub file cache to a temp dir for the whole run (held alive here)
+    // so the remote leg's first read is a genuine download. The local-leg download writes via
+    // `local_dir`, which bypasses this cache, so it can't pre-warm the remote leg.
+    let _hub_guard = if a.cold { Some(isolate_hub_cache()?) } else { None };
 
     // The local leg is a fresh download of the SAME dataset, so local vs remote isolates the hf://
     // I/O path rather than comparing two different stores. `local_dir` is held to the end of the run
     // so the downloaded copy isn't removed mid-benchmark.
     let local_dir = tempfile::Builder::new().prefix("funes-bench-local-").tempdir()?;
-    download_dataset(a.remote.trim(), local_dir.path())?;
+    download_dataset(a.remote.trim(), local_dir.path()).await?;
     let local = Store::Local {
         path: local_dir.path().to_path_buf(),
     };
@@ -186,12 +189,12 @@ async fn main() -> Result<()> {
     );
 
     if a.cold {
-        println!("\nnote: --cold gave the remote leg an empty (temp) Xet cache, so its cold call is a true");
-        println!("      download. The OS page cache isn't dropped, so the local cold figure is only as");
-        println!("      cold as the page cache already was.");
+        println!("\nnote: --cold gave the remote leg an empty (temp) hf-hub file cache, so its cold call");
+        println!("      is a true download. The OS page cache isn't dropped, so the local cold figure is");
+        println!("      only as cold as the page cache already was.");
     } else {
-        println!("\nnote: without --cold the remote leg used your existing Xet cache, so its 'cold' call may");
-        println!("      already be partly warm. Pass --cold for a true cold-download measurement.");
+        println!("\nnote: without --cold the remote leg used your existing hf-hub cache, so its 'cold' call");
+        println!("      may already be warm. Pass --cold for a true cold-download measurement.");
     }
     Ok(())
 }

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -4,6 +4,7 @@
 
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use arrow_array::RecordBatch;
@@ -16,6 +17,7 @@ use lance_index::scalar::InvertedIndexParams;
 use lance_index::vector::ivf::IvfBuildParams;
 use lance_index::vector::pq::PQBuildParams;
 use lance_index::IndexType;
+use lance_io::object_store::{ObjectStoreParams, WrappingObjectStore};
 use lance_linalg::distance::MetricType;
 
 /// The table (Lance dataset) name within a store.
@@ -36,18 +38,40 @@ pub fn local_store_dir() -> String {
     funes_dir().join("store").to_string_lossy().into_owned()
 }
 
-/// The `chunks` dataset URI under a store base (a local directory or an `hf://…` prefix).
+/// The `chunks` dataset URI under a store base (a local directory or a remote URI prefix).
 pub fn table_uri(base: &str) -> String {
     format!("{base}/{TABLE}.lance")
 }
 
-/// Open the `chunks` dataset at `uri`; `storage_options` carries the hf token/revision for a remote.
+/// Open the `chunks` dataset at `uri`; `storage_options` carries the backend credentials/revision a
+/// remote needs (empty for a local store).
 pub async fn open(uri: &str, storage_options: HashMap<String, String>) -> Result<Dataset> {
     DatasetBuilder::from_uri(uri)
         .with_storage_options(storage_options)
         .load()
         .await
         .context("opening the dataset")
+}
+
+/// Open the `chunks` dataset at `uri` with `wrapper` decorating its object store. It is installed
+/// before load, so it sees every read Lance issues, including those during load. `storage_options`
+/// carries the backend credentials/revision a remote needs; the caller supplies the wrapper.
+pub async fn open_wrapped(
+    uri: &str,
+    storage_options: HashMap<String, String>,
+    wrapper: Arc<dyn WrappingObjectStore>,
+) -> Result<Dataset> {
+    // Order matters: `with_store_params` replaces the params wholesale, so install the wrapper
+    // first, then layer the storage options on top (`with_storage_options` merges into them).
+    DatasetBuilder::from_uri(uri)
+        .with_store_params(ObjectStoreParams {
+            object_store_wrapper: Some(wrapper),
+            ..Default::default()
+        })
+        .with_storage_options(storage_options)
+        .load()
+        .await
+        .context("opening the wrapped dataset")
 }
 
 /// Project `columns` (empty = all columns; optionally filtered by a SQL predicate, optionally

--- a/src/fetch_store.rs
+++ b/src/fetch_store.rs
@@ -1,0 +1,296 @@
+//! A fetch-through read object-store decorator.
+//!
+//! [`FetchStore`] wraps an inner [`ObjectStore`](object_store::ObjectStore): it serves every `get*`
+//! from a whole local file supplied by a [`FileFetcher`] — fetched once, then sliced to the requested
+//! range — and delegates every other method (listing, writes) to the inner store. It is the read
+//! mirror of [`CaptureStore`](crate::capture_store::CaptureStore), the write decorator.
+//!
+//! It owns no cache. The [`FileFetcher`] decides where the file comes from and whether it persists: a
+//! fetcher backed by a disk cache turns this into a read-through cache; a fetcher that re-downloads
+//! every time does not. The decorator only fetches-and-slices — the concrete fetcher is the caller's
+//! to provide, so this module stays backend-agnostic.
+//!
+//! ```text
+//!   get → fetcher.fetch(path) → whole local file → serve the requested range
+//!   list / put / copy / delete → delegated to the inner store
+//! ```
+//!
+//! **A decorator, because Rust has no inheritance** — the inner store is held and every method
+//! forwarded by hand, intercepting only the reads.
+
+use std::ops::Range;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use futures::stream::{self, BoxStream, StreamExt};
+use object_store::path::Path as OPath;
+use object_store::{
+    Attributes, CopyOptions, GetOptions, GetRange, GetResult, GetResultPayload, ListResult, MultipartUpload,
+    ObjectMeta, ObjectStore as OSObjectStore, PutMultipartOptions, PutOptions, PutPayload, PutResult,
+    Result as OSResult,
+};
+
+/// Supplies a whole local file for an object key: given the object path, return a local filesystem
+/// path holding its bytes, fetching it on first touch. The seam that keeps [`FetchStore`]
+/// backend-agnostic and unit-testable — the caller provides the concrete fetcher.
+#[async_trait]
+pub(crate) trait FileFetcher: std::fmt::Debug + Send + Sync {
+    /// Resolve `filename` (the object's path) to a local path holding its bytes.
+    async fn fetch(&self, filename: &str) -> anyhow::Result<PathBuf>;
+}
+
+/// Reads are served from the whole file `fetcher` supplies for the key; every other method delegates
+/// to `inner` (also the live fallback when a fetch fails).
+#[derive(Debug)]
+pub(crate) struct FetchStore {
+    inner: Arc<dyn OSObjectStore>,
+    fetcher: Arc<dyn FileFetcher>,
+}
+
+impl FetchStore {
+    /// Decorate `inner`, serving reads from files `fetcher` resolves.
+    pub(crate) fn new(inner: Arc<dyn OSObjectStore>, fetcher: Arc<dyn FileFetcher>) -> Self {
+        Self { inner, fetcher }
+    }
+}
+
+impl std::fmt::Display for FetchStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "FetchStore({})", self.inner)
+    }
+}
+
+#[async_trait]
+impl OSObjectStore for FetchStore {
+    async fn get_opts(&self, location: &OPath, options: GetOptions) -> OSResult<GetResult> {
+        // Serve the read from the whole file the fetcher supplies for this key, sliced to the request.
+        // Any failure (fetch, or reading the file back) falls back to the inner store, so a transient
+        // miss never breaks a read.
+        match self.fetcher.fetch(location.as_ref()).await {
+            Ok(path) => match serve_from_file(&path, location, &options) {
+                Ok(result) => Ok(result),
+                Err(_) => self.inner.get_opts(location, options).await,
+            },
+            Err(_) => self.inner.get_opts(location, options).await,
+        }
+    }
+
+    async fn put_opts(&self, location: &OPath, payload: PutPayload, opts: PutOptions) -> OSResult<PutResult> {
+        self.inner.put_opts(location, payload, opts).await
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &OPath,
+        opts: PutMultipartOptions,
+    ) -> OSResult<Box<dyn MultipartUpload>> {
+        self.inner.put_multipart_opts(location, opts).await
+    }
+
+    fn list(&self, prefix: Option<&OPath>) -> BoxStream<'static, OSResult<ObjectMeta>> {
+        self.inner.list(prefix)
+    }
+
+    async fn list_with_delimiter(&self, prefix: Option<&OPath>) -> OSResult<ListResult> {
+        self.inner.list_with_delimiter(prefix).await
+    }
+
+    fn delete_stream(&self, locations: BoxStream<'static, OSResult<OPath>>) -> BoxStream<'static, OSResult<OPath>> {
+        self.inner.delete_stream(locations)
+    }
+
+    async fn copy_opts(&self, from: &OPath, to: &OPath, opts: CopyOptions) -> OSResult<()> {
+        self.inner.copy_opts(from, to, opts).await
+    }
+}
+
+/// Build a [`GetResult`] over the fetched file at `path` for the request `options`, reporting the
+/// object's `location` and whole-file size. A `head` returns metadata only; a body request hands the
+/// open file to `object_store`, which reads the resolved range off the executor (so a large file is
+/// never buffered here).
+fn serve_from_file(path: &Path, location: &OPath, options: &GetOptions) -> std::io::Result<GetResult> {
+    let total = std::fs::metadata(path)?.len();
+    let meta = meta(location.clone(), total);
+    if options.head {
+        return Ok(GetResult {
+            payload: GetResultPayload::Stream(stream::empty().boxed()),
+            meta,
+            range: 0..0,
+            attributes: Attributes::default(),
+        });
+    }
+    let range = resolve_range(&options.range, total);
+    let file = std::fs::File::open(path)?;
+    Ok(GetResult {
+        payload: GetResultPayload::File(file, path.to_path_buf()),
+        meta,
+        range,
+        attributes: Attributes::default(),
+    })
+}
+
+/// The concrete byte range a [`GetOptions`] selects within a `total`-byte file (clamped to the file).
+fn resolve_range(range: &Option<GetRange>, total: u64) -> Range<u64> {
+    match range {
+        None => 0..total,
+        Some(GetRange::Bounded(r)) => r.start..r.end.min(total),
+        Some(GetRange::Offset(o)) => (*o).min(total)..total,
+        Some(GetRange::Suffix(n)) => total.saturating_sub(*n)..total,
+    }
+}
+
+fn meta(location: OPath, size: u64) -> ObjectMeta {
+    ObjectMeta {
+        location,
+        last_modified: Utc::now(),
+        size,
+        e_tag: None,
+        version: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use bytes::Bytes;
+    use object_store::memory::InMemory;
+    use tempfile::TempDir;
+
+    /// A fake fetcher: writes each requested file to a temp dir from a fixed body and returns its
+    /// path, counting fetches so a test can assert how often the fetch path was taken. A filename not
+    /// in `bodies` yields an error, exercising the live-fallback path.
+    #[derive(Debug)]
+    struct FakeFetcher {
+        dir: TempDir,
+        bodies: std::collections::HashMap<String, Bytes>,
+        calls: AtomicUsize,
+    }
+
+    impl FakeFetcher {
+        fn new(files: &[(&str, &[u8])]) -> Self {
+            let bodies = files
+                .iter()
+                .map(|(name, body)| (name.to_string(), Bytes::copy_from_slice(body)))
+                .collect();
+            Self {
+                dir: tempfile::tempdir().unwrap(),
+                bodies,
+                calls: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl FileFetcher for FakeFetcher {
+        async fn fetch(&self, filename: &str) -> anyhow::Result<PathBuf> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            let body = self
+                .bodies
+                .get(filename)
+                .ok_or_else(|| anyhow::anyhow!("no such file: {filename}"))?;
+            let path = self.dir.path().join(filename.replace('/', "_"));
+            std::fs::write(&path, body)?;
+            Ok(path)
+        }
+    }
+
+    fn store_with(files: &[(&str, &[u8])]) -> (FetchStore, Arc<FakeFetcher>, Arc<InMemory>) {
+        let fetcher = Arc::new(FakeFetcher::new(files));
+        let inner = Arc::new(InMemory::new());
+        let store = FetchStore::new(inner.clone(), fetcher.clone());
+        (store, fetcher, inner)
+    }
+
+    /// A `get` serves the fetched file's bytes; the requested range is honored and `meta.size` is the
+    /// whole-file size (not the slice).
+    #[tokio::test]
+    async fn get_serves_fetched_file_and_reports_whole_size() {
+        let (store, fetcher, _inner) = store_with(&[("chunks.lance/data/0.lance", b"0123456789")]);
+        let loc = OPath::from("chunks.lance/data/0.lance");
+
+        let whole = store.get_opts(&loc, GetOptions::default()).await.unwrap();
+        assert_eq!(whole.meta.size, 10, "meta.size is the whole-file size");
+        assert_eq!(whole.range, 0..10);
+        assert_eq!(whole.bytes().await.unwrap(), Bytes::from_static(b"0123456789"));
+        assert_eq!(fetcher.calls.load(Ordering::SeqCst), 1, "one fetch per get");
+    }
+
+    /// Every `GetRange` variant resolves to the right slice, while `meta.size` stays the whole file.
+    #[tokio::test]
+    async fn range_variants_resolve_against_whole_file() {
+        let (store, _f, _inner) = store_with(&[("f", b"0123456789")]);
+        let loc = OPath::from("f");
+        let cases: &[(GetRange, &[u8])] = &[
+            (GetRange::Bounded(2..5), b"234"),
+            (GetRange::Offset(7), b"789"),
+            (GetRange::Suffix(3), b"789"),
+        ];
+        for (range, want) in cases {
+            let opts = GetOptions {
+                range: Some(range.clone()),
+                ..Default::default()
+            };
+            let got = store.get_opts(&loc, opts).await.unwrap();
+            assert_eq!(got.meta.size, 10, "{range:?}: whole-file size");
+            assert_eq!(got.bytes().await.unwrap(), Bytes::copy_from_slice(want), "{range:?}");
+        }
+    }
+
+    /// A `head` returns the whole-file size from the fetched file without reading a body.
+    #[tokio::test]
+    async fn head_returns_whole_size_no_body() {
+        let (store, _f, _inner) = store_with(&[("idx", b"abcdef")]);
+        let opts = GetOptions {
+            head: true,
+            ..Default::default()
+        };
+        let got = store.get_opts(&OPath::from("idx"), opts).await.unwrap();
+        assert_eq!(got.meta.size, 6);
+        assert!(got.bytes().await.unwrap().is_empty(), "head carries no body");
+    }
+
+    /// A failed fetch (unknown file) falls back to the inner store, which still serves the bytes — a
+    /// transient miss never breaks a read.
+    #[tokio::test]
+    async fn fetch_failure_falls_back_to_inner() {
+        let (store, fetcher, inner) = store_with(&[]);
+        let loc = OPath::from("data/live.lance");
+        inner
+            .put_opts(&loc, PutPayload::from("live"), PutOptions::default())
+            .await
+            .unwrap();
+        let got = store.get_opts(&loc, GetOptions::default()).await.unwrap();
+        assert_eq!(got.bytes().await.unwrap(), Bytes::from_static(b"live"));
+        assert_eq!(
+            fetcher.calls.load(Ordering::SeqCst),
+            1,
+            "fetch was attempted before falling back"
+        );
+    }
+
+    /// `list` is delegated to the inner store (version resolution must stay live) — the fetcher is
+    /// never consulted for a listing.
+    #[tokio::test]
+    async fn list_delegates_to_inner() {
+        let (store, fetcher, inner) = store_with(&[]);
+        inner
+            .put_opts(
+                &OPath::from("chunks.lance/_versions/1.manifest"),
+                PutPayload::from("m"),
+                PutOptions::default(),
+            )
+            .await
+            .unwrap();
+        let names: Vec<String> = store
+            .list(None)
+            .map(|r| r.unwrap().location.to_string())
+            .collect()
+            .await;
+        assert_eq!(names, vec!["chunks.lance/_versions/1.manifest".to_string()]);
+        assert_eq!(fetcher.calls.load(Ordering::SeqCst), 0, "listing never fetches");
+    }
+}

--- a/src/hf_dataset.rs
+++ b/src/hf_dataset.rs
@@ -37,11 +37,13 @@
 
 use std::collections::{BTreeMap, HashMap};
 use std::io::Write as _;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use arrow_array::{RecordBatch, RecordBatchIterator};
 use arrow_schema::SchemaRef;
+use async_trait::async_trait;
 use bytes::Bytes;
 use hf_hub::progress::{Progress, ProgressEvent, ProgressHandler, UploadEvent};
 use hf_hub::repository::{CommitInfo, CommitOperation};
@@ -54,6 +56,7 @@ use lance_io::object_store::WrappingObjectStore;
 use object_store::ObjectStore as OSObjectStore;
 
 use crate::capture_store::{CaptureStore, Captured};
+use crate::fetch_store::{FetchStore, FileFetcher};
 
 /// Outcome of an [`append`] commit.
 pub(crate) enum Appended {
@@ -310,6 +313,52 @@ struct CaptureWrapper {
 impl WrappingObjectStore for CaptureWrapper {
     fn wrap(&self, _prefix: &str, original: Arc<dyn OSObjectStore>) -> Arc<dyn OSObjectStore> {
         Arc::new(CaptureStore::new(original, self.captured.clone()))
+    }
+}
+
+/// Fetches a repo file whole at the pinned revision, returning its path in hf-hub's local cache.
+/// Pinning to a commit SHA (not a branch) is what makes a warm read zero-network — hf-hub serves the
+/// cached blob without a request — and fixes every read at one immutable revision.
+#[derive(Debug)]
+struct HubFetcher {
+    repo: Arc<HFRepository<RepoTypeDataset>>,
+    revision: String,
+}
+
+#[async_trait]
+impl FileFetcher for HubFetcher {
+    async fn fetch(&self, filename: &str) -> Result<PathBuf> {
+        self.repo
+            .download_file()
+            .filename(filename)
+            .revision(self.revision.clone())
+            .send()
+            .await
+            .with_context(|| format!("caching {filename}@{}", self.revision))
+    }
+}
+
+/// Installs a [`FetchStore`] backed by a [`HubFetcher`] in front of the store Lance built for a
+/// remote read. The read mirror of [`CaptureWrapper`]; built by the caller, where the repo handle
+/// and head SHA are known, because `wrap` is handed only the built store and an opendal-internal
+/// prefix.
+#[derive(Debug)]
+pub(crate) struct FetchWrapper {
+    fetcher: Arc<dyn FileFetcher>,
+}
+
+impl FetchWrapper {
+    /// A wrapper that serves reads from `repo` at the pinned `revision` (a commit SHA).
+    pub(crate) fn new(repo: Arc<HFRepository<RepoTypeDataset>>, revision: String) -> Self {
+        Self {
+            fetcher: Arc::new(HubFetcher { repo, revision }),
+        }
+    }
+}
+
+impl WrappingObjectStore for FetchWrapper {
+    fn wrap(&self, _prefix: &str, original: Arc<dyn OSObjectStore>) -> Arc<dyn OSObjectStore> {
+        Arc::new(FetchStore::new(original, self.fetcher.clone()))
     }
 }
 

--- a/src/hf_dataset.rs
+++ b/src/hf_dataset.rs
@@ -47,7 +47,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use hf_hub::progress::{Progress, ProgressEvent, ProgressHandler, UploadEvent};
 use hf_hub::repository::{CommitInfo, CommitOperation};
-use hf_hub::{HFError, HFRepository, RepoTypeDataset};
+use hf_hub::{HFClient, HFError, HFRepository, RepoTypeDataset};
 use lance::dataset::builder::DatasetBuilder;
 use lance::dataset::Dataset;
 use lance::index::DatasetIndexExt;
@@ -360,6 +360,26 @@ impl WrappingObjectStore for FetchWrapper {
     fn wrap(&self, _prefix: &str, original: Arc<dyn OSObjectStore>) -> Arc<dyn OSObjectStore> {
         Arc::new(FetchStore::new(original, self.fetcher.clone()))
     }
+}
+
+/// Resolve the head commit of `branch` for `owner/name` and build a [`FetchWrapper`] pinned to it,
+/// returning the wrapper and that SHA. The SHA is the read pin: the caller puts it in the dataset's
+/// `hf_revision` so Lance reads the exact commit the wrapper serves, and a commit SHA is what makes
+/// warm reads zero-network. A fresh repo handle is built from `token` and shared into the wrapper.
+pub(crate) async fn fetch_wrapper(
+    owner: &str,
+    name: &str,
+    token: Option<&str>,
+    branch: &str,
+) -> Result<(Arc<FetchWrapper>, String)> {
+    let mut builder = HFClient::builder();
+    if let Some(t) = token {
+        builder = builder.token(t.to_string());
+    }
+    let client = builder.build().context("building hf-hub client")?;
+    let repo = Arc::new(client.dataset(owner, name));
+    let sha = head_oid(&repo, branch).await?;
+    Ok((Arc::new(FetchWrapper::new(repo, sha.clone())), sha))
 }
 
 #[cfg(test)]

--- a/src/hub.rs
+++ b/src/hub.rs
@@ -1,10 +1,8 @@
 //! Remote, shared memory tiers.
 //!
-//! A [`Store`] is either the local index or a remote Lance dataset on the HF Hub. Remote
-//! reads go over `hf://` and are lazy by construction: the IVF_PQ index bounds which
-//! fragments a query touches, and lance's HF object store fetches only those byte ranges.
-//! Caching across CLI runs is handled by the **Xet chunk cache** (`~/.cache/huggingface/xet`,
-//! on by default), so funes adds no cache layer of its own.
+//! A [`Store`] is either the local index or a remote Lance dataset on the HF Hub. A remote open pins
+//! reads to the head commit and installs a read wrapper over Lance's object store; the pin is
+//! re-resolved on every open, so a new push is picked up by the next command.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -16,6 +14,7 @@ use lance::dataset::Dataset;
 
 use crate::config;
 use crate::dataset;
+use crate::hf_dataset;
 use crate::index::{DIM, MODEL};
 
 /// A store to recall from: a local Lance directory or a remote dataset on the HF Hub.
@@ -26,6 +25,10 @@ pub enum Store {
     /// A remote Lance dataset on the HF Hub, e.g. `hf://datasets/<org>/<repo>`.
     Remote { uri: String },
 }
+
+/// The branch reads pin to and resolve the head commit of. It must be the branch writes target, so a
+/// read sees the commits a push produced.
+const READ_BRANCH: &str = "main";
 
 impl Store {
     /// The default local store (`$FUNES_HOME` / `~/.funes` → `…/store`).
@@ -82,11 +85,23 @@ impl Store {
                 dataset::open(&dataset::table_uri(&path.to_string_lossy()), HashMap::new()).await?
             }
             Store::Remote { uri } => {
+                let (owner, name, _) = parse_hf(uri)?;
+                let token = hf_token();
                 let mut opts = HashMap::new();
-                if let Some(token) = hf_token() {
-                    opts.insert("hf_token".to_string(), token);
+                if let Some(t) = &token {
+                    opts.insert("hf_token".to_string(), t.clone());
                 }
-                dataset::open(&dataset::table_uri(uri), opts).await?
+                let table = dataset::table_uri(uri);
+                // Pin reads to the head commit and install the read wrapper. The pin is re-resolved
+                // on every open, so a new push is picked up by the next command. If the head can't
+                // be resolved (offline/transient), degrade to a plain live open rather than fail.
+                match hf_dataset::fetch_wrapper(&owner, &name, token.as_deref(), READ_BRANCH).await {
+                    Ok((wrapper, sha)) => {
+                        opts.insert("hf_revision".to_string(), sha);
+                        dataset::open_wrapped(&table, opts, wrapper).await?
+                    }
+                    Err(_) => dataset::open(&table, opts).await?,
+                }
             }
         };
         check_compat(&ds)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod chunk;
 pub mod claude_traces;
 pub mod config;
 pub mod dataset;
+pub mod fetch_store;
 pub mod hello;
 pub mod hermes;
 pub mod hf_dataset;

--- a/tests/remote_cache.rs
+++ b/tests/remote_cache.rs
@@ -66,7 +66,10 @@ async fn warm_recall_is_served_from_cache_without_downloading() {
     let cold = recall(MARKER).await;
     assert!(cold.contains(MARKER), "cold recall should surface the marker: {cold}");
     let after_cold = cache_footprint(cache.path());
-    assert!(after_cold.0 > 0, "cold recall must populate the cache, got {after_cold:?}");
+    assert!(
+        after_cold.0 > 0,
+        "cold recall must populate the cache, got {after_cold:?}"
+    );
 
     // Warm: same head commit ⇒ every file is already cached ⇒ nothing is downloaded.
     let warm = recall(MARKER).await;

--- a/tests/remote_cache.rs
+++ b/tests/remote_cache.rs
@@ -1,0 +1,79 @@
+//! Gated live test: the read-through cache behind remote reads. A first recall over `hf://`
+//! downloads the fixture's files (index + touched fragments) into an isolated HF cache; a second
+//! recall at the same head commit is served from that cache and downloads nothing. Skipped unless
+//! `HF_FUNES_TEST_TOKEN` is in the environment — to run it:
+//!
+//!   export HF_FUNES_TEST_TOKEN=<your HF token>   # or a CI secret
+//!   cargo test --test remote_cache -- --nocapture
+//!
+//! The fixture is a stable, synthetic, read-only dataset (no real data).
+
+use std::path::Path;
+
+use funes::hub::Store;
+
+const FIXTURE_URI: &str = "hf://datasets/optimum-internal-testing/funes-test/fixture/lancedb";
+const MARKER: &str = "UNIQUEMARKERXYZZY";
+
+/// (entry count, total bytes) under `dir`, recursively. A download grows both; a cache hit grows
+/// neither — so comparing this across two recalls detects whether the second one fetched anything.
+fn cache_footprint(dir: &Path) -> (usize, u64) {
+    let (mut entries, mut bytes) = (0usize, 0u64);
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(d) = stack.pop() {
+        let Ok(rd) = std::fs::read_dir(&d) else { continue };
+        for e in rd.flatten() {
+            match std::fs::symlink_metadata(e.path()) {
+                Ok(m) if m.is_dir() => stack.push(e.path()),
+                Ok(m) => {
+                    entries += 1;
+                    if m.is_file() {
+                        bytes += m.len();
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    (entries, bytes)
+}
+
+async fn recall(query: &str) -> String {
+    funes::recall::recall(Store::parse(FIXTURE_URI), query.to_string(), 5, 30, 0.0, 0, None, None)
+        .await
+        .expect("recall over remote fixture")
+}
+
+#[tokio::test]
+async fn warm_recall_is_served_from_cache_without_downloading() {
+    // In CI, an unset/fork secret expands to "" (env::var returns Ok("")), which must also skip.
+    let token = std::env::var("HF_FUNES_TEST_TOKEN").unwrap_or_default();
+    let token = token.trim();
+    if token.is_empty() {
+        eprintln!("skip: HF_FUNES_TEST_TOKEN not set");
+        return;
+    }
+    // funes' Store::open authenticates via HF_TOKEN.
+    std::env::set_var("HF_TOKEN", token);
+
+    // Isolate the hf-hub cache to a fresh dir, so "cold" is a genuine first download and "warm"
+    // can't be served by an entry left over from another run.
+    let cache = tempfile::tempdir().unwrap();
+    std::env::set_var("HF_HUB_CACHE", cache.path());
+    assert_eq!(cache_footprint(cache.path()), (0, 0), "cache must start empty");
+
+    // Cold: the read wrapper downloads the fixture's index + touched fragments into the cache.
+    let cold = recall(MARKER).await;
+    assert!(cold.contains(MARKER), "cold recall should surface the marker: {cold}");
+    let after_cold = cache_footprint(cache.path());
+    assert!(after_cold.0 > 0, "cold recall must populate the cache, got {after_cold:?}");
+
+    // Warm: same head commit ⇒ every file is already cached ⇒ nothing is downloaded.
+    let warm = recall(MARKER).await;
+    assert!(warm.contains(MARKER), "warm recall should surface the marker: {warm}");
+    let after_warm = cache_footprint(cache.path());
+    assert_eq!(
+        after_warm, after_cold,
+        "warm recall must download nothing — cache changed: cold={after_cold:?} warm={after_warm:?}"
+    );
+}


### PR DESCRIPTION
The default lance `opendal[huggingface]` backend used for `recall` does not perform any caching.

We wrap the `lance` object store used when reading to replace `opendal` download calls by `hf-hub` download calls that benefit from the local cache.

Details:
- Reads are pinned to the resolved head commit, so every file is immutable and whole-file caching is always safe (no path allowlist). Freshness comes from each command re-opening and re-resolving the head; if it can't be resolved (offline/transient) the open degrades to a live, uncached read.
- `FetchStore` is a generic `ObjectStore` decorator (the read mirror of `CaptureStore`); the HF-specific `HubFetcher`/`FetchWrapper` live in `hf_dataset`, so the generic layer stays backend-agnostic.
- Effect: warm remote recall ≈ local (the per-call `hf://` round-trips are gone); the first touch still pays a one-time download. Guarded by a gated live test (`tests/remote_cache.rs`).
- Also fixes `bench_recall --cold` to isolate the hf-hub file cache (it was isolating the Xet cache, which this path no longer uses) and drops its `hf`-CLI dependency in favour of the `hf-hub` crate.
