### PR TITLE
Rename --remote to --store and expose it in the MCP server tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,10 +114,10 @@ funes use local            # detach — back to your local store
 ```
 
 To query a **different remote for a single call** — say, someone's published memories on a topic —
-without changing your default, pass `--remote`:
+without changing your default, pass `--store`:
 
 ```bash
-funes recall "..." --remote other-org/subject-kb
+funes recall "..." --store other-org/subject-kb
 ```
 
 ![Attaching a shared Hugging Face dataset with funes use, then pi recalling a decision from a project this machine never worked on](docs/img/hub-store.gif)

--- a/integrations/pi/README.md
+++ b/integrations/pi/README.md
@@ -36,6 +36,7 @@ zero-config discovery, or load it for a single run with `pi -e ./integrations/pi
 - `funes` on `PATH` (set `FUNES_BIN` to override the binary path).
 - A funes store the binary can read — local, or a live `hf://` remote configured
   via `FUNES_HOME`/`funes.json` (needs network + an HF token for a private remote).
+  Set `FUNES_STORE` to pin one explicitly — forwarded as `funes mcp --store <spec>`.
 
 `typebox` and the pi SDK are provided by pi's loader, so the extension declares
 no dependencies.

--- a/integrations/pi/README.md
+++ b/integrations/pi/README.md
@@ -10,23 +10,21 @@ just fronted by a thin pi tool.
 
 ## Install
 
-Once `funes` is on your PATH, one command extracts this extension and registers
-it with pi. It installs into the current project by default; add `-g` to make
-it available in every project:
+Once `funes` is on your PATH, one command extracts this extension to a fixed
+`~/.funes/integrations/pi` and registers it with pi, user-wide:
 
 ```sh
-funes add pi        # this project (.pi/settings.json)
-funes add pi -g     # all projects (user-wide)
+funes add pi
 ```
 
 funes embeds the extension in its binary, so this always matches the installed
 funes version — no separate package to fetch, and a re-run after an upgrade
-re-extracts the refreshed copy automatically. (`--dest` extracts elsewhere;
-`--force` rewrites even when the on-disk copy is already current.)
+re-extracts the refreshed copy automatically (`--force` rewrites even when the
+on-disk copy is already current).
 
 For development from a funes checkout you can also install the package directly
-with `pi install ./integrations/pi`, drop it under `<cwd>/.pi/extensions/` for
-zero-config discovery, or load it for a single run with `pi -e ./integrations/pi`.
+with `pi install ./integrations/pi`, or load it for a single run with
+`pi -e ./integrations/pi`.
 
 > There's no `pi install git:…/funes`: pi has no subdir/monorepo install syntax,
 > and the funes repo root is a Cargo project rather than a pi package.

