### PR TITLE
Improve index developer experience

### DIFF
--- a/docs/automation.md
+++ b/docs/automation.md
@@ -22,8 +22,11 @@ with no manual step.
 funes index          # parse → chunk → embed ~/.claude/projects → ~/.funes
 ```
 
-If you only want local recall, you're done with setup — skip to
-[the hook](#claude-code). The hook will run `funes index` and nothing else.
+Run this once, interactively — **the hook won't build the first index for you.** An
+automated (non-terminal) `funes index` refuses to build a from-scratch index (it can take
+a long time) and refuses to run with no target; it only does incremental, per-harness
+updates once a local index exists. So this manual first index is required on each machine.
+If you only want local recall, you're done — skip to [the hook](#claude-code).
 
 ### 2. Attach a shared store (optional)
 
@@ -137,8 +140,11 @@ worker() {
     printf '%s\n' "$$" >"$LOCK/pid" 2>/dev/null || true
     trap 'rm -rf "$LOCK" 2>/dev/null' EXIT
 
+    # Name the target explicitly: an automated (no-TTY) `funes index` refuses to run with no
+    # target, so this indexes only Claude sessions — Codex/pi are handled by their own hooks. It
+    # also refuses to build a *first* index unattended, hence the manual `funes index` in setup.
     log "index: start"
-    if "$funes" index >>"$LOG" 2>&1; then
+    if "$funes" index --harness claude >>"$LOG" 2>&1; then
         log "index: ok"
     else
         log "index: FAILED (exit $?)"
@@ -215,6 +221,9 @@ funes status                            # chunk count should grow across session
 
 - **Local-first, always safe.** `funes index` only ever writes `~/.funes`. If no
   remote is attached, the hook indexes and logs `push: skipped` — never an error.
+- **The first index is manual.** The hook only does incremental, per-harness updates;
+  it refuses to build a from-scratch index unattended, so a fresh machine does nothing
+  until you run `funes index` once by hand (setup step 1).
 - **Fresh the next session, not the current one.** The worker outlives the session
   that spawned it, but a session's *final* turns land as it tears down. They're
   swept up by the next session's run (or the current run if they were already
@@ -230,7 +239,7 @@ funes status                            # chunk count should grow across session
 
 The automation *pattern* is agent-agnostic: point an equivalent hook — or a
 cron/launchd/systemd timer, if your agent has no session hook — at a script like the
-one above. Only the *source path* is Claude-specific. `funes index` with no argument
-reads `~/.claude/projects`; to index another agent, pass its transcript location —
-`funes index <path>`, where `<path>` is a directory of session transcripts or a trace
-`.parquet`. Everything downstream — chunk, embed, store, push — is identical.
+one above. Only the *target* is Claude-specific, and an automated run must name one:
+`funes index --harness claude | codex | pi` indexes that agent's standard session dir,
+or pass an explicit path — `funes index <path>`, a directory of session transcripts or a
+trace `.parquet`. Everything downstream — chunk, embed, store, push — is identical.

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -33,6 +33,16 @@ impl Harness {
         }
     }
 
+    /// The `--harness` spelling `index` accepts and shows in `--help` (`claude`/`codex`/`pi`).
+    /// Differs from [`Harness::as_str`], the stored facet, only for Claude (facet `claude_code`).
+    pub fn cli_name(&self) -> &'static str {
+        match self {
+            Harness::Claude => "claude",
+            Harness::Codex => "codex",
+            Harness::Pi => "pi",
+        }
+    }
+
     /// Parse a `--harness` override: `claude`/`claude_code`, `codex`, or `pi`.
     pub fn parse(s: &str) -> Result<Harness> {
         match s {

--- a/src/index.rs
+++ b/src/index.rs
@@ -15,10 +15,10 @@ use arrow_schema::{DataType, Field, Schema};
 use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
 use lance::dataset::{Dataset, WriteParams};
 use std::collections::{HashMap, HashSet};
-use std::io::Write as _;
+use std::io::{IsTerminal, Write as _};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 pub const MODEL: &str = "BAAI/bge-small-en-v1.5";
 pub const DIM: i32 = 384;
@@ -265,18 +265,19 @@ impl Indexer<'_> {
 /// Build/update the local index from one or more source roots — each `(path, harness override)`
 /// where `None` auto-detects. All roots share one store, embedder, and `state.json` (keyed by
 /// absolute file path, so cross-root incremental works). Writes only locally — publishing is the
-/// separate `push`. `max_sessions` caps sessions *per root* (`None` = all) — the CLI passes `None`;
-/// a benchmark passes a cap to bound build time.
+/// separate `push`. `max_sessions` caps sessions *per root* to the most recent N (`None` = all).
+/// `yes` skips the first-index confirmation and the automated-first-index guard (`--yes`).
 pub async fn run_index_roots(
     roots: &[(PathBuf, Option<Harness>)],
     no_thinking: bool,
     max_sessions: Option<usize>,
+    yes: bool,
 ) -> Result<()> {
     let sources = roots
         .iter()
         .map(|(path, harness)| source::open_with_harness(path, max_sessions, *harness))
         .collect();
-    index_sources(sources, no_thinking).await
+    index_sources(sources, no_thinking, yes).await
 }
 
 /// Index a Hub trace dataset (`funes index <org/repo>`): resolve its `refs/convert/parquet` shards,
@@ -285,14 +286,15 @@ pub async fn run_index_roots(
 pub async fn run_index_remote(uri: &str, no_thinking: bool) -> Result<()> {
     let (owner, name, _prefix) = hub::parse_hf(uri)?;
     let src = source::open_remote(&owner, &name, None).await?;
-    index_sources(vec![src], no_thinking).await
+    // A Hub import is an explicit, deliberate command — bypass the first-index confirmation/guard.
+    index_sources(vec![src], no_thinking, true).await
 }
 
 /// Index a set of already-opened sources into the local store, sharing one embedder, `state.json`,
 /// and dataset handle across them (state keyed by absolute path / `hf://…` shard, so incremental
 /// works cross-source). The wrappers above open the sources; this drives the
 /// units→skip→read→embed→write loop and builds the indexes once.
