### PR TITLE
Improve onboarding, secure and extend automation hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Code, Codex, and pi and lets any agent recall the past decisions, rationale, and
 - **Your agent recalls your past work.** The model spontaneously uses funes to recall prior decisions, rationale, and findings mid-task.
 - **One memory across your agents.** Index Claude Code, Codex, and pi into a single store; recall
   spans all of them, and every hit shows which agent it came from.
-- **Share across machines or a team.** Publish your index to a Hugging Face dataset you own; a
+- **Share across machines or a team.** Publish your store to a Hugging Face dataset you own; a
   teammate or another host recalls it.
 
 ## Get funes
@@ -102,15 +102,15 @@ between sessions and the memory doesn't move.
 
 ## Share across machines or a team
 
-Attach a Hugging Face dataset repo you own as your **active store**. `recall` then reads it, and
-`funes push` publishes your local index to it — no per-command flags:
+Your local store is a dataset — link a Hugging Face **dataset** repo you own as your **active store** to
+share it. `recall` then reads it, and `funes push` publishes your local store to it — no per-command flags:
 
 ```bash
 funes use acme/kb          # attach hf://datasets/acme/kb as the active store (persisted in funes.json)
-funes index                # build/update the local index
-funes push                 # publish the local index's new chunks to the active remote
-funes recall "..."         # reads the active remote
-funes use local            # detach — back to the local index
+funes index                # build/update your local store
+funes push                 # publish your local store's new chunks to the active store
+funes recall "..."         # reads the active store
+funes use local            # detach — back to your local store
 ```
 
 To query a **different remote for a single call** — say, someone's published memories on a topic —
@@ -124,7 +124,7 @@ funes recall "..." --remote other-org/subject-kb
 
 *A project this machine never worked on: one `funes use dacorvo/funes-Glint-Research-Fable-5` attaches ~21.6k chunks straight from the Hub, and pi recalls a past decision from that shared store.*
 
