### PR TITLE
Add a push store gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,11 @@ changing your default, pass `--remote`:
 funes recall "..." --remote other-org/subject-kb
 ```
 
-`push` publishes your local index's new chunks to the active remote; `index` only ever writes
-locally, so uploading is always an explicit step. You never need the Hub to use funes locally —
-it's a tier you opt into.
+`push` publishes your local index's new chunks to the active remote — or to a store you name
+(`funes push other-org/kb`); `index` only ever writes locally, so uploading is always an explicit
+step. If the target shares no chunks with your local index — a first push, a new machine, or the
+wrong store — `push` asks to confirm before uploading anything (`--yes` skips it; off a terminal it
+refuses rather than guess). You never need the Hub to use funes locally — it's a tier you opt into.
 
 ## Building from source
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,9 +89,7 @@ enum Cmd {
         store: String,
     },
     /// Publish the local index's new chunks to a remote store on the HF Hub — the active remote by
-    /// default, or `[store]` to publish elsewhere. `index` only writes locally, so this is the one
-    /// step that uploads. A publish to a store your index shares no chunks with (a first push, a new
-    /// host, or the wrong store) asks for confirmation first; `--yes` skips it.
+    /// default, or `[store]` to publish elsewhere.
     Push {
         /// Store to publish to: `<org>/<repo>` or a full `hf://…` URI. Defaults to the active remote.
         store: Option<String>,