-async fn index_sources(sources: Vec<Box<dyn source::TraceSource>>, no_thinking: bool) -> Result<()> {
+async fn index_sources(sources: Vec<Box<dyn source::TraceSource>>, no_thinking: bool, yes: bool) -> Result<()> {
     let include_thinking = !no_thinking;
     let dir = dataset::funes_dir();
     std::fs::create_dir_all(&dir)?;
@@ -310,6 +312,20 @@ async fn index_sources(sources: Vec<Box<dyn source::TraceSource>>, no_thinking: 
                 return Err(anyhow!("index built with model {em:?}, refusing to mix with {MODEL:?}"));
             }
         }
+    }
+
+    let first_index = ds.is_none();
+    let interactive = std::io::stdin().is_terminal();
+
+    // A first index can take a long time; never let an automated run (no TTY — a hook, cron) trigger
+    // it. Fail closed like push's new-store guard: require a manual `funes index` first, or --yes to
+    // force. Exit 0 so a session-end hook isn't treated as failed.
+    if first_index && !yes && !interactive {
+        eprintln!(
+            "funes: no index yet — run `funes index` in a terminal first to build the initial index \
+             (one-time; it can take a while), or pass --yes to force it here. Skipping."
+        );
+        return Ok(());
     }
 
     // Incremental state: path -> "size:mtime".
@@ -338,9 +354,17 @@ async fn index_sources(sources: Vec<Box<dyn source::TraceSource>>, no_thinking: 
         scanner,
         include_thinking,
     };
+    // Enumerate every source's units up front (cheap: stat, no parse) so a first-index estimate
+    // knows the total session count before any embedding starts.
+    let per_source: Vec<Vec<source::Unit>> = sources.iter().map(|s| s.units()).collect::<Result<_>>()?;
+    let total_units: usize = per_source.iter().map(|u| u.len()).sum();
+
+    // First interactive index: after the first session lands, estimate the whole run from its time
+    // and — if it looks long — ask whether to continue or bail and re-run with --limit.
+    let mut probe_pending = first_index && !yes && interactive;
+
     let (mut n_sessions, mut n_skipped, mut n_chunks) = (0u64, 0u64, 0u64);