-The first push to a store your local index shares no chunks with (a first push, a new host, or the
+The first push to a store that shares no chunks with your local one (a first push, a new host, or the
 wrong store) asks to confirm before uploading; off a terminal it refuses rather than guess (`--yes`
 overrides). You never need the Hub to use funes locally — it's a tier you opt into. Recall over a remote caches whole files to local disk, so warm calls run at local speed ([how caching works](docs/hub-caching.md)).
 
@@ -158,13 +158,13 @@ push — at the end of every agent session instead of by hand, wire up a hook: s
    │  parse        deterministic — turns (text / thinking / tool_use / tool_result), tagged by agent
    │  chunk        one chunk per content block, tight provenance
    │  embed        pinned local model (BAAI/bge-small-en-v1.5)
-   ▼  store        embedded vector store (vector + BM25)
+   ▼  store        a local Lance dataset (vector + BM25)
 recall(query) ──>  vector + BM25  →  RRF  →  cross-encoder rerank  →  recency  →  neighbors
 ```
 
 Each source is a [`TraceSource`](src/source.rs) that reads its format into a generic turn/block
 shape; everything downstream — chunk → embed → store → recall — is source-agnostic. Adding another
-agent means implementing one trait, not touching the index or query path.
+agent means implementing one trait, not touching the indexing or query path.
 
 ### Inspect it yourself
 
@@ -202,8 +202,8 @@ integration test downloads the embedder/reranker weights on first run.
 
 ## Notes
 
-- **Embedding model is pinned** and stamped into the index; querying with a different embedding
-  model is refused. To change it, rebuild from the transcripts (the index is a disposable derived
+- **Embedding model is pinned** and stamped into the store; querying with a different embedding
+  model is refused. To change it, rebuild from the transcripts (the store is a disposable derived
   artifact — the raw text is retained in every row). This is separate from the model you *reason*
   with, which is free to change.
 - **Subagent transcripts** (`.../subagents/agent-*.jsonl`) are indexed too.

--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ overrides). You never need the Hub to use funes locally — it's a tier you opt 
 
 funes redacts credentials from each session *before* it's stored. On publish, a separate,
 always-on gate withholds any chunk that still contains a secret and exits non-zero, rather than
-upload it — run `funes scrub` to clean older rows in place, then push again. This is what makes a
-shared store safe to push to.
+upload it — run `funes scrub` to clean older rows in place, then push again. It removes credentials
+only; the rest is published as-is.
 
 For example, when the gate holds back every dirty row, nothing ships and the push exits non-zero:
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ funes get <session_id> <turn_uuid>                # expand a hit into its full s
 
 Each hit prints `[time] agent project/session type score`, a `→ get <session_id> <turn_uuid>` line,
 a preview, and a few neighboring chunks. Narrow with `--type` (`text|thinking|tool_use|tool_result`),
-`--project`, and `--harness` (`claude_code|codex|pi`); tune with `--k`, `--half-life` (recency
+`--project`, and `--harness` (`claude|codex|pi`); tune with `--k`, `--half-life` (recency
 decay), and `--neighbors`.
 
 ## Share across machines or a team

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ curl -fsSL https://huggingface.co/buckets/huggingface/funes/resolve/install.sh |
 Then try it:
 
 ```bash
-funes recall "how do I get started with funes"
+funes guide
 ```
 
 Alternatively, grab a [binary](https://huggingface.co/buckets/huggingface/funes) by hand:
@@ -45,12 +45,11 @@ Alternatively, grab a [binary](https://huggingface.co/buckets/huggingface/funes)
 
 ```bash
 curl -fsSL https://huggingface.co/buckets/huggingface/funes/resolve/funes-x86_64-linux -o funes
-chmod +x funes && ./funes recall "how do I get started with funes"
+chmod +x funes && ./funes guide
 ```
 
-funes works the moment it lands: with no index yet, `recall` (and `get` / `list`) answer from a
-small **built-in guide to funes itself**, so you can feel recall before indexing anything. `funes
-status` tells you whether you're reading that built-in guide or your own index.
+funes works the moment it lands: **`funes guide`** walks you through it before you've indexed
+anything, and `funes status` tells you whether recall is reading your own index yet.
 
 Already installed? **`funes update`** replaces the binary in place with the latest build for your
 platform (`--force` reinstalls the current one); `funes status` tells you when a newer release is

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ chmod +x funes && ./funes guide
 ```
 
 funes works the moment it lands: **`funes guide`** walks you through it before you've indexed
-anything, and `funes status` tells you whether recall is reading your own index yet.
+anything, and `funes status` tells you whether recall is reading your own store yet.
 
 Already installed? **`funes update`** replaces the binary in place with the latest build for your
 platform (`--force` reinstalls the current one); `funes status` tells you when a newer release is

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # funes
 
-**Durable, local memory for your AI coding agent.** funes indexes your past sessions across Claude
-Code, Codex, and pi and lets the agent recall its own decisions, rationale, and findings mid-task —
-the exact passages, with provenance, using whatever model it's running. Everything stays on your
-machine; you can query the memories yourself from the CLI to check or debug a result.
+**Durable memory for your AI coding agents.** funes indexes your past sessions across Claude
+Code, Codex, and pi and lets any agent recall the past decisions, rationale, and findings.
 
 ![Choosing an embedding model in Claude Code, then Codex recalling that decision in a separate session](docs/img/cross-agents.gif)
 
@@ -16,9 +14,6 @@ machine; you can query the memories yourself from the CLI to check or debug a re
   spans all of them, and every hit shows which agent it came from.
 - **Share across machines or a team.** Publish your index to a Hugging Face dataset you own; a
   teammate or another host recalls it.
-- **Runs on your machine.** Indexing and recall are local; nothing is sent anywhere until you `push`.
-- **Secrets stay out.** Credentials are redacted at index time, and a fail-closed gate blocks them
-  from any push.
 
 ## Get funes
 
@@ -53,7 +48,7 @@ anything, and `funes status` tells you whether recall is reading your own index 
 
 Already installed? **`funes update`** replaces the binary in place with the latest build for your
 platform (`--force` reinstalls the current one); `funes status` tells you when a newer release is
-out. Along with `push`, that update check is the only routine call funes makes off your machine.
+out.
 
 To build it yourself instead, see [Building from source](#building-from-source).
 
@@ -69,7 +64,7 @@ funes index      # sweeps ~/.claude/projects, ~/.codex/sessions, ~/.pi/agent/ses
 ```
 
 Run with no arguments and funes indexes every supported agent's sessions it finds, into one store.
-It's incremental — only new turns are embedded — so it's cheap to re-run as you work. Point it at a
+It's incremental — only new turns are embedded — so it's cheap to re-run as you work — a store runs ~2.3 KB/chunk and grows ~6 MB on a heavy day ([storage growth](docs/storage.md)). Point it at a
 path to index one place, or scope to a single agent with `--harness codex`.
 
 funes can index sessions from: Claude, Codex, Pi
@@ -105,23 +100,6 @@ Models work the same way. funes runs no model of its own, so you reason with wha
 does — through **pi**, any local model or one served through the Hugging Face router. Switch models
 between sessions and the memory doesn't move.
 
-## Inspect it yourself
-
-Because everything's local, you can query the store yourself from the CLI — handy to check what's
-indexed or debug a result:
-
-```bash
-funes recall "why did we switch off lancedb"
-funes recall "the lance schema" --type tool_use --harness codex --project funes
-funes list --project funes                        # browse indexed sessions
-funes get <session_id> <turn_uuid>                # expand a hit into its full surrounding turns
-```
-
-Each hit prints `[time] agent project/session type score`, a `→ get <session_id> <turn_uuid>` line,
-a preview, and a few neighboring chunks. Narrow with `--type` (`text|thinking|tool_use|tool_result`),
-`--project`, and `--harness` (`claude|codex|pi`); tune with `--k`, `--half-life` (recency
-decay), and `--neighbors`.
-
 ## Share across machines or a team
 
 Attach a Hugging Face dataset repo you own as your **active store**. `recall` then reads it, and
@@ -148,7 +126,7 @@ funes recall "..." --remote other-org/subject-kb
 
 The first push to a store your local index shares no chunks with (a first push, a new host, or the
 wrong store) asks to confirm before uploading; off a terminal it refuses rather than guess (`--yes`
-overrides). You never need the Hub to use funes locally — it's a tier you opt into.
+overrides). You never need the Hub to use funes locally — it's a tier you opt into. Recall over a remote caches whole files to local disk, so warm calls run at local speed ([how caching works](docs/hub-caching.md)).
 
 ## Keeping secrets out
 
@@ -187,6 +165,22 @@ recall(query) ──>  vector + BM25  →  RRF  →  cross-encoder rerank  →  
 Each source is a [`TraceSource`](src/source.rs) that reads its format into a generic turn/block
 shape; everything downstream — chunk → embed → store → recall — is source-agnostic. Adding another
 agent means implementing one trait, not touching the index or query path.
+
+### Inspect it yourself
+
+You can query the store yourself from the CLI — handy to check what's indexed or debug a result:
+
+```bash
+funes recall "why did we switch off lancedb"
+funes recall "the lance schema" --type tool_use --harness codex --project funes
+funes list --project funes                        # browse indexed sessions
+funes get <session_id> <turn_uuid>                # expand a hit into its full surrounding turns
+```
+
+Each hit prints `[time] agent project/session type score`, a `→ get <session_id> <turn_uuid>` line,
+a preview, and a few neighboring chunks. Narrow with `--type` (`text|thinking|tool_use|tool_result`),
+`--project`, and `--harness` (`claude|codex|pi`); tune with `--k`, `--half-life` (recency
+decay), and `--neighbors`.
 
 ## Building from source
 

--- a/docs/RATIONALE.md
+++ b/docs/RATIONALE.md
@@ -57,10 +57,10 @@ decay relative to it.
 ### 3. Local-first, model-agnostic, on storage you own
 
 Local embeddings (`BAAI/bge-small-en-v1.5`) and a local cross-encoder reranker. The only
-state is a derived, rebuildable index; the transcripts are the source of truth. Any model
+state is a derived, rebuildable store; the transcripts are the source of truth. Any model
 can query it — switch models per task; nothing is trained into weights.
 
-By default everything stays on the machine. **Optionally**, the index — a Lance dataset that
+By default everything stays on the machine. **Optionally**, the store — a Lance dataset that
 still holds the raw passages — can be synced to the **HF Hub**, where `recall` reads it
 over `hf://` — fetching the immutable Lance files a query touches into a local cache pinned to
 the dataset's commit, so a warm recall reads from disk with no network. That hub repo is

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -90,184 +90,35 @@ at the end: a chunk's id derives from `(session, turn, block, split)`, so a comp
 turn's chunks are identical no matter when they're indexed, and `funes index`
 re-embeds nothing already stored.
 
-### `~/.claude/hooks/funes-index.sh`
+### Install the two scripts
 
-Save this and `chmod +x` it:
-
-```bash
-#!/usr/bin/env bash
-# Index new Claude Code turns into funes — local only, no network.
-#
-# Fired by the Stop hook (after every turn), so the local store stays fresh as you
-# work. `funes index` is incremental and idempotent — it re-embeds nothing already
-# stored — and indexing per turn yields the same chunks as indexing once per session,
-# since chunk ids derive from (session, turn, block, split). Publishing to the remote
-# is a separate step (funes-push.sh, on session boundaries), so this per-turn run
-# stays cheap and never touches the network.
-#
-# The work runs detached so it never blocks the turn or trips the hook timeout: the
-# foreground half drains the hook payload, re-execs as a background worker, and
-# returns. Detach and locking use only portable idioms (nohup + a mkdir lock) — stock
-# macOS ships neither setsid nor flock, and this runs on macOS and Linux.
-
-set -uo pipefail
-
-LOG="$HOME/.claude/hooks/funes-sync.log"
-LOCK="$HOME/.claude/hooks/.funes-index.lock"   # serialize concurrent index runs
-STALE_LOCK_SECS=1800                           # take over a lock a hard-killed run left behind
-
-log() { printf '%s %s\n' "$(date +%Y-%m-%dT%H:%M:%S%z)" "$*" >>"$LOG"; }
-
-# Resolve a binary by name, falling back to common install dirs — hooks can run with a
-# minimal PATH (e.g. launched from the IDE).
-find_bin() {
-    command -v "$1" 2>/dev/null && return 0
-    for d in "$HOME/.local/bin" /opt/homebrew/bin /usr/local/bin "$HOME/go/bin" /usr/bin /bin; do
-        [ -x "$d/$1" ] && { printf '%s\n' "$d/$1"; return 0; }
-    done
-    return 1
-}
-
-# mtime in epoch seconds — GNU `stat -c` first, BSD `stat -f` second.
-lock_mtime() { stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null || echo 0; }
-
-worker() {
-    local funes holder mtime now stolen
-    funes="$(find_bin funes || true)"
-    if [ -z "$funes" ] || [ ! -x "$funes" ]; then
-        log "index ABORT: funes not found; skipping."
-        return
-    fi
-
-    # Serialize concurrent turns/sessions. mkdir is atomic; steal an existing lock only
-    # when its holder is truly gone (PID liveness, not wall-clock age — a long or
-    # laptop-slept run must not have its lock stolen while it is still working).
-    if ! mkdir "$LOCK" 2>/dev/null; then
-        holder="$(cat "$LOCK/pid" 2>/dev/null || true)"
-        if [ -n "$holder" ] && kill -0 "$holder" 2>/dev/null; then
-            log "index: another run (pid $holder) in progress; skipping."
-            return
-        fi
-        if [ -z "$holder" ]; then
-            mtime="$(lock_mtime "$LOCK")"; now="$(date +%s)"
-            if [ "$mtime" -gt 0 ] && [ "$((now - mtime))" -le "$STALE_LOCK_SECS" ]; then
-                log "index: lock being acquired by another worker; skipping."
-                return
-            fi
-        fi
-        stolen="$LOCK.stale.$$"
-        if mv "$LOCK" "$stolen" 2>/dev/null; then
-            rm -rf "$stolen" 2>/dev/null
-            log "index: reclaimed abandoned lock (holder=${holder:-unknown})"
-        fi
-        mkdir "$LOCK" 2>/dev/null || { log "index: another worker grabbed the lock; skipping."; return; }
-    fi
-    printf '%s\n' "$$" >"$LOCK/pid" 2>/dev/null || true
-    trap 'rm -rf "$LOCK" 2>/dev/null' EXIT
-
-    # Name the target explicitly: an automated (no-TTY) `funes index` refuses to run with
-    # no target, so this indexes only Claude sessions — other agents get their own hook.
-    log "index: start"
-    if "$funes" index --harness claude >>"$LOG" 2>&1; then
-        log "index: ok"
-    else
-        log "index: FAILED (exit $?)"
-    fi
-}
-
-# Worker mode (re-exec): do the real work, already detached from the turn.
-if [ "${1:-}" = "--worker" ]; then
-    worker
-    exit 0
-fi
-
-# Foreground: drain the Stop payload on stdin, hand off to a detached worker, return.
-cat >/dev/null
-nohup bash "$0" --worker >/dev/null 2>&1 </dev/null &
-disown 2>/dev/null || true
-exit 0
-```
-
-### `~/.claude/hooks/funes-push.sh`
-
-Save this and `chmod +x` it:
+Both live in this repo under [`scripts/automation/`](../scripts/automation):
+**`funes-index.sh`** (the per-turn local index) and **`funes-push.sh`** (the network
+publish). Neither is Claude-specific — `funes-index.sh` takes the harness as its first
+argument and `funes-push.sh` publishes the whole store — so Claude and Codex point at one
+copy. Install them where the hooks below expect them:
 
 ```bash
-#!/usr/bin/env bash
-# Publish the local funes index to the active remote.
-#
-# Fired by SessionEnd (publish what this session produced) AND SessionStart (catch up
-# anything a previous session left unpublished — its SessionEnd may never have fired
-# because the host was disconnected, the window closed, or the conversation was
-# switched away). The Stop hook (funes-index.sh) keeps the LOCAL index fresh per turn;
-# this is the only step that touches the network, so it runs at session boundaries,
-# not per turn.
-#
-# `funes push` is incremental and commit-guarded (it retries against a moved remote
-# head), so overlapping publishes — and a publish that overlaps an index — are safe;
-# no lock is needed. It has a fail-closed secret gate: a chunk holding a credential is
-# withheld (exit 2) rather than published. A first push to a store your local one
-# shares no chunks with is refused off a terminal — clear it once by hand (see setup).
-#
-# Runs detached so it never blocks session start/teardown or trips the hook timeout.
-
-set -uo pipefail
-
-LOG="$HOME/.claude/hooks/funes-sync.log"
-FUNES_HOME="${FUNES_HOME:-$HOME/.funes}"
-FUNES_JSON="$FUNES_HOME/funes.json"
-
-log() { printf '%s %s\n' "$(date +%Y-%m-%dT%H:%M:%S%z)" "$*" >>"$LOG"; }
-
-# Resolve a binary by name, falling back to common install dirs — hooks can run with a
-# minimal PATH (e.g. launched from the IDE).
-find_bin() {
-    command -v "$1" 2>/dev/null && return 0
-    for d in "$HOME/.local/bin" /opt/homebrew/bin /usr/local/bin "$HOME/go/bin" /usr/bin /bin; do
-        [ -x "$d/$1" ] && { printf '%s\n' "$d/$1"; return 0; }
-    done
-    return 1
-}
-
-worker() {
-    local funes rc remote
-    funes="$(find_bin funes || true)"
-    if [ -z "$funes" ] || [ ! -x "$funes" ]; then
-        log "push ABORT: funes not found; skipping."
-        return
-    fi
-
-    # Push only when a remote is attached, naming it explicitly so the target is
-    # unambiguous in the log and immune to the active store changing mid-run. A first
-    # push to a store this index shares no chunks with is refused here (the overlap
-    # guard fails closed off a terminal) — clear it once by hand: `funes push <repo>`.
-    remote="$(sed -n 's/.*"remote"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$FUNES_JSON" 2>/dev/null)"
-    if [ -z "$remote" ]; then
-        log "push: skipped (no remote attached — 'funes use <org>/<repo>' to enable)"
-        return
-    fi
-    log "push: start ($remote)"
-    "$funes" push "$remote" >>"$LOG" 2>&1
-    rc=$?
-    case "$rc" in
-        0) log "push: ok" ;;
-        2) log "push: WARN — secrets held back; run 'funes scrub', then it publishes next run" ;;
-        *) log "push: FAILED (exit $rc)" ;;
-    esac
-}
-
-# Worker mode (re-exec): do the real work, already detached from the session.
-if [ "${1:-}" = "--worker" ]; then
-    worker
-    exit 0
-fi
-
-# Foreground: drain the hook payload on stdin, hand off to a detached worker, return.
-cat >/dev/null
-nohup bash "$0" --worker >/dev/null 2>&1 </dev/null &
-disown 2>/dev/null || true
-exit 0
+mkdir -p ~/.claude/hooks
+cp scripts/automation/funes-index.sh scripts/automation/funes-push.sh ~/.claude/hooks/
+chmod +x ~/.claude/hooks/funes-index.sh ~/.claude/hooks/funes-push.sh
 ```
+
+Read them before installing — they run on every turn and session boundary. Both are
+built the same way: the foreground half drains the hook payload on stdin and re-execs a
+**detached worker**, so the hook returns in well under a second and never blocks the turn
+or trips the timeout. The worker then:
+
+- **`funes-index.sh`** — runs `funes index --harness <arg>`. Local only, no network. No
+  locking in the script: `funes` serializes local-store writes itself (an advisory lock
+  in the binary). If another store operation holds the lock, the run exits non-zero
+  (logged) and the next turn re-sweeps the same content — indexing is idempotent.
+- **`funes-push.sh`** — reads the attached remote from `~/.funes/funes.json` and runs
+  `funes push`. Logs a warning, not a failure, if the fail-closed secret gate held
+  chunks back (exit 2 → run `funes scrub`).
+
+Everything downstream is identical for every agent; only the harness argument and which
+lifecycle events fire the scripts differ.
 
 ### Register all three hooks in `~/.claude/settings.json`
 
@@ -279,7 +130,7 @@ exit 0
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"$HOME/.claude/hooks/funes-index.sh\"",
+            "command": "bash \"$HOME/.claude/hooks/funes-index.sh\" claude",
             "timeout": 15,
             "statusMessage": "Indexing turn into funes memory"
           }
@@ -318,14 +169,116 @@ exit 0
 and the network push run in the detached worker, not in the hook Claude Code is
 waiting on.
 
+## Codex
+
+Codex's [hooks](https://developers.openai.com/codex/hooks) give the same two triggers
+Claude's do — a per-turn `Stop` and a `SessionStart` — so **the same two scripts drive
+it**, no Codex-specific copies needed:
+
+- **`Stop` → `funes-index.sh codex`** — index the turn's new content locally, exactly
+  as Claude's `Stop` does. The harness argument is the only difference; the script and
+  its log are shared — one implementation, one timeline. A Codex index and a Claude one
+  can safely run at once: `funes` serializes local-store writes in the binary, so no
+  coordination between the scripts is needed.
+- **`SessionStart` → `funes-push.sh`** — publish on the way in. The push script is
+  **harness-agnostic** — `funes push` publishes the whole local index, whatever produced
+  it — so it needs no `codex` argument and is reused verbatim.
+
+The one structural difference from Claude: **Codex has no session-end event.** So the
+`SessionEnd` publish has no equivalent here; publishing happens only on the way in at the
+next `SessionStart`. See [the gap](#the-codex-gap) below.
+
+### Register the hooks in `~/.codex/config.toml`
+
+Codex discovers hooks either as inline `[hooks]` tables in `config.toml` or in a
+separate `~/.codex/hooks.json`. The TOML form, alongside your other Codex config:
+
+```toml
+[[hooks.Stop]]
+[[hooks.Stop.hooks]]
+type = "command"
+command = 'bash "$HOME/.claude/hooks/funes-index.sh" codex'
+timeout = 15
+statusMessage = "Indexing turn into funes memory"
+
+[[hooks.SessionStart]]
+[[hooks.SessionStart.hooks]]
+type = "command"
+command = 'bash "$HOME/.claude/hooks/funes-push.sh"'
+timeout = 15
+statusMessage = "Publishing funes memory"
+```
+
+Or the equivalent `~/.codex/hooks.json`:
+
+```json
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$HOME/.claude/hooks/funes-index.sh\" codex",
+            "timeout": 15,
+            "statusMessage": "Indexing turn into funes memory"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$HOME/.claude/hooks/funes-push.sh\"",
+            "timeout": 15,
+            "statusMessage": "Publishing funes memory"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The commands point at the scripts you installed under `~/.claude/hooks/` for the Claude
+setup — that path is not Claude-specific, and pointing both agents at one copy keeps a
+single implementation to maintain. If you run Codex without Claude, install the two
+scripts wherever you like (e.g. `~/.codex/hooks/`) and adjust the paths.
+
+> **Older Codex without the hooks system?** Use the legacy `notify` program for the
+> per-turn index — it fires on `agent-turn-complete`, the same moment as `Stop`:
+> `notify = ["bash", "/home/you/.claude/hooks/funes-index.sh", "codex"]` (a root key, so
+> it must sit above any `[table]` header). `notify` is exec'd directly, not through a
+> shell, so use a literal absolute path — `$HOME`/`~` won't expand. It appends its JSON
+> payload as a trailing argument, which the script ignores. But `notify` has no
+> `SessionStart` equivalent, so you get local indexing only — publish on a timer (see
+> [Other agents](#other-agents)) or by hand.
+
+<h3 id="the-codex-gap">The Codex publish gap</h3>
+
+With no session-end event, a Codex session's last turns publish no sooner than the
+**next** Codex `SessionStart`; a machine retired without starting another Codex session
+keeps them local until you run `funes push <repo>` by hand. Two things narrow this:
+
+- **`SessionStart` fires on `resume`, `clear`, and `compact`**, not just fresh startup,
+  so long-lived work publishes at each of those points, not only when you next launch.
+- **If you also run Claude on the same machine**, its `SessionEnd`/`SessionStart` pushes
+  publish the Codex-indexed turns too — `funes push` is whole-store — so any agent's
+  push boundary flushes every agent's freshly indexed turns.
+
 ## Verify it
 
 Take a couple of turns in one session, then start a fresh session and:
 
 ```bash
-tail ~/.claude/hooks/funes-sync.log   # index: ok (per turn) · push: ok (per boundary)
+tail ~/.claude/hooks/funes-sync.log   # index[<harness>]: ok (per turn) · push: ok (per boundary)
 funes status                          # chunk count grows across turns; publishes at start/end
 ```
+
+Both agents log to the same `funes-sync.log`, tagged by harness (`index[claude]`,
+`index[codex]`), so it's one timeline for everything.
 
 ## How it behaves
 
@@ -339,15 +292,21 @@ funes status                          # chunk count grows across turns; publishe
 - **Fresh every turn.** `Stop` re-indexes after each turn, so the local store tracks
   the session as it grows; a session killed mid-flight is already indexed up to its
   last completed turn. Because `funes index` is incremental, that re-sweep is cheap.
-- **Published at both boundaries.** `SessionEnd` publishes what the session produced;
-  `SessionStart` republishes anything a prior session left unpushed — the recovery
-  path for a `SessionEnd` that never fired (host disconnect, closed window, a
-  switched-away conversation).
-- **Serialized where it matters.** Concurrent `funes index` runs would race on the
-  store, so `funes-index.sh` holds a lock and a contended run just skips — its turns
-  are swept by the next turn's run. `funes push` needs no lock: it is commit-guarded
-  on the remote and retries on conflict, so overlapping publishes (and a publish that
-  overlaps an index) are safe.
+- **Published at the boundaries you have.** On Claude, `SessionEnd` publishes what the
+  session produced and `SessionStart` republishes anything a prior session left unpushed
+  — the recovery path for a `SessionEnd` that never fired (host disconnect, closed
+  window, a switched-away conversation). Codex has no session-end event, so it publishes
+  only at `SessionStart`; see [the Codex gap](#the-codex-gap).
+- **Serialized in the binary.** `funes` holds an advisory lock while it mutates the local
+  store, so only one writer touches it at a time — no matter what launched them (a hook, a
+  manual `funes index`, `funes scrub`, a cron timer). A run that hits the lock fails loudly
+  rather than waiting or skipping: a per-turn index just re-sweeps next turn (indexing is
+  idempotent), and a manual `funes index`/`funes scrub` prints "another funes store
+  operation is in progress" so you retry. This is what makes concurrent automation safe, and
+  it lives in the binary because the "one writer at a time" rule is a property of the store,
+  not of any one script. Reads (recall/get/status) take no lock — they read a consistent
+  snapshot. `funes push` targets the remote and is commit-guarded there, so overlapping
+  publishes (and a publish that overlaps an index) are safe.
 - **The remaining gap.** A session's very last turn is published no later than the
   next session's start; a machine retired without ever starting another session keeps
   its last unpushed turns local. If that matters, run `funes push <repo>` by hand
@@ -355,9 +314,16 @@ funes status                          # chunk count grows across turns; publishe
 
 ## Other agents
 
-The automation *pattern* is agent-agnostic: point equivalent hooks — or a
-cron/launchd/systemd timer, if your agent has no session hook — at scripts like the
-ones above. Only the *target* is Claude-specific, and an automated run must name one:
-`funes index --harness claude | codex | pi` indexes that agent's standard session dir,
-or pass an explicit path — `funes index <path>`, a directory of session transcripts or a
-trace `.parquet`. Everything downstream — chunk, embed, store, push — is identical.
+The two scripts above are already agent-agnostic — `funes-index.sh` takes the harness as
+its argument and `funes-push.sh` publishes the whole store — so extending to a third
+agent (pi, …) is just wiring, not new code. Point that agent's per-turn and per-session
+hooks at `funes-index.sh <harness>` and `funes-push.sh`, exactly as Claude and Codex do.
+
+If an agent has no hooks, drive `funes-index.sh <harness>` — or the `funes` binary
+directly — from a cron/launchd/systemd timer instead. Either is safe: `funes` serializes
+local-store writes in the binary, so a timer firing while a hook run is in flight just
+fails loudly and re-sweeps on its next tick. An automated run must always name a target:
+`funes index --harness claude | codex
+| pi` indexes that agent's standard session dir, or pass an explicit path — `funes index
+<path>`, a directory of transcripts or a trace `.parquet`. Everything downstream — chunk,
+embed, store, push — is identical.

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -16,16 +16,16 @@ manual step.
 
 ## One-time setup
 
-### 1. Build the local index
+### 1. Build your local store
 
 ```bash
 funes index          # parse → chunk → embed ~/.claude/projects → ~/.funes
 ```
 
-Run this once, interactively — **the hook won't build the first index for you.** An
-automated (non-terminal) `funes index` refuses to build a from-scratch index (it can take
+Run this once, interactively — **the hook won't build your store the first time.** An
+automated (non-terminal) `funes index` refuses to build a store from scratch (it can take
 a long time) and refuses to run with no target; it only does incremental, per-harness
-updates once a local index exists. So this manual first index is required on each machine.
+updates once a local store exists. So this manual first build is required on each machine.
 If you only want local recall, you're done — skip to [the hooks](#claude-code).
 
 ### 2. Attach a shared store (optional)
@@ -43,19 +43,19 @@ funes push <org>/<repo>    # name the store explicitly
 ```
 
 Why this can't be skipped: `funes push` **refuses, off a terminal, to publish to a
-store your local index shares no chunks with.** That guard exists so an unattended
+store your local store shares no chunks with.** That guard exists so an unattended
 push can never silently dump your sessions into the wrong repo. A brand-new store —
-or an established shared store seen from **a new machine** whose index is all its
+or an established shared store seen from **a new machine** whose store is all its
 own sessions — shares nothing yet, so a *non-interactive* push (like the one a hook
 makes) aborts with:
 
 ```
-refusing to push N chunk(s) to <store>: your local index shares no chunks with it
+refusing to push N chunk(s) to <store>: your local store shares no chunks with it
 (a first push, a new host, or the wrong store) — re-run with `--yes` to confirm.
 ```
 
 Doing the first push interactively (or with `--yes`) clears it: afterwards your
-local index and the remote share chunks, so every later push — including the
+local store and the remote share chunks, so every later push — including the
 hook's — has overlap and goes through without prompting. **Run this one-time push
 on each machine you set up.**
 
@@ -77,7 +77,7 @@ Two scripts split the work along the two operations funes performs — a local i
 update and a network publish — and wire each to the hook that fits it:
 
 - **`Stop` → `funes-index.sh`** — index the session's new turns **locally, no
-  network**. `Stop` fires after every turn, so the local index tracks the session as
+  network**. `Stop` fires after every turn, so the local store tracks the session as
   it grows; a session killed mid-flight (host disconnect, closed window, a
   switched-away conversation) is already indexed up to its last completed turn.
 - **`SessionEnd` → `funes-push.sh`** — **publish** what the session produced.
@@ -98,7 +98,7 @@ Save this and `chmod +x` it:
 #!/usr/bin/env bash
 # Index new Claude Code turns into funes — local only, no network.
 #
-# Fired by the Stop hook (after every turn), so the local index stays fresh as you
+# Fired by the Stop hook (after every turn), so the local store stays fresh as you
 # work. `funes index` is incremental and idempotent — it re-embeds nothing already
 # stored — and indexing per turn yields the same chunks as indexing once per session,
 # since chunk ids derive from (session, turn, block, split). Publishing to the remote
@@ -206,7 +206,7 @@ Save this and `chmod +x` it:
 # `funes push` is incremental and commit-guarded (it retries against a moved remote
 # head), so overlapping publishes — and a publish that overlaps an index — are safe;
 # no lock is needed. It has a fail-closed secret gate: a chunk holding a credential is
-# withheld (exit 2) rather than published. A first push to a store the local index
+# withheld (exit 2) rather than published. A first push to a store your local one
 # shares no chunks with is refused off a terminal — clear it once by hand (see setup).
 #
 # Runs detached so it never blocks session start/teardown or trips the hook timeout.
@@ -336,7 +336,7 @@ funes status                          # chunk count grows across turns; publishe
   per-harness updates; the push hook's first publish to a store it shares no chunks
   with is refused off a terminal. So a fresh machine does nothing until you run
   `funes index` and `funes push <repo>` once by hand (setup steps 1 and 3).
-- **Fresh every turn.** `Stop` re-indexes after each turn, so the local index tracks
+- **Fresh every turn.** `Stop` re-indexes after each turn, so the local store tracks
   the session as it grows; a session killed mid-flight is already indexed up to its
   last completed turn. Because `funes index` is incremental, that re-sweep is cheap.
 - **Published at both boundaries.** `SessionEnd` publishes what the session produced;

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -181,7 +181,7 @@ it**, no Codex-specific copies needed:
   can safely run at once: `funes` serializes local-store writes in the binary, so no
   coordination between the scripts is needed.
 - **`SessionStart` → `funes-push.sh`** — publish on the way in. The push script is
-  **harness-agnostic** — `funes push` publishes the whole local index, whatever produced
+  **harness-agnostic** — `funes push` publishes the whole local store, whatever produced
   it — so it needs no `codex` argument and is reused verbatim.
 
 The one structural difference from Claude: **Codex has no session-end event.** So the
@@ -323,7 +323,5 @@ If an agent has no hooks, drive `funes-index.sh <harness>` — or the `funes` bi
 directly — from a cron/launchd/systemd timer instead. Either is safe: `funes` serializes
 local-store writes in the binary, so a timer firing while a hook run is in flight just
 fails loudly and re-sweeps on its next tick. An automated run must always name a target:
-`funes index --harness claude | codex
-| pi` indexes that agent's standard session dir, or pass an explicit path — `funes index
-<path>`, a directory of transcripts or a trace `.parquet`. Everything downstream — chunk,
-embed, store, push — is identical.
+`funes index --harness claude|codex|pi` indexes that agent's standard session dir, or pass an explicit path — `funes index <path>`, a directory of transcripts or a trace `.parquet`.
+Everything downstream — chunk, embed, store, push — is identical.

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -102,7 +102,7 @@ sustained heavy daily use, or several years of moderate use.
 
 Re-indexing commits a new version rather than overwriting, so superseded index
 generations — and, after row-rewriting ops like `scrub`, orphaned data
-fragments — would otherwise accumulate. funes reaps them after each local index
+fragments — would otherwise accumulate. funes reaps them after each local re-index
 (past a short grace window, so a concurrent read isn't cut off), keeping on-disk
 size at the figures above. The remote push path optimizes indexes incrementally
 but does not yet reap, so a published store runs somewhat above these figures.

--- a/scripts/automation/funes-index.sh
+++ b/scripts/automation/funes-index.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Index an agent's new turns into funes — local only, no network.
+#
+# The harness to index is the first argument (`claude`, `codex`, `pi`, …); it defaults
+# to `claude`. One script serves every agent — Claude's Stop hook calls it with `claude`,
+# Codex's with `codex` — so there's a single implementation to maintain.
+#
+# Fired per turn (Claude's Stop hook, Codex's Stop hook), so the local index stays fresh
+# as you work. `funes index` is incremental and idempotent — it re-embeds nothing already
+# stored — and indexing per turn yields the same chunks as indexing once per session,
+# since chunk ids derive from (session, turn, block, split). Publishing to the remote
+# is a separate step (funes-push.sh, on session boundaries), so this per-turn run
+# stays cheap and never touches the network.
+#
+# No locking here: `funes` itself serializes local-store writes (an advisory lock in the
+# binary). If another store operation holds it, this run exits non-zero (logged below) and
+# the next turn re-sweeps the same content — indexing is idempotent, so nothing is lost.
+# The script only detaches so it never blocks the turn or trips the hook timeout: the
+# foreground half drains the hook payload, re-execs as a background worker, and returns.
+# Detach uses only portable idioms (nohup) — this runs on macOS and Linux.
+
+set -uo pipefail
+
+LOG="$HOME/.claude/hooks/funes-sync.log"
+
+log() { printf '%s %s\n' "$(date +%Y-%m-%dT%H:%M:%S%z)" "$*" >>"$LOG"; }
+
+# Resolve a binary by name, falling back to common install dirs — hooks can run with a
+# minimal PATH (e.g. launched from the IDE).
+find_bin() {
+    command -v "$1" 2>/dev/null && return 0
+    for d in "$HOME/.local/bin" /opt/homebrew/bin /usr/local/bin "$HOME/go/bin" /usr/bin /bin; do
+        [ -x "$d/$1" ] && { printf '%s\n' "$d/$1"; return 0; }
+    done
+    return 1
+}
+
+worker() {
+    local funes
+    funes="$(find_bin funes || true)"
+    if [ -z "$funes" ] || [ ! -x "$funes" ]; then
+        log "index ABORT: funes not found; skipping."
+        return
+    fi
+
+    # Name the target explicitly: an automated (no-TTY) `funes index` refuses to run with
+    # no target, so this indexes only the named harness's sessions.
+    log "index[$HARNESS]: start"
+    if "$funes" index --harness "$HARNESS" >>"$LOG" 2>&1; then
+        log "index[$HARNESS]: ok"
+    else
+        log "index[$HARNESS]: FAILED (exit $?)"
+    fi
+}
+
+# Worker mode (re-exec): do the real work, already detached from the turn.
+# Invoked as: `$0 --worker <harness>`.
+if [ "${1:-}" = "--worker" ]; then
+    HARNESS="${2:-claude}"
+    worker
+    exit 0
+fi
+
+# Foreground: drain the hook payload on stdin, hand off to a detached worker, return.
+# The harness is our first argument (default `claude`). A `notify`-style caller that
+# appends its own JSON as a trailing argument is fine — we read only $1 here.
+HARNESS="${1:-claude}"
+cat >/dev/null
+nohup bash "$0" --worker "$HARNESS" >/dev/null 2>&1 </dev/null &
+disown 2>/dev/null || true
+exit 0

--- a/scripts/automation/funes-index.sh
+++ b/scripts/automation/funes-index.sh
@@ -5,7 +5,7 @@
 # to `claude`. One script serves every agent — Claude's Stop hook calls it with `claude`,
 # Codex's with `codex` — so there's a single implementation to maintain.
 #
-# Fired per turn (Claude's Stop hook, Codex's Stop hook), so the local index stays fresh
+# Fired per turn (Claude's Stop hook, Codex's Stop hook), so the local store stays fresh
 # as you work. `funes index` is incremental and idempotent — it re-embeds nothing already
 # stored — and indexing per turn yields the same chunks as indexing once per session,
 # since chunk ids derive from (session, turn, block, split). Publishing to the remote

--- a/scripts/automation/funes-push.sh
+++ b/scripts/automation/funes-push.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Publish the local funes index to the active remote.
+#
+# Fired by SessionEnd (publish what this session produced) AND SessionStart (catch up
+# anything a previous session left unpublished — its SessionEnd may never have fired
+# because the host was disconnected, the window closed, or the conversation was
+# switched away). Codex has no session-end event, so there it runs on SessionStart only.
+# The Stop hook (funes-index.sh) keeps the LOCAL index fresh per turn; this is the only
+# step that touches the network, so it runs at session boundaries, not per turn.
+#
+# Harness-agnostic: `funes push` publishes the whole local index, whatever produced it,
+# so this script takes no harness argument — one copy serves every agent.
+#
+# `funes push` is incremental and commit-guarded (it retries against a moved remote
+# head), so overlapping publishes — and a publish that overlaps an index — are safe;
+# no lock is needed. It has a fail-closed secret gate: a chunk holding a credential is
+# withheld (exit 2) rather than published. A first push to a store the local index
+# shares no chunks with is refused off a terminal — clear it once by hand (see setup).
+#
+# Runs detached so it never blocks session start/teardown or trips the hook timeout.
+
+set -uo pipefail
+
+LOG="$HOME/.claude/hooks/funes-sync.log"
+FUNES_HOME="${FUNES_HOME:-$HOME/.funes}"
+FUNES_JSON="$FUNES_HOME/funes.json"
+
+log() { printf '%s %s\n' "$(date +%Y-%m-%dT%H:%M:%S%z)" "$*" >>"$LOG"; }
+
+# Resolve a binary by name, falling back to common install dirs — hooks can run with a
+# minimal PATH (e.g. launched from the IDE).
+find_bin() {
+    command -v "$1" 2>/dev/null && return 0
+    for d in "$HOME/.local/bin" /opt/homebrew/bin /usr/local/bin "$HOME/go/bin" /usr/bin /bin; do
+        [ -x "$d/$1" ] && { printf '%s\n' "$d/$1"; return 0; }
+    done
+    return 1
+}
+
+worker() {
+    local funes rc remote
+    funes="$(find_bin funes || true)"
+    if [ -z "$funes" ] || [ ! -x "$funes" ]; then
+        log "push ABORT: funes not found; skipping."
+        return
+    fi
+
+    # Push only when a remote is attached, naming it explicitly so the target is
+    # unambiguous in the log and immune to the active store changing mid-run. A first
+    # push to a store this index shares no chunks with is refused here (the overlap
+    # guard fails closed off a terminal) — clear it once by hand: `funes push <repo>`.
+    remote="$(sed -n 's/.*"remote"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$FUNES_JSON" 2>/dev/null)"
+    if [ -z "$remote" ]; then
+        log "push: skipped (no remote attached — 'funes use <org>/<repo>' to enable)"
+        return
+    fi
+    log "push: start ($remote)"
+    "$funes" push "$remote" >>"$LOG" 2>&1
+    rc=$?
+    case "$rc" in
+        0) log "push: ok" ;;
+        2) log "push: WARN — secrets held back; run 'funes scrub', then it publishes next run" ;;
+        *) log "push: FAILED (exit $rc)" ;;
+    esac
+}
+
+# Worker mode (re-exec): do the real work, already detached from the session.
+if [ "${1:-}" = "--worker" ]; then
+    worker
+    exit 0
+fi
+
+# Foreground: drain the hook payload on stdin, hand off to a detached worker, return.
+cat >/dev/null
+nohup bash "$0" --worker >/dev/null 2>&1 </dev/null &
+disown 2>/dev/null || true
+exit 0

--- a/scripts/automation/funes-push.sh
+++ b/scripts/automation/funes-push.sh
@@ -1,20 +1,20 @@
 #!/usr/bin/env bash
-# Publish the local funes index to the active remote.
+# Publish the local funes store to the active remote store.
 #
 # Fired by SessionEnd (publish what this session produced) AND SessionStart (catch up
 # anything a previous session left unpublished — its SessionEnd may never have fired
 # because the host was disconnected, the window closed, or the conversation was
 # switched away). Codex has no session-end event, so there it runs on SessionStart only.
-# The Stop hook (funes-index.sh) keeps the LOCAL index fresh per turn; this is the only
+# The Stop hook (funes-index.sh) keeps the LOCAL store fresh per turn; this is the only
 # step that touches the network, so it runs at session boundaries, not per turn.
 #
-# Harness-agnostic: `funes push` publishes the whole local index, whatever produced it,
+# Harness-agnostic: `funes push` publishes the whole local store, whatever produced it,
 # so this script takes no harness argument — one copy serves every agent.
 #
 # `funes push` is incremental and commit-guarded (it retries against a moved remote
 # head), so overlapping publishes — and a publish that overlaps an index — are safe;
 # no lock is needed. It has a fail-closed secret gate: a chunk holding a credential is
-# withheld (exit 2) rather than published. A first push to a store the local index
+# withheld (exit 2) rather than published. A first push to a store your local store
 # shares no chunks with is refused off a terminal — clear it once by hand (see setup).
 #
 # Runs detached so it never blocks session start/teardown or trips the hook timeout.

--- a/src/hello.rs
+++ b/src/hello.rs
@@ -21,15 +21,16 @@ pub const PASSAGES: &[(&str, &str)] = &[
     ("user", "What is funes and how do I get started?"),
     (
         "assistant",
-        "funes gives an AI agent durable, mid-term memory of your past Claude Code sessions. It \
+        "funes gives an AI agent durable, mid-term memory of your past coding-agent sessions. It \
          indexes your transcripts locally and serves selective, reranked recall: you ask in \
          natural language and get back the few relevant passages with exact provenance — not a \
          flood of detail, and never an LLM-rewritten summary.",
     ),
     (
         "assistant",
-        "Build the index first: run `funes index`. It walks ~/.claude/projects, parses each \
-         session, and embeds the turns into a local store at ~/.funes. It's incremental — \
+        "Build the index first: run `funes index`. It walks ~/.claude/projects, \
+         ~/.codex/sessions, and ~/.pi/agent/sessions, parses each session, and embeds the turns \
+         into a local store at ~/.funes. It's incremental — \
          re-running it only adds new turns — so it's cheap to run often.",
     ),
     (
@@ -56,7 +57,7 @@ pub const PASSAGES: &[(&str, &str)] = &[
         "assistant",
         "Keep recall fresh. The index only updates when `funes index` runs, so the latest turns of \
          the current session aren't searchable until you re-run it. Re-run it periodically, or add \
-         a Claude Code Stop hook that runs `funes index` after each session.",
+         a session-end hook that runs `funes index` after each session (see docs/automation.md).",
     ),
     (
         "assistant",
@@ -74,6 +75,48 @@ pub const PASSAGES: &[(&str, &str)] = &[
          always rebuild from your transcripts. The transcripts are the source of truth.",
     ),
 ];
+
+/// A short, human-readable welcome shown by `funes guide`. It is the friendly counterpart to
+/// `recall`'s ranked, provenance-tagged output: that format is built for an agent to parse, and on
+/// a fresh install it makes a person work to read a scrambled list. A first-time human runs this
+/// instead. Kept separate from `PASSAGES` (which feeds the agent-facing recall fallback) so each
+/// can speak to its own audience.
+pub fn guide() -> String {
+    "\
+funes — durable, local memory for your AI coding agent
+
+funes indexes your past AI agent sessions and lets your agent recall its own decisions,
+rationale, and findings mid-task — the exact passages, with provenance, all on your machine.
+
+Getting started
+
+  1. Index your sessions       funes index
+     Sweeps ~/.claude/projects, ~/.codex/sessions, and ~/.pi/agent/sessions into one local
+     store. It's incremental, so it's cheap to re-run as you work.
+
+  2. Add funes to your agent    funes add <agent>
+     Works with claude, codex, pi, hermes, and opencode. Your agent gains `recall` and
+     `get` as tools and reaches for them on its own — no pasting context back in.
+
+  3. Just work.
+     When something touches a past decision, its rationale, or an earlier finding, your
+     agent recalls it for you — no re-pasting context.
+
+Once indexed, you can query the store yourself:
+
+  funes recall \"why did we switch off lancedb\"    ask in natural language
+  funes list                                       browse indexed sessions
+  funes status                                     what's indexed, and which store you're on
+
+Share across machines or a team (optional)
+
+  funes use <org>/<repo>    attach a Hugging Face dataset you own as your store
+  funes push                publish your local index to it
+
+Nothing leaves your machine until you run `funes push`.
+"
+    .to_string()
+}
 
 /// Build the corpus as an ephemeral lance dataset; the returned temp dir backs it (keep alive
 /// while reading). With an `embedder`, passages get real vectors for search; without, zeros.

--- a/src/hello.rs
+++ b/src/hello.rs
@@ -28,7 +28,7 @@ pub const PASSAGES: &[(&str, &str)] = &[
     ),
     (
         "assistant",
-        "Build the index first: run `funes index`. It walks ~/.claude/projects, \
+        "Build your store first: run `funes index`. It walks ~/.claude/projects, \
          ~/.codex/sessions, and ~/.pi/agent/sessions, parses each session, and embeds the turns \
          into a local store at ~/.funes. It's incremental — \
          re-running it only adds new turns — so it's cheap to run often.",
@@ -55,7 +55,7 @@ pub const PASSAGES: &[(&str, &str)] = &[
     ),
     (
         "assistant",
-        "Keep recall fresh. The index only updates when `funes index` runs, so the latest turns of \
+        "Keep recall fresh. Your store only updates when `funes index` runs, so the latest turns of \
          the current session aren't searchable until you re-run it. Re-run it periodically, or add \
          a session-end hook that runs `funes index` after each session (see docs/automation.md).",
     ),
@@ -63,7 +63,7 @@ pub const PASSAGES: &[(&str, &str)] = &[
         "assistant",
         "Optional, and later: share your memory across machines or a team via the Hugging Face \
          Hub. `funes use <org>/<repo>` attaches a dataset repo you own as your active store — \
-         recall then reads it, and `funes push` publishes your local index to it; `funes use \
+         recall then reads it, and `funes push` publishes your local store to it; `funes use \
          local` detaches. To query a different store for one call without changing your default, \
          pass `recall --remote <org>/<repo>`. You never need the Hub to use funes locally — it's \
          a tier you opt into.",
@@ -71,7 +71,7 @@ pub const PASSAGES: &[(&str, &str)] = &[
     (
         "assistant",
         "funes is local-first and deterministic: no LLM in the ingest path, the embedding model is \
-         pinned (BAAI/bge-small-en-v1.5), and the index is a disposable derived artifact you can \
+         pinned (BAAI/bge-small-en-v1.5), and the store is a disposable derived artifact you can \
          always rebuild from your transcripts. The transcripts are the source of truth.",
     ),
 ];
@@ -111,7 +111,7 @@ Once indexed, you can query the store yourself:
 Share across machines or a team (optional)
 
   funes use <org>/<repo>    attach a Hugging Face dataset you own as your store
-  funes push                publish your local index to it
+  funes push                publish your local store to it
 
 Your indexed sessions stay on your machine until you `funes push`.
 "

--- a/src/hello.rs
+++ b/src/hello.rs
@@ -113,7 +113,7 @@ Share across machines or a team (optional)
   funes use <org>/<repo>    attach a Hugging Face dataset you own as your store
   funes push                publish your local index to it
 
-Nothing leaves your machine until you run `funes push`.
+Your indexed sessions stay on your machine until you `funes push`.
 "
     .to_string()
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -7,7 +7,7 @@
 //! contributes just its new turns, nothing is re-embedded or deleted.
 
 use crate::harness::Harness;
-use crate::{chunk, dataset, hub, scan, source, trace};
+use crate::{chunk, dataset, hub, lock, scan, source, trace};
 use anyhow::{anyhow, Result};
 use arrow_array::types::Float32Type;
 use arrow_array::{Array, FixedSizeListArray, Int64Array, RecordBatch, RecordBatchIterator, StringArray};
@@ -298,6 +298,9 @@ async fn index_sources(sources: Vec<Box<dyn source::TraceSource>>, no_thinking: 
     let include_thinking = !no_thinking;
     let dir = dataset::funes_dir();
     std::fs::create_dir_all(&dir)?;
+
+    // Held for the whole run so the stored-id read and the appends below see one stable version.
+    let _lock = lock::StoreLock::acquire()?;
 
     let uri = dataset::table_uri(&dataset::local_store_dir());
     let ds = dataset::open(&uri, HashMap::new()).await.ok();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub mod hf_traces;
 pub mod hub;
 pub mod index;
 pub mod jsonl;
+pub mod lock;
 pub mod mcp;
 pub mod opencode;
 pub mod pi;

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -1,0 +1,42 @@
+//! Serializes writers to the local store: concurrent writers can lose, duplicate, or orphan rows
+//! (Lance's commit guard doesn't prevent it on a local dataset), so at most one mutates at a time. It
+//! lives in the binary, not a launcher script, so the rule holds for every writer however it started.
+//! An advisory `flock`, released on drop and on process death; contention fails loudly, never blocks.
+//! Readers take no lock — Lance gives each a consistent snapshot.
+
+use std::fs::{File, TryLockError};
+
+use anyhow::{bail, Context, Result};
+
+use crate::dataset;
+
+/// An exclusive advisory lock on the local store, released on drop (and on process death).
+#[derive(Debug)]
+pub struct StoreLock(#[allow(dead_code)] File);
+
+fn open_lockfile() -> Result<File> {
+    let dir = dataset::funes_dir();
+    std::fs::create_dir_all(&dir).with_context(|| format!("creating {}", dir.display()))?;
+    // A sibling of store/, not inside the Lance dataset, so version cleanup never reaps it.
+    let path = dir.join("store.lock");
+    File::options()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        .open(&path)
+        .with_context(|| format!("opening the store lock at {}", path.display()))
+}
+
+impl StoreLock {
+    /// Take the lock, or fail if another store operation holds it. Never blocks.
+    pub fn acquire() -> Result<Self> {
+        let f = open_lockfile()?;
+        match f.try_lock() {
+            Ok(()) => Ok(Self(f)),
+            Err(TryLockError::WouldBlock) => {
+                bail!("another funes store operation is in progress; retry once it finishes")
+            }
+            Err(TryLockError::Error(e)) => Err(e).context("locking the store"),
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,7 @@ enum Cmd {
         /// Restrict to a project (the path segment under `projects`).
         #[arg(long)]
         project: Option<String>,
-        /// Restrict to a harness: claude_code | codex | pi.
+        /// Restrict to a harness: claude | codex | pi.
         #[arg(long)]
         harness: Option<String>,
         #[command(flatten)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@
 //! `$FUNES_HOME` or `~/.funes`.
 
 use funes::harness::Harness;
-use funes::{claude, codex, config, hermes, hub, index, mcp, opencode, pi, push, recall, scrub, update};
+use funes::{claude, codex, config, hello, hermes, hub, index, mcp, opencode, pi, push, recall, scrub, update};
 
 use anyhow::{anyhow, Result};
 use clap::{Args, Parser, Subcommand};
@@ -21,6 +21,8 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Cmd {
+    /// Print a short, human-readable guide to funes — the friendly first run (no index needed).
+    Guide,
     /// Recall passages from past sessions (hybrid → rerank → recency → neighbors).
     Recall {
         /// What to recall (free text).
@@ -176,6 +178,10 @@ impl StoreOpts {
 #[tokio::main]
 async fn main() -> Result<()> {
     match Cli::parse().cmd {
+        Cmd::Guide => {
+            print!("{}", hello::guide());
+            Ok(())
+        }
         Cmd::Recall {
             query,
             k,

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,7 +75,7 @@ enum Cmd {
         #[command(flatten)]
         store: StoreOpts,
     },
-    /// Build or update the index from session transcripts.
+    /// Build or update your local store from session transcripts.
     Index {
         /// A transcript tree or `.parquet` file, or a Hub trace repo `<org>/<repo>`. Omit — in a
         /// terminal — to index every known harness dir (~/.claude/projects, ~/.codex/sessions,
@@ -105,15 +105,15 @@ enum Cmd {
     /// funes.json; honored by recall/push and the MCP server).
     Use {
         /// Remote to attach: `<org>/<repo>` (→ `hf://datasets/<org>/<repo>`) or a full `hf://…`
-        /// URI. Pass `local` to detach and go back to the local index.
+        /// URI. Pass `local` to detach and go back to your local store.
         store: String,
     },
-    /// Publish the local index's new chunks to a remote store on the HF Hub — the active remote by
+    /// Publish your local store's new chunks to a remote store on the HF Hub — the active store by
     /// default, or `[store]` to publish elsewhere.
     Push {
-        /// Store to publish to: `<org>/<repo>` or a full `hf://…` URI. Defaults to the active remote.
+        /// Store to publish to: `<org>/<repo>` or a full `hf://…` URI. Defaults to the active store.
         store: Option<String>,
-        /// Skip the confirmation when the target shares no chunks with your local index.
+        /// Skip the confirmation when the target shares no chunks with your local store.
         #[arg(short, long)]
         yes: bool,
         /// Refresh the remote index after pushing (retrying on conflict) even if the unindexed
@@ -121,7 +121,7 @@ enum Cmd {
         #[arg(long)]
         force_reindex: bool,
     },
-    /// Redact secrets from the local index in place — for rows indexed before redaction existed (or
+    /// Redact secrets from your local store in place — for rows indexed before redaction existed (or
     /// flagged by an updated ruleset); needs no source transcript. Cleans the local store only: it
     /// does NOT scrub an already-published remote, which the push gate can only stop adding to.
     Scrub,
@@ -164,7 +164,7 @@ enum AddAgent {
 #[derive(Args)]
 struct StoreOpts {
     /// A remote to read for this call — an `<org>/<repo>` shorthand or `hf://…` URI — overriding
-    /// the active store. Defaults to the active store, else the local index.
+    /// the active store. Defaults to the active store, else your local store.
     #[arg(long)]
     remote: Option<String>,
 }
@@ -295,7 +295,7 @@ async fn main() -> Result<()> {
             let remote = match store {
                 Some(s) => s,
                 None => config::load().remote.ok_or_else(|| {
-                    anyhow!("no active remote — attach one with `funes use <org>/<repo>`, or name a store: `funes push <org>/<repo>`")
+                    anyhow!("no active store — attach one with `funes use <org>/<repo>`, or name a store: `funes push <org>/<repo>`")
                 })?,
             };
             let confirm = if yes {
@@ -337,7 +337,7 @@ async fn use_store(spec: String) -> Result<()> {
     if spec == "local" {
         cfg.remote = None;
         config::save(&cfg)?;
-        println!("active store: local index");
+        println!("active store: local store");
         return Ok(());
     }
     let uri = match hub::Store::parse(&spec) {
@@ -345,7 +345,7 @@ async fn use_store(spec: String) -> Result<()> {
         hub::Store::Local { .. } => {
             return Err(anyhow!(
                 "`funes use` takes a remote (e.g. `acme/kb` or `hf://datasets/<org>/<repo>`); for the \
-                 local index use `funes use local`, or relocate funes's home with $FUNES_HOME"
+                 local store use `funes use local`, or relocate funes's home with $FUNES_HOME"
             ))
         }
     };
@@ -358,7 +358,7 @@ async fn use_store(spec: String) -> Result<()> {
     // heuristic and say what's wrong — caught here at attach time rather than at the next push.
     match hub::remote_reachability(&uri).await {
         hub::Reachability::Offline => {
-            println!("remote currently unreachable — recall will use your local index until it's back");
+            println!("remote currently unreachable — recall will use your local store until it's back");
             return Ok(());
         }
         hub::Reachability::Missing => {
@@ -378,20 +378,20 @@ async fn use_store(spec: String) -> Result<()> {
 /// The next-step hint for `funes use`.
 fn attach_hint(local: usize, remote: usize, unpushed: usize) -> String {
     if local == 0 && remote == 0 {
-        "no memories indexed yet — run `funes index` to build your local index, then `funes push` to publish it here."
+        "no memories indexed yet — run `funes index` to build your local store, then `funes push` to publish it here."
             .to_string()
     } else if local == 0 {
         format!("the remote holds {remote} chunks — recall reads them now. if you own this remote store, run `funes index` then `funes push` to add this machine's sessions.")
     } else if unpushed == 0 {
-        format!("local index: {local} chunks, all present on the remote.")
+        format!("local store: {local} chunks, all present on the remote.")
     } else if remote == 0 {
-        format!("local index: {local} chunks, none on the remote yet — run `funes push`.")
+        format!("local store: {local} chunks, none on the remote yet — run `funes push`.")
     } else if local > unpushed {
         // Shares chunks with the remote → it's yours to add to; publish the extras.
-        format!("local index: {local} chunks, {unpushed} not yet on the remote — run `funes push`.")
+        format!("local store: {local} chunks, {unpushed} not yet on the remote — run `funes push`.")
     } else {
         // No shared chunks with a populated remote: a fresh host of yours, or a store you only read.
-        format!("local index: {local} chunks, remote: {remote} — no shared chunks: a new host of yours, or a store you only read. `funes push` to contribute, skip if it's not yours.")
+        format!("local store: {local} chunks, remote: {remote} — no shared chunks: a new host of yours, or a store you only read. `funes push` to contribute, skip if it's not yours.")
     }
 }
 
@@ -401,13 +401,13 @@ fn attach_hint(local: usize, remote: usize, unpushed: usize) -> String {
 fn prompt_new_store(label: &str, chunks: usize) -> bool {
     if !std::io::stdin().is_terminal() {
         eprintln!(
-            "refusing to push {chunks} chunk(s) to {label}: your local index shares no chunks with it \
+            "refusing to push {chunks} chunk(s) to {label}: your local store shares no chunks with it \
              (a first push, a new host, or the wrong store) — re-run with `--yes` to confirm."
         );
         return false;
     }
     eprint!(
-        "{label}: your local index shares no chunks with it — a first push here, a new host of yours, \
+        "{label}: your local store shares no chunks with it — a first push here, a new host of yours, \
          or the wrong store. Publish {chunks} chunk(s) anyway? [y/N] "
     );
     let _ = std::io::stderr().flush();

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -21,7 +21,7 @@ pub struct RecallRequest {
     pub block_type: Option<String>,
     #[schemars(description = "Restrict to a project (the directory segment under `projects`)")]
     pub project: Option<String>,
-    #[schemars(description = "Restrict to a harness: claude_code | codex | pi")]
+    #[schemars(description = "Restrict to a harness: claude | codex | pi")]
     pub harness: Option<String>,
 }
 

--- a/src/recall.rs
+++ b/src/recall.rs
@@ -5,6 +5,7 @@
 
 use crate::chunk;
 use crate::dataset;
+use crate::harness::Harness;
 use crate::hello;
 use crate::hub::{self, Reachability, Store};
 use anyhow::{anyhow, Context, Result};
@@ -267,6 +268,14 @@ pub async fn recall(
     project: Option<String>,
     harness: Option<String>,
 ) -> Result<String> {
+    // `--harness` accepts the same spellings as `index`/`add` (claude|codex|pi); normalize to the
+    // stored facet (Claude's is `claude_code`) so `--harness claude` filters instead of silently
+    // matching nothing, and an unknown value errors here rather than returning zero hits.
+    let harness = harness
+        .map(|h| Harness::parse(&h))
+        .transpose()?
+        .map(|h| h.as_str().to_string());
+
     let mut guard = models().await?.lock().await;
     let Models { embedder, reranker } = &mut *guard;
 

--- a/src/recall.rs
+++ b/src/recall.rs
@@ -218,7 +218,7 @@ async fn degrade_offline(uri: &str, embedder: Option<&mut TextEmbedding>) -> Res
         Ok(ReadOutcome::Ready(ds)) => Ok(Read {
             _hello: None,
             ds,
-            note: Some(format!("remote {uri} unreachable — recalling from your local index\n")),
+            note: Some(format!("remote {uri} unreachable — recalling from your local store\n")),
         }),
         _ => {
             let (dir, ds) = hello::dataset(embedder).await?;
@@ -226,7 +226,7 @@ async fn degrade_offline(uri: &str, embedder: Option<&mut TextEmbedding>) -> Res
                 _hello: Some(dir),
                 ds,
                 note: Some(format!(
-                    "remote {uri} unreachable and no local index yet — showing the built-in guide\n"
+                    "remote {uri} unreachable and no local store yet — showing the built-in guide\n"
                 )),
             })
         }
@@ -722,14 +722,14 @@ pub async fn status(store: Store) -> Result<String> {
         ReadOutcome::Offline => {
             let body = Box::pin(status(Store::local())).await?;
             Ok(format!(
-                "remote {} unreachable — showing the local index instead\n{body}",
+                "remote {} unreachable — showing your local store instead\n{body}",
                 store.label()
             ))
         }
         // No personal index yet: point at `funes index` instead of erroring. (recall/get/list
         // quietly serve the built-in guide in the same situation.)
         ReadOutcome::NoIndex => Ok(format!(
-            "store: {}\nno personal index yet — showing the built-in guide ({} passages).\nrun `funes index` to index ~/.claude/projects, then recall your own history.\n",
+            "store: {}\nno personal store yet — showing the built-in guide ({} passages).\nrun `funes index` to index ~/.claude/projects, then recall your own history.\n",
             store.label(),
             hello::PASSAGES.len()
         )),

--- a/src/scrub.rs
+++ b/src/scrub.rs
@@ -23,7 +23,7 @@ pub async fn run() -> Result<()> {
     let _lock = lock::StoreLock::acquire()?;
     let uri = dataset::table_uri(&dataset::local_store_dir());
     let Ok(ds) = dataset::open(&uri, HashMap::new()).await else {
-        println!("no local index to scrub");
+        println!("no local store to scrub");
         return Ok(());
     };
     let scanner = scan::Trufflehog::find()?;

--- a/src/scrub.rs
+++ b/src/scrub.rs
@@ -3,7 +3,7 @@
 //! re-indexing cannot. Operates only on the local store; it does not touch a published remote.
 
 use crate::index::{build_batch, embed_batched, schema};
-use crate::{chunk, dataset, scan};
+use crate::{chunk, dataset, lock, scan};
 use anyhow::Result;
 use arrow_array::{BooleanArray, RecordBatch, RecordBatchIterator};
 use arrow_select::filter::filter_record_batch;
@@ -19,6 +19,8 @@ use std::time::Instant;
 /// (e.g. a key stored with escaped `\n`) — drop the block whole. Fail-closed on the scanner:
 /// scrubbing is the whole point.
 pub async fn run() -> Result<()> {
+    // scrub rewrites the whole table, so hold the store lock to be the sole writer.
+    let _lock = lock::StoreLock::acquire()?;
     let uri = dataset::table_uri(&dataset::local_store_dir());
     let Ok(ds) = dataset::open(&uri, HashMap::new()).await else {
         println!("no local index to scrub");

--- a/tests/store_lock.rs
+++ b/tests/store_lock.rs
@@ -1,4 +1,4 @@
-//! The in-binary store lock serializes local-store mutations, failing loudly on contention. Own test
+//! The in-binary store lock serializes local-store mutations, failing loudly on contention. Its own test
 //! binary so its `$FUNES_HOME` can't race another integration test's. `flock` treats independent
 //! `open()`s of the same file as contending — even within one process (flock(2)) — so a single
 //! process can hold the lock and then observe the contention paths without spawning `funes`

--- a/tests/store_lock.rs
+++ b/tests/store_lock.rs
@@ -1,0 +1,35 @@
+//! The in-binary store lock serializes local-store mutations, failing loudly on contention. Own test
+//! binary so its `$FUNES_HOME` can't race another integration test's. `flock` treats independent
+//! `open()`s of the same file as contending — even within one process (flock(2)) — so a single
+//! process can hold the lock and then observe the contention paths without spawning `funes`
+//! subprocesses.
+
+use funes::lock::StoreLock;
+
+#[tokio::test]
+async fn store_lock_fails_loudly_on_contention() {
+    let home = tempfile::tempdir().unwrap();
+    std::env::set_var("FUNES_HOME", home.path());
+
+    // Hold the store lock, then observe every writer refuse rather than wait or skip.
+    let held = StoreLock::acquire().unwrap();
+
+    // A second acquire fails loudly.
+    let err = StoreLock::acquire().unwrap_err();
+    assert!(
+        err.to_string().contains("another funes store operation is in progress"),
+        "acquire should report contention, got: {err}"
+    );
+
+    // scrub refuses while the lock is held (its guard is the same acquire).
+    let err = funes::scrub::run().await.unwrap_err();
+    assert!(
+        err.to_string().contains("another funes store operation is in progress"),
+        "scrub should report contention, got: {err}"
+    );
+
+    // Releasing frees it for the next writer.
+    drop(held);
+    let regained = StoreLock::acquire().unwrap();
+    drop(regained);
+}


### PR DESCRIPTION
This pull request updates the documentation to clarify terminology, improve instructions, and simplify the setup process for funes. The main focus is to consistently use "store" instead of "index", clarify the agent-agnostic and local-first nature of funes, and streamline the automation scripts section by replacing lengthy inline scripts with references to reusable scripts. The changes also improve explanations of sharing, caching, and security.
Finally, this protects all write operations to a store behind a lock, and adds a `funes guide` CLI comment to ease onboarding. 