@@ -214,7 +212,7 @@ async fn main() -> Result<()> {
             yes,
             force_reindex,
         } => {
-            let target = match store {
+            let remote = match store {
                 Some(s) => s,
                 None => config::load().remote.ok_or_else(|| {
                     anyhow!("no active remote — attach one with `funes use <org>/<repo>`, or name a store: `funes push <org>/<repo>`")
@@ -225,7 +223,7 @@ async fn main() -> Result<()> {
             } else {
                 push::Confirm::Ask(prompt_new_store)
             };
-            match push::run_push(hub::Store::parse(&target), force_reindex, confirm).await {
+            match push::run_push(hub::Store::parse(&remote), force_reindex, confirm).await {
                 Ok(pushed) => {
                     print!("{}", pushed.report);
                     // Secrets held back everything — surface a non-zero exit so automation can react.
@@ -235,7 +233,7 @@ async fn main() -> Result<()> {
                     Ok(())
                 }
                 Err(e) if push::is_read_only(&e) => Err(anyhow!(
-                    "{target} is read-only for your token — recall can read it, but publishing needs write access (check your HF token)"
+                    "{remote} is read-only for your token — recall can read it, but publishing needs write access (check your HF token)"
                 )),
                 Err(e) => Err(e),
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use funes::{config, hermes, hub, index, mcp, opencode, pi, push, recall, scrub};
 
 use anyhow::{anyhow, Result};
 use clap::{Args, Parser, Subcommand};
+use std::io::{IsTerminal, Write};
 use std::path::PathBuf;
 
 #[derive(Parser)]
@@ -87,9 +88,16 @@ enum Cmd {
         /// URI. Pass `local` to detach and go back to the local index.
         store: String,
     },
-    /// Publish the local index's new chunks to the active remote. `index` only writes locally, so
-    /// this is the one step that uploads.
+    /// Publish the local index's new chunks to a remote store on the HF Hub — the active remote by
+    /// default, or `[store]` to publish elsewhere. `index` only writes locally, so this is the one
+    /// step that uploads. A publish to a store your index shares no chunks with (a first push, a new
+    /// host, or the wrong store) asks for confirmation first; `--yes` skips it.
     Push {
+        /// Store to publish to: `<org>/<repo>` or a full `hf://…` URI. Defaults to the active remote.
+        store: Option<String>,
+        /// Skip the confirmation when the target shares no chunks with your local index.
+        #[arg(short, long)]
+        yes: bool,
         /// Refresh the remote index after pushing (retrying on conflict) even if the unindexed
         /// backlog is below the auto-reindex threshold. With nothing new to push, reindex only.
         #[arg(long)]
@@ -201,11 +209,23 @@ async fn main() -> Result<()> {
             Ok(())
         }
         Cmd::Use { store } => use_store(store).await,
-        Cmd::Push { force_reindex } => {
-            let remote = config::load()
-                .remote
-                .ok_or_else(|| anyhow!("no active remote — attach one with `funes use <org>/<repo>`"))?;
-            match push::run_push(hub::Store::parse(&remote), force_reindex).await {
+        Cmd::Push {
+            store,
+            yes,
+            force_reindex,
+        } => {
+            let target = match store {
+                Some(s) => s,
+                None => config::load().remote.ok_or_else(|| {
+                    anyhow!("no active remote — attach one with `funes use <org>/<repo>`, or name a store: `funes push <org>/<repo>`")
+                })?,
+            };
+            let confirm = if yes {
+                push::Confirm::Yes
+            } else {
+                push::Confirm::Ask(prompt_new_store)
+            };
+            match push::run_push(hub::Store::parse(&target), force_reindex, confirm).await {
                 Ok(pushed) => {
                     print!("{}", pushed.report);
                     // Secrets held back everything — surface a non-zero exit so automation can react.
@@ -215,7 +235,7 @@ async fn main() -> Result<()> {
                     Ok(())
                 }
                 Err(e) if push::is_read_only(&e) => Err(anyhow!(
-                    "{remote} is read-only for your token — recall can read it, but publishing needs write access (check your HF token)"
+                    "{target} is read-only for your token — recall can read it, but publishing needs write access (check your HF token)"
                 )),
                 Err(e) => Err(e),
             }
@@ -292,6 +312,29 @@ fn attach_hint(local: usize, remote: usize, unpushed: usize) -> String {
         // No shared chunks with a populated remote: a fresh host of yours, or a store you only read.
         format!("local index: {local} chunks, remote: {remote} — no shared chunks: a new host of yours, or a store you only read. `funes push` to contribute, skip if it's not yours.")
     }
+}
+
+/// The push confirmation for a store the local index shares no chunks with. Fails closed (returns
+/// false) off a terminal, so an unattended push can't silently publish to the wrong store — there it
+/// must be re-run with `--yes`.
+fn prompt_new_store(label: &str, chunks: usize) -> bool {
+    if !std::io::stdin().is_terminal() {
+        eprintln!(
+            "refusing to push {chunks} chunk(s) to {label}: your local index shares no chunks with it \
+             (a first push, a new host, or the wrong store) — re-run with `--yes` to confirm."
+        );
+        return false;
+    }
+    eprint!(
+        "{label}: your local index shares no chunks with it — a first push here, a new host of yours, \
+         or the wrong store. Publish {chunks} chunk(s) anyway? [y/N] "
+    );
+    let _ = std::io::stderr().flush();
+    let mut answer = String::new();
+    if std::io::stdin().read_line(&mut answer).is_err() {
+        return false;
+    }
+    matches!(answer.trim().to_ascii_lowercase().as_str(), "y" | "yes")
 }
 
 #[cfg(test)]

--- a/src/push.rs
+++ b/src/push.rs
@@ -172,6 +172,12 @@ pub async fn run_push(target: Store, force_reindex: bool, confirm: Confirm) -> R
         return Ok(format!("{}: already up to date ({} chunks)\n", target.label(), remote_ids.len()).into());
     }
 
+    // 2. HF repo handle (every write path below needs it). Resolve the target and token *before* the
+    // confirmation below, so a bad URI or a missing token fails now — not after the user has answered
+    // a "publish anyway?" for a push that could never have proceeded.
+    let (owner, name, prefix) = hub::parse_hf(&uri)?;
+    let token = hub::hf_token().context("no HF token (set HF_TOKEN) — required to push")?;
+
     // Guard against publishing to a store this index shares nothing with — a first push here, a new
     // host of yours, or the wrong store. The overlap is already in hand (see [`must_confirm`]), so
     // this costs no extra round-trip. Only the real-upload paths reach here; the nothing-to-push
@@ -180,9 +186,6 @@ pub async fn run_push(target: Store, force_reindex: bool, confirm: Confirm) -> R
         bail!("push aborted");
     }
 
-    // 2. HF repo handle (every write path below needs it).
-    let (owner, name, prefix) = hub::parse_hf(&uri)?;
-    let token = hub::hf_token().context("no HF token (set HF_TOKEN) — required to push")?;
     let client = HFClient::builder()
         .token(token.clone())
         .build()

--- a/src/push.rs
+++ b/src/push.rs
@@ -103,15 +103,11 @@ impl From<String> for Pushed {
     }
 }
 
-/// How a push handles a target the local index shares no chunks with — a first publish, a new host
-/// of yours, or (the case this guards) the wrong store. Consulted at most once, only when there are
-/// rows to publish and the overlap is empty, and always before anything is uploaded.
+/// How a push handles a target the local index shares no chunks with.
 pub enum Confirm {
     /// Proceed without asking (`--yes`, or a caller that has already established intent, e.g. tests).
     Yes,
-    /// Ask before publishing. Called with the target label and the number of chunks about to be
-    /// pushed; returns whether to proceed. The CLI wires this to a stdin y/N prompt that fails closed
-    /// off a terminal.
+    /// Ask before publishing. Called with the target label and the number of chunks to be pushed.
     Ask(fn(&str, usize) -> bool),
 }
 
@@ -125,10 +121,8 @@ impl Confirm {
     }
 }
 
-/// Whether a push must be confirmed first: there are rows to publish (`to_push > 0`) and the local
-/// index shares no chunk with the remote (`to_push == local` ⇔ `|local ∩ remote| = 0`) — a first
-/// publish, a new host of yours, or the wrong store. `to_push` is `local − remote`, so it can never
-/// exceed `local`; equality means every local chunk is new to the remote.
+/// Whether a push must be confirmed first: there are rows to publish and the local index shares
+/// no chunk with the remote — a first publish, a new host of yours, or the wrong store.
 fn must_confirm(local: usize, to_push: usize) -> bool {
     to_push > 0 && to_push == local
 }
@@ -172,16 +166,12 @@ pub async fn run_push(target: Store, force_reindex: bool, confirm: Confirm) -> R
         return Ok(format!("{}: already up to date ({} chunks)\n", target.label(), remote_ids.len()).into());
     }
 
-    // 2. HF repo handle (every write path below needs it). Resolve the target and token *before* the
-    // confirmation below, so a bad URI or a missing token fails now — not after the user has answered
-    // a "publish anyway?" for a push that could never have proceeded.
+    // 2. HF repo handle. Resolve the target and token before the confirmation, so a bad URI or a
+    // missing token fails before we prompt for one.
     let (owner, name, prefix) = hub::parse_hf(&uri)?;
     let token = hub::hf_token().context("no HF token (set HF_TOKEN) — required to push")?;
 
-    // Guard against publishing to a store this index shares nothing with — a first push here, a new
-    // host of yours, or the wrong store. The overlap is already in hand (see [`must_confirm`]), so
-    // this costs no extra round-trip. Only the real-upload paths reach here; the nothing-to-push
-    // paths returned above.
+    // When required, ask for confirmation before publishing.
     if must_confirm(local_ids.len(), to_push.len()) && !confirm.proceed(&target.label(), to_push.len()) {
         bail!("push aborted");
     }

--- a/src/push.rs
+++ b/src/push.rs
@@ -103,11 +103,41 @@ impl From<String> for Pushed {
     }
 }
 
+/// How a push handles a target the local index shares no chunks with — a first publish, a new host
+/// of yours, or (the case this guards) the wrong store. Consulted at most once, only when there are
+/// rows to publish and the overlap is empty, and always before anything is uploaded.
+pub enum Confirm {
+    /// Proceed without asking (`--yes`, or a caller that has already established intent, e.g. tests).
+    Yes,
+    /// Ask before publishing. Called with the target label and the number of chunks about to be
+    /// pushed; returns whether to proceed. The CLI wires this to a stdin y/N prompt that fails closed
+    /// off a terminal.
+    Ask(fn(&str, usize) -> bool),
+}
+
+impl Confirm {
+    /// Whether the push may proceed to a share-nothing target.
+    fn proceed(self, label: &str, chunks: usize) -> bool {
+        match self {
+            Confirm::Yes => true,
+            Confirm::Ask(ask) => ask(label, chunks),
+        }
+    }
+}
+
+/// Whether a push must be confirmed first: there are rows to publish (`to_push > 0`) and the local
+/// index shares no chunk with the remote (`to_push == local` ⇔ `|local ∩ remote| = 0`) — a first
+/// publish, a new host of yours, or the wrong store. `to_push` is `local − remote`, so it can never
+/// exceed `local`; equality means every local chunk is new to the remote.
+fn must_confirm(local: usize, to_push: usize) -> bool {
+    to_push > 0 && to_push == local
+}
+
 /// Publish the local store's new chunks to `target` (a remote store on the HF Hub). With
 /// `force_reindex`, refresh the remote index after the data commit (retrying until it lands) even
 /// if the unindexed backlog is below [`REINDEX_THRESHOLD`]; with no new chunks pending it's a pure
-/// index refresh.
-pub async fn run_push(target: Store, force_reindex: bool) -> Result<Pushed> {
+/// index refresh. `confirm` gates a publish to a store the local index shares no chunks with.
+pub async fn run_push(target: Store, force_reindex: bool, confirm: Confirm) -> Result<Pushed> {
     let uri = match &target {
         Store::Remote { uri } => uri.clone(),
         Store::Local { .. } => {
@@ -140,6 +170,14 @@ pub async fn run_push(target: Store, force_reindex: bool) -> Result<Pushed> {
     // remote, which is still work.
     if to_push.is_empty() && (first_publish || !force_reindex) {
         return Ok(format!("{}: already up to date ({} chunks)\n", target.label(), remote_ids.len()).into());
+    }
+
+    // Guard against publishing to a store this index shares nothing with — a first push here, a new
+    // host of yours, or the wrong store. The overlap is already in hand (see [`must_confirm`]), so
+    // this costs no extra round-trip. Only the real-upload paths reach here; the nothing-to-push
+    // paths returned above.
+    if must_confirm(local_ids.len(), to_push.len()) && !confirm.proceed(&target.label(), to_push.len()) {
+        bail!("push aborted");
     }
 
     // 2. HF repo handle (every write path below needs it).
@@ -394,6 +432,18 @@ async fn reindex_auto(
 mod tests {
     use super::*;
     use crate::index;
+
+    #[test]
+    fn must_confirm_only_when_overlap_is_empty_and_there_is_work() {
+        // First publish / fully disjoint (every local chunk is new to the remote) → confirm.
+        assert!(must_confirm(5, 5));
+        assert!(must_confirm(1, 1));
+        // Some overlap (fewer to push than the local total) → no prompt, it's a store you add to.
+        assert!(!must_confirm(5, 3));
+        // Nothing to push (up to date, or a reindex-only run) → never prompt, even with 0 overlap.
+        assert!(!must_confirm(5, 0));
+        assert!(!must_confirm(0, 0));
+    }
 
     #[test]
     fn is_read_only_matches_the_type_not_the_message() {

--- a/tests/push_round_trip.rs
+++ b/tests/push_round_trip.rs
@@ -80,7 +80,7 @@ async fn push_round_trip_create_append_recall() {
     // create (first publish) → grow → append (data-only, no reindex) → recall both. The appended
     // turn is left unindexed, so recalling it back exercises Lance's brute-force fallback. Then
     // force a reindex and recall it again, now served by the index.
-    let create = funes::push::run_push(Store::parse(&uri), false).await;
+    let create = funes::push::run_push(Store::parse(&uri), false, funes::push::Confirm::Yes).await;
     write_session(
         src.path(),
         &[
@@ -89,12 +89,12 @@ async fn push_round_trip_create_append_recall() {
         ],
     );
     funes::index::run_index(src.path(), false, None).await.unwrap();
-    let append = funes::push::run_push(Store::parse(&uri), false).await;
+    let append = funes::push::run_push(Store::parse(&uri), false, funes::push::Confirm::Yes).await;
     let recall_base = recall_remote(&uri, "SYNCSMOKE parsing").await;
     let recall_new = recall_remote(&uri, "SYNCSMOKE2 continuation").await;
     // Nothing new to push, so this is a pure forced reindex: fold the unindexed appended turn into
     // the index as its own commit (capture_reindex + a separate commit), then recall it again.
-    let reindex = funes::push::run_push(Store::parse(&uri), true).await;
+    let reindex = funes::push::run_push(Store::parse(&uri), true, funes::push::Confirm::Yes).await;
     let recall_reindexed = recall_remote(&uri, "SYNCSMOKE2 continuation").await;
     // The model id must travel with the store (stamped in the schema metadata, uploaded by push).
     let remote_model = match Store::parse(&uri).open().await {

--- a/tests/push_round_trip.rs
+++ b/tests/push_round_trip.rs
@@ -3,6 +3,10 @@
 //! (append → capture Lance's native append), recall both markers back from the remote, then delete the
 //! scratch path. No real data.
 //!
+//! Also covers the no-overlap confirmation gate against the live remote: declining a first publish
+//! (the local index shares nothing with the empty remote) must abort and upload nothing, while an
+//! append to a store that already shares chunks must not be prompted at all.
+//!
 //! Skipped unless `HF_FUNES_TEST_TOKEN` is set (it provides `HF_TOKEN` for `Store::open` / the
 //! hf-hub client) AND `trufflehog` is on PATH (push's pre-publish gate is fail-closed). Needs a
 //! bigger thread stack than the default — lance + fastembed recurse deeply — so set
@@ -13,9 +17,11 @@
 
 use std::io::Write;
 use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use funes::hub::Store;
+use funes::push::Confirm;
 use hf_hub::HFClient;
 
 const OWNER: &str = "optimum-internal-testing";
@@ -49,6 +55,25 @@ async fn recall_remote(uri: &str, query: &str) -> String {
         .unwrap_or_else(|e| format!("<recall error: {e}>"))
 }
 
+/// Push confirmations, recorded so the test can assert whether — and with what pending-chunk count —
+/// the no-overlap gate consulted the prompt. Safe as process globals: this binary runs one test.
+static PROMPTS: AtomicUsize = AtomicUsize::new(0);
+static LAST_CHUNKS: AtomicUsize = AtomicUsize::new(0);
+
+/// A confirmation that records the call and declines.
+fn decline(_label: &str, chunks: usize) -> bool {
+    PROMPTS.fetch_add(1, Ordering::SeqCst);
+    LAST_CHUNKS.store(chunks, Ordering::SeqCst);
+    false
+}
+
+/// A confirmation that records the call and accepts.
+fn accept(_label: &str, chunks: usize) -> bool {
+    PROMPTS.fetch_add(1, Ordering::SeqCst);
+    LAST_CHUNKS.store(chunks, Ordering::SeqCst);
+    true
+}
+
 #[tokio::test]
 async fn push_round_trip_create_append_recall() {
     let token = std::env::var("HF_FUNES_TEST_TOKEN")
@@ -77,10 +102,15 @@ async fn push_round_trip_create_append_recall() {
     write_session(src.path(), &[("s1", "SYNCSMOKE parsing transcripts into turns")]);
     funes::index::run_index(src.path(), false, None).await.unwrap();
 
-    // create (first publish) → grow → append (data-only, no reindex) → recall both. The appended
-    // turn is left unindexed, so recalling it back exercises Lance's brute-force fallback. Then
-    // force a reindex and recall it again, now served by the index.
-    let create = funes::push::run_push(Store::parse(&uri), false, funes::push::Confirm::Yes).await;
+    // Gate: the local index shares nothing with the (empty) remote, so a first publish is prompted.
+    // Declining must abort and upload nothing — the "don't publish to the wrong store" promise.
+    let declined = funes::push::run_push(Store::parse(&uri), false, Confirm::Ask(decline)).await;
+    let after_decline = funes::push::store_ids(&Store::parse(&uri)).await;
+
+    // create (first publish): accept the same gate → grow → append (data-only, no reindex) → recall
+    // both. The appended turn is left unindexed, so recalling it back exercises Lance's brute-force
+    // fallback. Then force a reindex and recall it again, now served by the index.
+    let create = funes::push::run_push(Store::parse(&uri), false, Confirm::Ask(accept)).await;
     write_session(
         src.path(),
         &[
@@ -89,12 +119,16 @@ async fn push_round_trip_create_append_recall() {
         ],
     );
     funes::index::run_index(src.path(), false, None).await.unwrap();
-    let append = funes::push::run_push(Store::parse(&uri), false, funes::push::Confirm::Yes).await;
+    // append: the grown local store now shares chunks with the remote, so the gate must NOT fire —
+    // pass a prompt that would decline and assert it is never consulted.
+    let prompts_before_append = PROMPTS.load(Ordering::SeqCst);
+    let append = funes::push::run_push(Store::parse(&uri), false, Confirm::Ask(decline)).await;
+    let prompts_after_append = PROMPTS.load(Ordering::SeqCst);
     let recall_base = recall_remote(&uri, "SYNCSMOKE parsing").await;
     let recall_new = recall_remote(&uri, "SYNCSMOKE2 continuation").await;
     // Nothing new to push, so this is a pure forced reindex: fold the unindexed appended turn into
     // the index as its own commit (capture_reindex + a separate commit), then recall it again.
-    let reindex = funes::push::run_push(Store::parse(&uri), true, funes::push::Confirm::Yes).await;
+    let reindex = funes::push::run_push(Store::parse(&uri), true, Confirm::Yes).await;
     let recall_reindexed = recall_remote(&uri, "SYNCSMOKE2 continuation").await;
     // The model id must travel with the store (stamped in the schema metadata, uploaded by push).
     let remote_model = match Store::parse(&uri).open().await {
@@ -111,6 +145,33 @@ async fn push_round_trip_create_append_recall() {
         .commit_message("cleanup funes push round-trip test")
         .send()
         .await;
+
+    // Gate: declining a first publish aborts and leaves the remote empty (nothing was uploaded).
+    let declined = match declined {
+        Ok(p) => panic!(
+            "declining the no-overlap gate must abort, but push reported: {}",
+            p.report
+        ),
+        Err(e) => e,
+    };
+    assert!(
+        declined.to_string().contains("aborted"),
+        "a declined push should report an abort, got: {declined}"
+    );
+    assert!(
+        after_decline.is_empty(),
+        "a declined push must upload nothing, but the remote holds {} chunk(s)",
+        after_decline.len()
+    );
+    assert!(
+        LAST_CHUNKS.load(Ordering::SeqCst) > 0,
+        "the confirmation should be told how many chunks are pending"
+    );
+    // Gate: a store that already shares chunks with the local index is not prompted.
+    assert_eq!(
+        prompts_after_append, prompts_before_append,
+        "an append to a store you already share chunks with must not trigger the confirmation"
+    );
 
     let create = create.expect("create push").report;
     assert!(create.contains("pushed"), "create should publish: {create}");

--- a/tests/push_round_trip.rs
+++ b/tests/push_round_trip.rs
@@ -89,6 +89,8 @@ async fn push_round_trip_create_append_recall() {
         return;
     }
     std::env::set_var("HF_TOKEN", &token);
+    let client = HFClient::builder().token(token).build().unwrap();
+    let repo = client.dataset(OWNER, NAME);
 
     // Unique scratch path so concurrent/repeated runs don't collide.
     let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
@@ -105,7 +107,15 @@ async fn push_round_trip_create_append_recall() {
     // Gate: the local index shares nothing with the (empty) remote, so a first publish is prompted.
     // Declining must abort and upload nothing — the "don't publish to the wrong store" promise.
     let declined = funes::push::run_push(Store::parse(&uri), false, Confirm::Ask(decline)).await;
-    let after_decline = funes::push::store_ids(&Store::parse(&uri)).await;
+    // Verify via a *successful* Hub query that the declined push published nothing: get_paths_info
+    // returns the entries present under the path (Ok([]) when absent) and Err on a transport failure,
+    // so an unreachable remote fails the test loudly instead of masquerading as "nothing uploaded".
+    let after_decline = repo
+        .get_paths_info()
+        .paths(vec![prefix.clone()])
+        .send()
+        .await
+        .expect("querying the remote for the declined scratch path");
 
     // create (first publish): accept the same gate → grow → append (data-only, no reindex) → recall
     // both. The appended turn is left unindexed, so recalling it back exercises Lance's brute-force
@@ -137,11 +147,9 @@ async fn push_round_trip_create_append_recall() {
     };
 
     // Cleanup before asserting, so a failed assertion can't leave the scratch path behind.
-    let client = HFClient::builder().token(token).build().unwrap();
-    let _ = client
-        .dataset(OWNER, NAME)
+    let _ = repo
         .delete_folder()
-        .path_in_repo(prefix)
+        .path_in_repo(prefix.clone())
         .commit_message("cleanup funes push round-trip test")
         .send()
         .await;
@@ -160,7 +168,7 @@ async fn push_round_trip_create_append_recall() {
     );
     assert!(
         after_decline.is_empty(),
-        "a declined push must upload nothing, but the remote holds {} chunk(s)",
+        "a declined push must upload nothing, but the remote holds {} entry(ies) under {prefix}",
         after_decline.len()
     );
     assert!(


### PR DESCRIPTION
This makes it harder to push to the wrong remote store.