-    for src in &sources {
-        let units = src.units()?;
+    'sources: for (src, units) in sources.iter().zip(&per_source) {
         let total = units.len();
         let cached = units
             .iter()
@@ -369,6 +393,7 @@ async fn index_sources(sources: Vec<Box<dyn source::TraceSource>>, no_thinking: 
                 }
                 Err(e) => return Err(e),
             };
+            let t_unit = Instant::now();
             let (sessions, added) = indexer.index_unit(&progress, &unit.key, turns).await?;
             n_sessions += sessions;
             n_chunks += added;
@@ -379,6 +404,19 @@ async fn index_sources(sources: Vec<Box<dyn source::TraceSource>>, no_thinking: 
             if let Some(sig) = &unit.signature {
                 state.insert(unit.key.clone(), sig.clone());
                 std::fs::write(&state_path, serde_json::to_string_pretty(&state)?)?;
+            }
+
+            // Estimate off the first session that actually embedded, and ask before a long haul.
+            if probe_pending && added > 0 {
+                probe_pending = false;
+                let est = t_unit.elapsed().mul_f64(total_units as f64);
+                if est >= Duration::from_secs(FIRST_INDEX_PROMPT_SECS) && !confirm_full_index(total_units, est) {
+                    eprintln!(
+                        "stopped after 1 session (kept — the index is resumable). Re-run \
+                         `funes index --limit M` for the most recent M, or `funes index` to do all."
+                    );
+                    break 'sources;
+                }
             }
         }
     }
@@ -409,8 +447,40 @@ async fn index_sources(sources: Vec<Box<dyn source::TraceSource>>, no_thinking: 
 
 /// Build/update the local index from a single source root, auto-detecting its harness — a thin
 /// convenience over [`run_index_roots`] for a single path (tests, benchmarks, one explicit path).
+/// Passes `yes = true`: these callers are non-interactive and must not gate on the first-index prompt.
 pub async fn run_index(path: &Path, no_thinking: bool, max_sessions: Option<usize>) -> Result<()> {
-    run_index_roots(&[(path.to_path_buf(), None)], no_thinking, max_sessions).await
+    run_index_roots(&[(path.to_path_buf(), None)], no_thinking, max_sessions, true).await
+}
+
+/// A first interactive index estimated at ≥ this many seconds prompts before continuing.
+const FIRST_INDEX_PROMPT_SECS: u64 = 120;
+
+/// Prompt before a long first index (interactive only): continue all, or bail and re-run with a
+/// `--limit`. Returns whether to proceed.
+fn confirm_full_index(total: usize, est: Duration) -> bool {
+    eprint!(
+        "indexing all {total} sessions is estimated at ~{} (rough, from one session). Continue? [y/N]  \
+         (or re-run with `--limit M` for the most recent M) ",
+        fmt_eta(est)
+    );
+    let _ = std::io::stderr().flush();
+    let mut answer = String::new();
+    if std::io::stdin().read_line(&mut answer).is_err() {
+        return false;
+    }
+    matches!(answer.trim().to_ascii_lowercase().as_str(), "y" | "yes")
+}
+
+/// Rough human ETA: "45s", "12 min", "2.3 h".
+fn fmt_eta(d: Duration) -> String {
+    let s = d.as_secs_f64();
+    if s < 90.0 {
+        format!("{s:.0}s")
+    } else if s < 5400.0 {
+        format!("{:.0} min", s / 60.0)
+    } else {
+        format!("{:.1} h", s / 3600.0)
+    }
 }
 
 #[cfg(test)]

--- a/src/index.rs
+++ b/src/index.rs
@@ -354,17 +354,20 @@ async fn index_sources(sources: Vec<Box<dyn source::TraceSource>>, no_thinking: 
         scanner,
         include_thinking,
     };
-    // Enumerate every source's units up front (cheap: stat, no parse) so a first-index estimate
-    // knows the total session count before any embedding starts.
-    let per_source: Vec<Vec<source::Unit>> = sources.iter().map(|s| s.units()).collect::<Result<_>>()?;
-    let total_units: usize = per_source.iter().map(|u| u.len()).sum();
-
     // First interactive index: after the first session lands, estimate the whole run from its time
     // and — if it looks long — ask whether to continue or bail and re-run with --limit.
     let mut probe_pending = first_index && !yes && interactive;
+    // Only that estimate needs the grand total up front (a cheap stat-only pass); an incremental run
+    // skips it and enumerates each source lazily in the loop, holding nothing for the whole run.
+    let total_units: usize = if probe_pending {
+        sources.iter().map(|s| s.units().map(|u| u.len()).unwrap_or(0)).sum()
+    } else {
+        0
+    };
 
     let (mut n_sessions, mut n_skipped, mut n_chunks) = (0u64, 0u64, 0u64);
-    'sources: for (src, units) in sources.iter().zip(&per_source) {
+    'sources: for src in &sources {
+        let units = src.units()?;
         let total = units.len();
         let cached = units
             .iter()
@@ -383,6 +386,8 @@ async fn index_sources(sources: Vec<Box<dyn source::TraceSource>>, no_thinking: 
                 }
             }
             let progress = format!("[{}/{}]", idx + 1, total);