--- a/integrations/pi/index.ts
+++ b/integrations/pi/index.ts
@@ -186,7 +186,7 @@ export default function (pi: any) {
     description:
       "Drill down on a recall hit: fetch the named turn plus the turns around it, reassembled " +
       "into readable text. Pass the `session_id` and `turn_uuid` from a recall hit's `→ get` line — " +
-      "and if the hit came from an explicit `store`, the same `store`.",
+      "and the `store` it names.",
     parameters: Type.Object({
       session_id: Type.String({ description: "Session id from a recall hit's `→ get` line" }),
       turn_uuid: Type.String({ description: "Turn uuid from a recall hit's `→ get` line" }),

--- a/integrations/pi/index.ts
+++ b/integrations/pi/index.ts
@@ -14,11 +14,13 @@
 // `funes` is taken from PATH; set FUNES_BIN to override — e.g. inside an
 // agentcap sandbox, --tool-dir puts the bundle's `funes` wrapper on PATH (which
 // also points FASTEMBED_CACHE_DIR at the prewarmed cache and FUNES_HOME at the
-// live-remote config).
+// live-remote config). FUNES_STORE, if set, is forwarded as `funes mcp --store
+// <spec>` — pinning the server to that store instead of the active one.
 import { Type } from "typebox";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 
 const FUNES_BIN = process.env.FUNES_BIN || "funes";
+const FUNES_ARGS = process.env.FUNES_STORE ? ["mcp", "--store", process.env.FUNES_STORE] : ["mcp"];
 const PROTOCOL_VERSION = "2024-11-05"; // matches funes' rmcp server
 const CALL_TIMEOUT_MS = 120_000;
 
@@ -35,7 +37,7 @@ class FunesMcp {
 
   private ensureStarted(): Promise<void> {
     if (this.child && this.ready) return this.ready;
-    const child = spawn(FUNES_BIN, ["mcp"], { stdio: ["pipe", "pipe", "pipe"] });
+    const child = spawn(FUNES_BIN, FUNES_ARGS, { stdio: ["pipe", "pipe", "pipe"] });
     this.child = child;
     // The server is kept warm for the whole session, so unref it (and its pipes)
     // — an in-flight call's timer keeps the loop alive, but once the agent's turn
@@ -162,13 +164,20 @@ export default function (pi: any) {
       "discussed in an earlier session rather than the current files, or before asserting the " +
       "history of anything. Recall subject-matter too, not only decisions: before re-deriving how " +
       "an API or system behaves — or anything a past session (often a research subagent) " +
-      "investigated — query the topic itself; recall surfaces those findings.",
+      "investigated — query the topic itself; recall surfaces those findings. To recall from a " +
+      "different store than the server's default, pass `store`.",
     parameters: Type.Object({
       query: Type.String({ description: "Natural-language search query" }),
       k: Type.Optional(Type.Number({ description: "Number of results (default 8)" })),
+      store: Type.Optional(
+        Type.String({
+          description:
+            "Store to read for this call — `<org>/<repo>`, an `hf://…` URI, a local path, or `local`. Defaults to the server's store.",
+        }),
+      ),
     }),
-    execute: (_id: string, params: { query: string; k?: number }) =>
-      call("recall", { query: params.query, k: params.k }),
+    execute: (_id: string, params: { query: string; k?: number; store?: string }) =>
+      call("recall", { query: params.query, k: params.k, store: params.store }),
   });
 
   pi.registerTool({
@@ -176,13 +185,22 @@ export default function (pi: any) {
     label: "Recall: get",
     description:
       "Drill down on a recall hit: fetch the named turn plus the turns around it, reassembled " +
-      "into readable text. Pass the `session_id` and `turn_uuid` from a recall hit's `→ get` line.",
+      "into readable text. Pass the `session_id` and `turn_uuid` from a recall hit's `→ get` line — " +
+      "and if the hit came from an explicit `store`, the same `store`.",
     parameters: Type.Object({
       session_id: Type.String({ description: "Session id from a recall hit's `→ get` line" }),
       turn_uuid: Type.String({ description: "Turn uuid from a recall hit's `→ get` line" }),
       window: Type.Optional(Type.Number({ description: "Turns within this window are included (default 3)" })),
+      store: Type.Optional(
+        Type.String({ description: "Store to read for this call — the one the recall hit came from" }),
+      ),
     }),
-    execute: (_id: string, params: { session_id: string; turn_uuid: string; window?: number }) =>
-      call("get", { session_id: params.session_id, turn_uuid: params.turn_uuid, window: params.window }),
+    execute: (_id: string, params: { session_id: string; turn_uuid: string; window?: number; store?: string }) =>
+      call("get", {
+        session_id: params.session_id,
+        turn_uuid: params.turn_uuid,
+        window: params.window,
+        store: params.store,
+      }),
   });
 }

--- a/integrations/pi/index.ts
+++ b/integrations/pi/index.ts
@@ -8,8 +8,7 @@
 // it consumes the same `funes mcp` surface every other agent integration uses.
 //
 // Install:  funes add pi   — or, from a funes checkout, `pi install
-// ./integrations/pi`, or drop this dir under <cwd>/.pi/extensions/ for
-// zero-config discovery.
+// ./integrations/pi`, or `pi -e ./integrations/pi` for a single run.
 //
 // `funes` is taken from PATH; set FUNES_BIN to override — e.g. inside an
 // agentcap sandbox, --tool-dir puts the bundle's `funes` wrapper on PATH (which

--- a/src/hello.rs
+++ b/src/hello.rs
@@ -65,7 +65,7 @@ pub const PASSAGES: &[(&str, &str)] = &[
          Hub. `funes use <org>/<repo>` attaches a dataset repo you own as your active store — \
          recall then reads it, and `funes push` publishes your local store to it; `funes use \
          local` detaches. To query a different store for one call without changing your default, \
-         pass `recall --remote <org>/<repo>`. You never need the Hub to use funes locally — it's \
+         pass `recall --store <org>/<repo>`. You never need the Hub to use funes locally — it's \
          a tier you opt into.",
     ),
     (

--- a/src/hub.rs
+++ b/src/hub.rs
@@ -56,7 +56,7 @@ impl Store {
         }
     }
 
-    /// Resolve the store the read commands should use: an explicit `spec` (a CLI `--remote`) wins,
+    /// Resolve the store the read commands should use: an explicit `spec` (a CLI `--store`) wins,
     /// else the persisted active store (`funes use`), else the local index.
     pub fn resolve(spec: Option<String>) -> Self {
         resolve_with(spec, config::load().remote)

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,15 +163,15 @@ enum AddAgent {
 /// Which store the read commands act on. Shared by `recall`/`list`/`get`/`status`.
 #[derive(Args)]
 struct StoreOpts {
-    /// A remote to read for this call — an `<org>/<repo>` shorthand or `hf://…` URI — overriding
-    /// the active store. Defaults to the active store, else your local store.
+    /// The store to read — an `<org>/<repo>` shorthand, an `hf://…` URI, a local path, or `local`
+    /// — overriding the active store. Defaults to the active store, else your local store.
     #[arg(long)]
-    remote: Option<String>,
+    store: Option<String>,
 }
 
 impl StoreOpts {
     fn resolve(self) -> hub::Store {
-        hub::Store::resolve(self.remote)
+        hub::Store::resolve(self.store)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,7 +133,10 @@ enum Cmd {
         force: bool,
     },
     /// Run as an MCP server over stdio (for Claude Code, Cursor, …).
-    Mcp,
+    Mcp {
+        #[command(flatten)]
+        store: StoreOpts,
+    },
     /// Add funes to a coding agent.
     #[command(subcommand_value_name = "AGENT", subcommand_help_heading = "Agents")]
     Add {
@@ -160,7 +163,7 @@ enum AddAgent {
     Opencode,
 }
 
-/// Which store the read commands act on. Shared by `recall`/`list`/`get`/`status`.
+/// Which store the read commands act on. Shared by `recall`/`list`/`get`/`status` and `mcp`.
 #[derive(Args)]
 struct StoreOpts {
     /// The store to read — an `<org>/<repo>` shorthand, an `hf://…` URI, a local path, or `local`
@@ -320,7 +323,9 @@ async fn main() -> Result<()> {
         }
         Cmd::Scrub => scrub::run().await,
         Cmd::Update { force } => update::run(force).await,
-        Cmd::Mcp => mcp::run().await,
+        Cmd::Mcp {
+            store: StoreOpts { store },
+        } => mcp::run(store).await,
         Cmd::Add { agent } => match agent {
             AddAgent::Claude => claude::install(),
             AddAgent::Codex => codex::install(),

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -23,6 +23,10 @@ pub struct RecallRequest {
     pub project: Option<String>,
     #[schemars(description = "Restrict to a harness: claude | codex | pi")]
     pub harness: Option<String>,
+    #[schemars(
+        description = "Store to read for this call — `<org>/<repo>`, an `hf://…` URI, a local path, or `local`. Defaults to the server's store."
+    )]
+    pub store: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
@@ -33,24 +37,46 @@ pub struct GetRequest {
     pub turn_uuid: String,
     #[schemars(description = "Turns within this seq window of the target are included (default 3)")]
     pub window: Option<i64>,
+    #[schemars(
+        description = "Store to read for this call — pass the same `store` the recall hit came from. Defaults to the server's store."
+    )]
+    pub store: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct StatusRequest {
+    #[schemars(
+        description = "Store to inspect — `<org>/<repo>`, an `hf://…` URI, a local path, or `local`. Defaults to the server's store."
+    )]
+    pub store: Option<String>,
 }
 
 #[derive(Clone)]
 pub(crate) struct Funes {
+    /// Explicit store spec (`funes mcp --store`), pinned for the server's lifetime. `None` keeps
+    /// resolution per call, so `funes use` takes effect on a running server without a restart.
+    store: Option<String>,
     #[allow(dead_code)]
     tool_router: ToolRouter<Funes>,
 }
 
 #[tool_router]
 impl Funes {
-    fn new() -> Self {
+    fn new(store: Option<String>) -> Self {
         Self {
+            store,
             tool_router: Self::tool_router(),
         }
     }
 
+    /// The store a call reads: its explicit `store` argument wins over the server's `--store`,
+    /// then the usual resolution (active store, else local).
+    fn store(&self, spec: Option<String>) -> Store {
+        Store::resolve(spec.filter(|s| !s.trim().is_empty()).or_else(|| self.store.clone()))
+    }
+
     #[tool(
-        description = "Recall decisions, rationale, and context from the user's past AI agent sessions. Returns ranked passages with provenance (timestamp, session, block type) plus surrounding neighbor chunks. Each hit carries a `→ get <session_id> <turn_uuid>` line — call `get` with those to read the full surrounding turns. Use when the user references earlier work, or when you lack context that may exist in a prior session. Recall subject-matter, not only decisions: before re-deriving how an API, library, or system behaves — or anything a past session already investigated — query the topic itself; research subagents accumulate exactly these findings and recall surfaces them, often as the top hit, so check before re-investigating from scratch. Also recall before asserting the history of anything — that it was never built, was dropped, is out of scope, or was never discussed; a confident claim about a past decision is the cue you're missing context this holds."
+        description = "Recall decisions, rationale, and context from the user's past AI agent sessions. Returns ranked passages with provenance (timestamp, session, block type) plus surrounding neighbor chunks. Each hit carries a `→ get <session_id> <turn_uuid>` line — call `get` with those to read the full surrounding turns. Use when the user references earlier work, or when you lack context that may exist in a prior session. Recall subject-matter, not only decisions: before re-deriving how an API, library, or system behaves — or anything a past session already investigated — query the topic itself; research subagents accumulate exactly these findings and recall surfaces them, often as the top hit, so check before re-investigating from scratch. Also recall before asserting the history of anything — that it was never built, was dropped, is out of scope, or was never discussed; a confident claim about a past decision is the cue you're missing context this holds. To recall from a different store than the server's default (e.g. a shared `<org>/<repo>` dataset on the HF Hub), pass `store` — no CLI needed."
     )]
     async fn recall(
         &self,
@@ -60,10 +86,11 @@ impl Funes {
             block_type,
             project,
             harness,
+            store,
         }): Parameters<RecallRequest>,
     ) -> String {
         match recall::recall(
-            Store::resolve(None),
+            self.store(store),
             query,
             k.unwrap_or(8),
             30,
@@ -82,7 +109,7 @@ impl Funes {
     }
 
     #[tool(
-        description = "Drill down on a recall hit: fetch the named turn plus the turns within `window` of it, each reassembled into readable text. Pass the `session_id` and `turn_uuid` from a recall hit's `→ get` line."
+        description = "Drill down on a recall hit: fetch the named turn plus the turns within `window` of it, each reassembled into readable text. Pass the `session_id` and `turn_uuid` from a recall hit's `→ get` line — and if the hit came from an explicit `store`, the same `store`."
     )]
     async fn get(
         &self,
@@ -90,9 +117,10 @@ impl Funes {
             session_id,
             turn_uuid,
             window,
+            store,
         }): Parameters<GetRequest>,
     ) -> String {
-        match recall::get(Store::resolve(None), session_id, turn_uuid, window.unwrap_or(3)).await {
+        match recall::get(self.store(store), session_id, turn_uuid, window.unwrap_or(3)).await {
             Ok(s) if !s.is_empty() => s,
             Ok(_) => "no results".to_string(),
             Err(e) => format!("get error: {e}"),
@@ -100,10 +128,10 @@ impl Funes {
     }
 
     #[tool(description = "Show funes index statistics (chunk count and store).")]
-    async fn status(&self) -> String {
+    async fn status(&self, Parameters(StatusRequest { store }): Parameters<StatusRequest>) -> String {
         // No update check here: it needs the network, and the "update available" notice belongs
         // on the human-facing CLI `funes status`, not on this hot, otherwise-local tool path.
-        recall::status(Store::resolve(None))
+        recall::status(self.store(store))
             .await
             .unwrap_or_else(|e| format!("status error: {e}"))
     }
@@ -126,14 +154,15 @@ impl ServerHandler for Funes {
                  about a past decision is the cue to recall first. Recall subject-matter too, not \
                  only decisions: before re-deriving how an API, library, or system behaves — or \
                  anything a prior session (often a research subagent) investigated — query the \
-                 topic itself; recall surfaces those findings. Drill into a hit with `get`."
+                 topic itself; recall surfaces those findings. Drill into a hit with `get`. Both \
+                 take an optional `store` to read a different store for one call."
                     .to_string(),
             )
     }
 }
 
-pub async fn run() -> Result<()> {
-    let service = Funes::new().serve(stdio()).await?;
+pub async fn run(store: Option<String>) -> Result<()> {
+    let service = Funes::new(store).serve(stdio()).await?;
     service.waiting().await?;
     Ok(())
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -38,7 +38,7 @@ pub struct GetRequest {
     #[schemars(description = "Turns within this seq window of the target are included (default 3)")]
     pub window: Option<i64>,
     #[schemars(
-        description = "Store to read for this call — pass the same `store` the recall hit came from. Defaults to the server's store."
+        description = "Store to read for this call — the one the recall hit's `→ get` line names. Defaults to the server's store."
     )]
     pub store: Option<String>,
 }
@@ -109,7 +109,7 @@ impl Funes {
     }
 
     #[tool(
-        description = "Drill down on a recall hit: fetch the named turn plus the turns within `window` of it, each reassembled into readable text. Pass the `session_id` and `turn_uuid` from a recall hit's `→ get` line — and if the hit came from an explicit `store`, the same `store`."
+        description = "Drill down on a recall hit: fetch the named turn plus the turns within `window` of it, each reassembled into readable text. Pass the `session_id` and `turn_uuid` from a recall hit's `→ get` line — and the `store` it names."
     )]
     async fn get(
         &self,

--- a/src/recall.rs
+++ b/src/recall.rs
@@ -121,6 +121,9 @@ struct Read {
     /// A degradation note to prepend to the command's output (e.g. the remote was unreachable);
     /// `None` when the requested store opened normally.
     note: Option<String>,
+    /// Label of the store the dataset actually came from (the requested one, or the local store
+    /// after an offline degrade); `None` for the built-in guide.
+    store_label: Option<String>,
 }
 
 /// The outcome of resolving a store for reading. The embedder-backed fallbacks (`Offline` → the
@@ -198,6 +201,7 @@ async fn open_read(store: &Store, embedder: Option<&mut TextEmbedding>) -> Resul
             _hello: None,
             ds,
             note: None,
+            store_label: Some(store.label()),
         }),
         ReadOutcome::Offline => degrade_offline(&store.label(), embedder).await,
         ReadOutcome::NoIndex => {
@@ -206,6 +210,7 @@ async fn open_read(store: &Store, embedder: Option<&mut TextEmbedding>) -> Resul
                 _hello: Some(dir),
                 ds,
                 note: None,
+                store_label: None,
             })
         }
     }
@@ -219,6 +224,7 @@ async fn degrade_offline(uri: &str, embedder: Option<&mut TextEmbedding>) -> Res
             _hello: None,
             ds,
             note: Some(format!("remote {uri} unreachable — recalling from your local store\n")),
+            store_label: Some(Store::local().label()),
         }),
         _ => {
             let (dir, ds) = hello::dataset(embedder).await?;
@@ -228,8 +234,18 @@ async fn degrade_offline(uri: &str, embedder: Option<&mut TextEmbedding>) -> Res
                 note: Some(format!(
                     "remote {uri} unreachable and no local store yet — showing the built-in guide\n"
                 )),
+                store_label: None,
             })
         }