+            // Time from before the read so a first-index estimate covers parse + I/O, not just embedding.
+            let t_unit = Instant::now();
             let turns = match src.read(unit) {
                 Ok(t) => t,
                 // Best-effort sources retry a failed read next run (no state recorded); a fatal
@@ -393,7 +398,6 @@ async fn index_sources(sources: Vec<Box<dyn source::TraceSource>>, no_thinking: 
                 }
                 Err(e) => return Err(e),
             };
-            let t_unit = Instant::now();
             let (sessions, added) = indexer.index_unit(&progress, &unit.key, turns).await?;
             n_sessions += sessions;
             n_chunks += added;
@@ -486,6 +490,20 @@ fn fmt_eta(d: Duration) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn fmt_eta_uses_the_right_unit_at_each_boundary() {
+        // < 90s → whole seconds.
+        assert_eq!(fmt_eta(Duration::from_secs(45)), "45s");
+        assert_eq!(fmt_eta(Duration::from_secs(89)), "89s");
+        // The 90s cutoff crosses into minutes; below 90 min it stays there.
+        assert!(fmt_eta(Duration::from_secs(90)).contains("min"));
+        assert_eq!(fmt_eta(Duration::from_secs(120)), "2 min");
+        assert_eq!(fmt_eta(Duration::from_secs(5340)), "89 min");
+        // >= 90 min → hours with one decimal.
+        assert_eq!(fmt_eta(Duration::from_secs(5400)), "1.5 h");
+        assert_eq!(fmt_eta(Duration::from_secs(9000)), "2.5 h");
+    }
 
     #[test]
     fn schema_column_order_is_load_bearing() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -259,7 +259,7 @@ async fn main() -> Result<()> {
                         .into_iter()
                         .find(|(_, kh)| *kh == h)
                         .map(|(dir, _)| vec![(dir, Some(h))])
-                        .ok_or_else(|| anyhow!("no {} session dir found on this machine", h.as_str()))?
+                        .ok_or_else(|| anyhow!("no {} session dir found on this machine", h.cli_name()))?
                 }
                 // No target at all: index every known harness root — but only in a terminal. An
                 // automated run (no TTY) must name a target, so a session-end hook indexes just its

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,6 +85,13 @@ enum Cmd {
         /// Exclude thinking blocks.
         #[arg(long)]
         no_thinking: bool,
+        /// Index only the most recent N sessions per source. Omit to index all.
+        #[arg(long)]
+        limit: Option<usize>,
+        /// Skip the first-index size confirmation, and allow a first index from a non-interactive
+        /// run (a hook/cron) — which is otherwise refused so the long initial build stays manual.
+        #[arg(long)]
+        yes: bool,
     },
     /// Show index statistics.
     Status {
@@ -227,6 +234,8 @@ async fn main() -> Result<()> {
             path,
             harness,
             no_thinking,
+            limit,
+            yes,
         } => {
             let harness = harness.map(|h| Harness::parse(&h)).transpose()?;
             let roots: Vec<(PathBuf, Option<Harness>)> = match path {
@@ -252,7 +261,7 @@ async fn main() -> Result<()> {
                     "no local sessions found — looked in ~/.claude/projects, ~/.codex/sessions, ~/.pi/agent/sessions"
                 ));
             }
-            index::run_index_roots(&roots, no_thinking, None).await
+            index::run_index_roots(&roots, no_thinking, limit, yes).await
         }
         Cmd::Status { store } => {
             print!("{}", recall::status(store.resolve()).await?);

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,9 +75,10 @@ enum Cmd {
     },
     /// Build or update the index from session transcripts.
     Index {
-        /// A transcript tree or `.parquet` file, or a Hub trace repo `<org>/<repo>`. Omit to index
-        /// every known local harness dir present (~/.claude/projects, ~/.codex/sessions,
-        /// ~/.pi/agent/sessions).
+        /// A transcript tree or `.parquet` file, or a Hub trace repo `<org>/<repo>`. Omit — in a
+        /// terminal — to index every known harness dir (~/.claude/projects, ~/.codex/sessions,
+        /// ~/.pi/agent/sessions); `--harness <name>` alone targets one. An automated (non-terminal)
+        /// run must name a target.
         path: Option<String>,
         /// Override harness auto-detection for PATH: claude | codex | pi.
         #[arg(long)]
@@ -250,11 +251,31 @@ async fn main() -> Result<()> {
                     return index::run_index_remote(&uri, no_thinking).await;
                 }
                 Some(p) => return Err(anyhow!("no such path: {p}")),
-                None if harness.is_some() => return Err(anyhow!("--harness needs a PATH")),
-                None => funes::harness::known_harness_roots()
-                    .into_iter()
-                    .map(|(dir, h)| (dir, Some(h)))
-                    .collect(),
+                // `--harness X` with no path targets that harness's known session dir — the
+                // per-target form a session-end hook uses (index only its own harness's sessions).
+                None if harness.is_some() => {
+                    let h = harness.unwrap();
+                    funes::harness::known_harness_roots()
+                        .into_iter()
+                        .find(|(_, kh)| *kh == h)
+                        .map(|(dir, _)| vec![(dir, Some(h))])
+                        .ok_or_else(|| anyhow!("no {} session dir found on this machine", h.as_str()))?
+                }
+                // No target at all: index every known harness root — but only in a terminal. An
+                // automated run (no TTY) must name a target, so a session-end hook indexes just its
+                // own harness — a Claude session-end shouldn't pull in Codex or pi sessions.
+                None => {
+                    if !std::io::stdin().is_terminal() {
+                        return Err(anyhow!(
+                            "automated `funes index` needs a target — pass a path or `--harness <claude|codex|pi>`; \
+                             refusing to index all harness roots unattended"
+                        ));
+                    }
+                    funes::harness::known_harness_roots()
+                        .into_iter()
+                        .map(|(dir, h)| (dir, Some(h)))
+                        .collect()
+                }
             };
             if roots.is_empty() {
                 return Err(anyhow!(

--- a/src/source.rs
+++ b/src/source.rs
@@ -99,7 +99,8 @@ pub(crate) fn file_sig(p: &Path) -> Option<String> {
 }
 
 /// A directory tree of `*.jsonl` transcripts for one `harness` — one session per file, indexed
-/// incrementally (each file skipped while unchanged). `limit` caps the number of files (sessions).
+/// incrementally (each file skipped while unchanged). `limit` keeps the most recent N files
+/// (sessions) by mtime.
 struct JsonlTree {
     root: PathBuf,
     limit: Option<usize>,
@@ -118,6 +119,11 @@ impl TraceSource for JsonlTree {
     fn units(&self) -> Result<Vec<Unit>> {
         let mut files = jsonl::iter_jsonl_files(&self.root);
         if let Some(n) = self.limit {
+            // Keep the most recent `n` by mtime: recall values recency, and the default order is by
+            // filename (≈ random for UUID-named sessions), so a plain truncate would drop recent work.
+            files.sort_by_cached_key(|p| {
+                std::cmp::Reverse(std::fs::metadata(p).and_then(|m| m.modified()).unwrap_or(UNIX_EPOCH))
+            });
             files.truncate(n);
         }
         Ok(files


### PR DESCRIPTION
We now warn when indexing might take longer than 2 minutes.

We also make sure automated indexing are applied:
- only on warm indexed sources,
- selectively on a specific target.