+    }
+}
+
+/// The store suffix for a hit's `→ get` hint: every hit names the store it was read from, so the
+/// hint drills into that store from any context. The built-in guide has no store to name.
+fn store_hint(read: Option<&str>) -> String {
+    match read {
+        Some(label) => format!(" --store {label}"),
+        None => String::new(),
     }
 }
 
@@ -333,6 +349,7 @@ pub async fn recall(
         attach_neighbors(ds, &mut refs, neighbors).await?;
     }
 
+    let store_arg = store_hint(read.store_label.as_deref());
     let mut out = note;
     for (h, score) in &top {
         let s8 = &h.session_id[..h.session_id.len().min(8)];
@@ -341,7 +358,7 @@ pub async fn recall(
             "[{}] {} {}/{} {}  score={:.3}",
             h.ts, h.harness, h.project, s8, h.block_type, score
         );
-        let _ = writeln!(out, "  → get {} {}", h.session_id, h.turn_uuid);
+        let _ = writeln!(out, "  → get {} {}{}", h.session_id, h.turn_uuid, store_arg);
         let preview: String = h.text.chars().take(400).collect();
         let _ = writeln!(out, "{preview}");
         for n in &h.neighbors {
@@ -778,6 +795,16 @@ mod tests {
     fn esc_doubles_single_quotes() {
         assert_eq!(esc("o'brien"), "o''brien");
         assert_eq!(esc("plain"), "plain");
+    }
+
+    #[test]
+    fn store_hint_names_the_read_store() {
+        assert_eq!(
+            store_hint(Some("hf://datasets/acme/kb")),
+            " --store hf://datasets/acme/kb"
+        );
+        // The built-in guide has no store to name.
+        assert_eq!(store_hint(None), "");
     }
 
     #[test]

--- a/tests/index_recall.rs
+++ b/tests/index_recall.rs
@@ -84,4 +84,44 @@ async fn index_then_read_surface() {
         .await
         .unwrap();
     assert!(got.contains("typed blocks"), "get should return the turn text: {got}");
+
+    // Every hit names the store it was read from — the default store and an explicit one alike.
+    let default_hint = format!("--store {}", db_dir.path().join("store").display());
+    assert!(
+        out.contains(&default_hint),
+        "hits should carry the read store `{default_hint}`: {out}"
+    );
+    let store2 = db_dir.path().join("store2");
+    copy_dir(&db_dir.path().join("store"), &store2);
+    let out2 = funes::recall::recall(
+        funes::hub::Store::parse(&store2.to_string_lossy()),
+        "parse transcripts into turns".into(),
+        5,
+        30,
+        30.0,
+        1,
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let hint = format!("--store {}", store2.display());
+    assert!(
+        out2.contains(&hint),
+        "explicit-store hits should carry `{hint}`: {out2}"
+    );
+}
+
+fn copy_dir(src: &std::path::Path, dst: &std::path::Path) {
+    std::fs::create_dir_all(dst).unwrap();
+    for e in std::fs::read_dir(src).unwrap() {
+        let e = e.unwrap();
+        let to = dst.join(e.file_name());
+        if e.file_type().unwrap().is_dir() {
+            copy_dir(&e.path(), &to);
+        } else {
+            std::fs::copy(e.path(), &to).unwrap();
+        }
+    }
 }


### PR DESCRIPTION
This renames the `--remote` flag to `--store`, and exposes it to the MCP server.

You can now tell your agent to target a specific remote store when fetching memories.