### PR TITLE
Human friendly recall get

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,77 @@
+# funes — agent notes
+
+Read this before changing the code or parsing funes output. The [README](README.md) explains what
+funes is, for humans; this file holds the **interface contract** the read commands expose and the
+**decisions that already hardened**.
+
+## The read interface
+
+Every read command has two renderings: **agent** — the stable contract below — and **human** —
+terminal presentation that is deliberately unstable; never parse it. Selection: human when both
+stdin and stdout are terminals, agent otherwise; `--format human|agent` overrides. The MCP server
+always returns agent-format strings.
+
+### recall
+
+`funes recall "<free text>" [flags]` — hybrid retrieval (vector + BM25, fused by reciprocal
+rank) → cross-encoder rerank → recency reweight → neighbor expansion. Agent format, per hit:
+
+```
+[<ts>] <harness> <project>/<session8> <block_type>  score=<s.sss>
+  → get <session_id> <turn_uuid> --store <label>
+<the chunk, first 400 chars>
+  ~ [<role> <block_type> seq<N>] <neighbor chunk, first 160 chars>
+---
+```
+
+`no results` when nothing matched. The `→ get` line carries exactly the arguments `get` wants —
+including the store the hits were actually read from (an offline degrade names the local store it
+fell back to; the built-in guide has no store to name and keeps a bare hint).
+
+| Flag | Default | Meaning |
+| --- | --- | --- |
+| `-k` | 8 | hits returned |
+| `--candidates` | 30 | fused pool reranked before the top-k cut |
+| `--half-life` | 30 | recency decay in days (a hit this old keeps half its weight); 0 disables |
+| `--neighbors` | 1 | adjacent chunks (by seq) attached per hit; 0 disables |
+| `--type` | — | restrict to `text \| thinking \| tool_use \| tool_result` |
+| `--project` | — | restrict to a project (the directory segment under `projects`) |
+| `--harness` | — | restrict to `claude \| codex \| pi` (the stored facet `claude_code` also parses) |
+| `--store` | active store | the store to read — `<org>/<repo>`, an `hf://…` URI, a local path, or `local` |
+
+### get
+
+`funes get <session_id> <turn_uuid> [--window 3] [--store <label>]` — the named turn plus turns
+within the seq window, splits reassembled into whole blocks. Pass the `--store` a recall hint
+names so the drill-down reads the same store the hit came from. Agent format, per turn:
+
+```
+[<ts>] <role> seq<N> turn=<turn_uuid>
+<blocks, joined by blank lines>
+---
+```
+
+`turn <uuid> not found in session <id>` when absent.
+
+### list / status
+
+- `funes list [--project …] [--limit 50]` — sessions, newest activity first:
+  `[<last_ts>] <project>/<session8>  chunks=<n>  <first user message, first 120 chars>`.
+  CLI-only; not an MCP tool.
+- `funes status` — store label, table name, chunk count.
+
+### MCP
+
+`funes mcp` serves stdio; `funes add claude|codex|pi|hermes|opencode` registers it. Tools:
+`recall` (query, k, block_type/project/harness filters, store), `get` (session_id, turn_uuid,
+window, store), `status` (store) — each returns the corresponding agent-format string verbatim.
+A tool call's `store` overrides the server's; `funes mcp --store <spec>` pins one for the
+server's lifetime, and with neither the active store resolves per call (so `funes use` takes
+effect without a restart).
+
+## Working on the repo
+
+Building needs `protoc` (lance compiles protobuf at build time): system package, or
+`./scripts/bootstrap-protoc.sh` then `export PROTOC="$PWD/.tools/protoc/bin/protoc"`. Before
+calling work done: `cargo fmt && cargo clippy && cargo test` (the integration tests download the
+embedder/reranker weights on first run).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,9 @@ fell back to; the built-in guide has no store to name and keeps a bare hint).
 
 `funes get <session_id> <turn_uuid> [--window 3] [--store <label>]` — the named turn plus turns
 within the seq window, splits reassembled into whole blocks. Pass the `--store` a recall hint
-names so the drill-down reads the same store the hit came from. Agent format, per turn:
+names so the drill-down reads the same store the hit came from. `--highlight <text>` marks the
+text in the human rendering (matched whitespace-insensitively; no effect on the agent format).
+Agent format, per turn:
 
 ```
 [<ts>] <role> seq<N> turn=<turn_uuid>

--- a/README.md
+++ b/README.md
@@ -168,26 +168,17 @@ agent means implementing one trait, not touching the indexing or query path.
 
 ### Inspect it yourself
 
-You can query the store yourself from the CLI — handy to check what's indexed or debug a result:
+`funes` is meant to be used by agents, so its outputs are not human-friendly by default.
+
+However, when `recall` is called within a terminal, it switches to a leaner, interactive mode
+useful to inspect a store:
 
 ```bash
 funes recall "why did we switch off lancedb"
-funes recall "the lance schema" --type tool_use --harness codex --project funes
-funes list --project funes                        # browse indexed sessions
-funes get <session_id> <turn_uuid>                # expand a hit into its full surrounding turns
 ```
 
-In a terminal, `recall` opens an [fzf](https://github.com/junegunn/fzf) picker over the hits when
-fzf is installed: fuzzy-search them (matching reaches past the visible line into each chunk's
-content), read the highlighted hit's surrounding turns live in the preview pane, press enter to
-page through that expansion in full (leaving the pager returns to the picker), and Esc to quit.
-Without fzf — or with `FUNES_NO_FZF` set — it prints a numbered one-line list instead: type a
-number to expand a hit (`3 10` widens the context) and the list reprints after it; enter or `q`
-quits. Piped or scripted, it prints the agent format instead — `[time] agent project/session type
-score`, a `→ get <session_id> <turn_uuid>` line, a preview, and a few neighboring chunks
-(`--format human|agent` overrides the detection). Narrow with `--type`
-(`text|thinking|tool_use|tool_result`), `--project`, and `--harness` (`claude|codex|pi`); tune
-with `--k`, `--half-life` (recency decay), and `--neighbors`.
+Browse the hits and expand any of them into its full surrounding turns.
+Install [fzf](https://github.com/junegunn/fzf) for a richer interface.
 
 ## Building from source
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ funes recall "why did we switch off lancedb"
 Browse the hits and expand any of them into its full surrounding turns.
 Install [fzf](https://github.com/junegunn/fzf) for a richer interface.
 
+The full interface — output formats, flags, defaults — is specified in [AGENTS.md](AGENTS.md).
+
 ## Building from source
 
 Needs a Rust toolchain and **`protoc`** — `lance`'s build scripts compile protobuf at build time

--- a/README.md
+++ b/README.md
@@ -177,10 +177,17 @@ funes list --project funes                        # browse indexed sessions
 funes get <session_id> <turn_uuid>                # expand a hit into its full surrounding turns
 ```
 
-Each hit prints `[time] agent project/session type score`, a `→ get <session_id> <turn_uuid>` line,
-a preview, and a few neighboring chunks. Narrow with `--type` (`text|thinking|tool_use|tool_result`),
-`--project`, and `--harness` (`claude|codex|pi`); tune with `--k`, `--half-life` (recency
-decay), and `--neighbors`.
+In a terminal, `recall` opens an [fzf](https://github.com/junegunn/fzf) picker over the hits when
+fzf is installed: fuzzy-search them (matching reaches past the visible line into each chunk's
+content), read the highlighted hit's surrounding turns live in the preview pane, press enter to
+page through that expansion in full (leaving the pager returns to the picker), and Esc to quit.
+Without fzf — or with `FUNES_NO_FZF` set — it prints a numbered one-line list instead: type a
+number to expand a hit (`3 10` widens the context) and the list reprints after it; enter or `q`
+quits. Piped or scripted, it prints the agent format instead — `[time] agent project/session type
+score`, a `→ get <session_id> <turn_uuid>` line, a preview, and a few neighboring chunks
+(`--format human|agent` overrides the detection). Narrow with `--type`
+(`text|thinking|tool_use|tool_result`), `--project`, and `--harness` (`claude|codex|pi`); tune
+with `--k`, `--half-life` (recency decay), and `--neighbors`.
 
 ## Building from source
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ pub mod pi;
 pub mod pi_traces;
 pub mod push;
 pub mod recall;
+pub mod render;
 pub mod scan;
 pub mod scrub;
 pub mod source;

--- a/src/main.rs
+++ b/src/main.rs
@@ -491,7 +491,7 @@ async fn select_hits(store: &hub::Store, hits: &[(Hit, f64)], color: bool, width
                                     "funes get {} {} --window {window} --store {}",
                                     h.session_id,
                                     h.turn_uuid,
-                                    store.label()
+                                    sh_word(&store.label())
                                 ),
                                 color
                             )
@@ -556,9 +556,9 @@ fn select_hits_fzf(store: &hub::Store, hits: &[(Hit, f64)], color: bool, width: 
             "--bind",
             // fzf shell-escapes {4} (the matched chunk) itself.
             &format!(
-                "enter:execute:'{}' turns {{2}} {{3}} --store '{}' --highlight {{4}}",
-                exe.display(),
-                store.label()
+                "enter:execute:{} turns {{2}} {{3}} --store {} --highlight {{4}}",
+                sh_quote(&exe.display().to_string()),
+                sh_quote(&store.label())
             ),
         ])
         .stdin(std::process::Stdio::piped())
@@ -600,9 +600,9 @@ async fn select_turns_fzf(
     }
     let exe = std::env::current_exe()?;
     let mut turn_cmd = format!(
-        "'{}' get {{2}} {{3}} --format human --window 0 --store '{}'",
-        exe.display(),
-        store.label()
+        "{} get {{2}} {{3}} --format human --window 0 --store {}",
+        sh_quote(&exe.display().to_string()),
+        sh_quote(&store.label())
     );
     if let Some(h) = &highlight {
         turn_cmd.push_str(&format!(" --highlight {}", sh_quote(h)));
@@ -640,6 +640,17 @@ async fn select_turns_fzf(
 /// `s` single-quoted for a shell command line.
 fn sh_quote(s: &str) -> String {
     format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+/// `s` quoted only when a shell would mangle it bare — for commands shown to be copy-pasted,
+/// where quoting the common clean label is just noise.
+fn sh_word(s: &str) -> String {
+    let clean = |c: char| c.is_ascii_alphanumeric() || "/:.@_+=%,~-".contains(c);
+    if !s.is_empty() && s.chars().all(clean) {
+        s.to_string()
+    } else {
+        sh_quote(s)
+    }
 }
 
 /// The installed fzf's (major, minor), or None when it can't be read.

--- a/src/main.rs
+++ b/src/main.rs
@@ -193,19 +193,21 @@ impl StoreOpts {
 enum OutputFormat {
     /// A numbered list with a hit selector.
     Human,
-    /// The stable machine layout.
+    /// The stable agent layout: multi-line hits with provenance, previews, and neighbors.
     Agent,
 }
 
 impl OutputFormat {
     /// Resolve the effective format: an explicit flag wins; otherwise human when both stdin and
     /// stdout are terminals (the hit selector needs both), agent when piped or scripted.
-    fn human(flag: Option<OutputFormat>) -> bool {
-        match flag {
-            Some(OutputFormat::Human) => true,
-            Some(OutputFormat::Agent) => false,
-            None => std::io::stdin().is_terminal() && std::io::stdout().is_terminal(),
-        }
+    fn resolve(flag: Option<OutputFormat>) -> OutputFormat {
+        flag.unwrap_or_else(|| {
+            if std::io::stdin().is_terminal() && std::io::stdout().is_terminal() {
+                OutputFormat::Human
+            } else {
+                OutputFormat::Agent
+            }
+        })
     }
 }
 
@@ -253,24 +255,35 @@ async fn main() -> Result<()> {
                 harness,
             )
             .await?;
-            if !OutputFormat::human(format) {
-                if hits.is_empty() {
-                    print!("{note}no results");
-                } else {
-                    print!(
-                        "{}",
-                        render::recall_agent(&note, &recall::store_hint(store_label.as_deref()), &hits)
-                    );
+            match OutputFormat::resolve(format) {
+                OutputFormat::Agent => {
+                    if hits.is_empty() {
+                        print!("{note}no results");
+                    } else {
+                        print!(
+                            "{}",
+                            render::recall_agent(&note, &recall::store_hint(store_label.as_deref()), &hits)
+                        );
+                    }
+                    Ok(())
                 }
-                return Ok(());
+                OutputFormat::Human => {
+                    if hits.is_empty() {
+                        println!("{note}no results");
+                        return Ok(());
+                    }
+                    let (color, width) = human_io();
+                    print!("{note}");
+                    // fzf owns the whole terminal, so it needs a real one; a forced human format
+                    // without TTYs (or without fzf installed) keeps the line selector.
+                    let interactive = std::io::stdin().is_terminal() && std::io::stdout().is_terminal();
+                    if interactive && use_fzf() {
+                        select_hits_fzf(&store, &hits, color, width)
+                    } else {
+                        select_hits(&store, &hits, color, width).await
+                    }
+                }
             }
-            if hits.is_empty() {
-                println!("{note}no results");
-                return Ok(());
-            }
-            let (color, width) = human_io();
-            print!("{note}");
-            select_hits(&store, &hits, color, width).await
         }
         Cmd::List { project, limit, store } => {
             print!("{}", recall::list(store.resolve(), project, limit).await?);
@@ -283,12 +296,13 @@ async fn main() -> Result<()> {
             format,
             store,
         } => {
+            let format = OutputFormat::resolve(format);
             let (note, turns) =
                 recall::get_turns(store.resolve(), session_id.clone(), turn_uuid.clone(), window).await?;
             if turns.is_empty() {
                 print!("{note}");
                 println!("turn {turn_uuid} not found in session {session_id}");
-            } else if OutputFormat::human(format) {
+            } else if matches!(format, OutputFormat::Human) {
                 let (color, width) = human_io();
                 print!("{}", render::get_human(&note, &turns, color, width));
             } else {
@@ -466,6 +480,70 @@ async fn select_hits(store: &hub::Store, hits: &[(Hit, f64)], color: bool, width
             }
         }
     }
+}
+
+/// fzf-driven hit selector, the human default when fzf is installed: the list pane holds one row
+/// per hit, the preview pane runs `get` on the highlighted one, enter opens that expansion in the
+/// pager and leaving it returns to the picker — the walk-back; Esc quits. Each row carries hidden
+/// tab columns — session id and turn uuid for the `get` command, plus a searchable blob so a
+/// query matches content beyond the visible scent.
+fn select_hits_fzf(store: &hub::Store, hits: &[(Hit, f64)], color: bool, width: usize) -> Result<()> {
+    let rows = render::recall_rows(hits, color, width, chrono::Utc::now());
+    let mut lines = String::new();
+    for ((h, _), row) in hits.iter().zip(&rows) {
+        let blob: String = h
+            .text
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ")
+            .chars()
+            .take(500)
+            .collect();
+        lines.push_str(&format!(
+            "{}\t{}\t{}\t{}\n",
+            row.replace('\t', " "),
+            h.session_id,
+            h.turn_uuid,
+            blob
+        ));
+    }
+    let exe = std::env::current_exe()?;
+    let get_cmd = format!(
+        "'{}' get {{2}} {{3}} --format human --store '{}'",
+        exe.display(),
+        store.label()
+    );
+    let mut fzf = std::process::Command::new("fzf")
+        .args([
+            "--ansi",
+            "--layout=reverse",
+            "--no-sort",
+            "--delimiter",
+            "\t",
+            "--with-nth",
+            "1",
+            "--preview",
+            &get_cmd,
+            "--preview-window",
+            "right:60%:wrap",
+            "--bind",
+            &format!("enter:execute:{get_cmd} | ${{PAGER:-less}}"),
+        ])
+        .stdin(std::process::Stdio::piped())
+        .spawn()?;
+    fzf.stdin.take().expect("stdin is piped").write_all(lines.as_bytes())?;
+    // Enter never terminates fzf (it pages the expansion and comes back); the picker ends on
+    // Esc or Ctrl-C, so any exit status just means "done browsing".
+    fzf.wait()?;
+    Ok(())
+}
+
+/// True when fzf is on PATH and `FUNES_NO_FZF` is unset (presence opts out, like `NO_COLOR`).
+fn use_fzf() -> bool {
+    std::env::var_os("FUNES_NO_FZF").is_none()
+        && std::env::var_os("PATH")
+            .map(|p| std::env::split_paths(&p).any(|d| d.join("fzf").is_file()))
+            .unwrap_or(false)
 }
 
 /// One parsed selection.

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,12 +5,16 @@
 //! `$FUNES_HOME` or `~/.funes`.
 
 use funes::harness::Harness;
-use funes::{claude, codex, config, hello, hermes, hub, index, mcp, opencode, pi, push, recall, scrub, update};
+use funes::recall::Hit;
+use funes::{claude, codex, config, hello, hermes, hub, index, mcp, opencode, pi, push, recall, render, scrub, update};
 
 use anyhow::{anyhow, Result};
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 use std::io::{IsTerminal, Write};
 use std::path::PathBuf;
+
+/// Turns around a `get` target when no window is given — shared by the CLI flag and the hit selector.
+const DEFAULT_WINDOW: i64 = 3;
 
 #[derive(Parser)]
 #[command(name = "funes", version, about = "Recall over your past AI agent sessions.")]
@@ -49,6 +53,9 @@ enum Cmd {
         /// Restrict to a harness: claude | codex | pi.
         #[arg(long)]
         harness: Option<String>,
+        /// Output format. Default: human in a terminal, agent when piped.
+        #[arg(long, value_enum)]
+        format: Option<OutputFormat>,
         #[command(flatten)]
         store: StoreOpts,
     },
@@ -70,8 +77,11 @@ enum Cmd {
         /// Turn uuid (from a recall hit's `→ get` line).
         turn_uuid: String,
         /// Turns within this seq window of the target are included.
-        #[arg(long, default_value_t = 3)]
+        #[arg(long, default_value_t = DEFAULT_WINDOW)]
         window: i64,
+        /// Output format. Default: human in a terminal, agent when piped.
+        #[arg(long, value_enum)]
+        format: Option<OutputFormat>,
         #[command(flatten)]
         store: StoreOpts,
     },
@@ -178,6 +188,39 @@ impl StoreOpts {
     }
 }
 
+/// The two output layouts for the read commands.
+#[derive(Clone, Copy, ValueEnum)]
+enum OutputFormat {
+    /// A numbered list with a hit selector.
+    Human,
+    /// The stable machine layout.
+    Agent,
+}
+
+impl OutputFormat {
+    /// Resolve the effective format: an explicit flag wins; otherwise human when both stdin and
+    /// stdout are terminals (the hit selector needs both), agent when piped or scripted.
+    fn human(flag: Option<OutputFormat>) -> bool {
+        match flag {
+            Some(OutputFormat::Human) => true,
+            Some(OutputFormat::Agent) => false,
+            None => std::io::stdin().is_terminal() && std::io::stdout().is_terminal(),
+        }
+    }
+}
+
+/// Color and width for the human renderings: color needs a terminal and no `NO_COLOR`; width
+/// follows `$COLUMNS` when exported, else 100.
+fn human_io() -> (bool, usize) {
+    let color = std::io::stdout().is_terminal() && std::env::var_os("NO_COLOR").is_none();
+    let width = std::env::var("COLUMNS")
+        .ok()
+        .and_then(|c| c.parse::<usize>().ok())
+        .map(|c| c.clamp(40, 120))
+        .unwrap_or(100);
+    (color, width)
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     match Cli::parse().cmd {
@@ -194,24 +237,40 @@ async fn main() -> Result<()> {
             block_type,
             project,
             harness,
+            format,
             store,
         } => {
-            print!(
-                "{}",
-                recall::recall(
-                    store.resolve(),
-                    query.join(" "),
-                    k,
-                    candidates,
-                    half_life,
-                    neighbors,
-                    block_type,
-                    project,
-                    harness,
-                )
-                .await?
-            );
-            Ok(())
+            let store = store.resolve();
+            let (note, store_label, hits) = recall::recall_hits(
+                store.clone(),
+                query.join(" "),
+                k,
+                candidates,
+                half_life,
+                neighbors,
+                block_type,
+                project,
+                harness,
+            )
+            .await?;
+            if !OutputFormat::human(format) {
+                if hits.is_empty() {
+                    print!("{note}no results");
+                } else {
+                    print!(
+                        "{}",
+                        render::recall_agent(&note, &recall::store_hint(store_label.as_deref()), &hits)
+                    );
+                }
+                return Ok(());
+            }
+            if hits.is_empty() {
+                println!("{note}no results");
+                return Ok(());
+            }
+            let (color, width) = human_io();
+            print!("{note}");
+            select_hits(&store, &hits, color, width).await
         }
         Cmd::List { project, limit, store } => {
             print!("{}", recall::list(store.resolve(), project, limit).await?);
@@ -221,9 +280,20 @@ async fn main() -> Result<()> {
             session_id,
             turn_uuid,
             window,
+            format,
             store,
         } => {
-            print!("{}", recall::get(store.resolve(), session_id, turn_uuid, window).await?);
+            let (note, turns) =
+                recall::get_turns(store.resolve(), session_id.clone(), turn_uuid.clone(), window).await?;
+            if turns.is_empty() {
+                print!("{note}");
+                println!("turn {turn_uuid} not found in session {session_id}");
+            } else if OutputFormat::human(format) {
+                let (color, width) = human_io();
+                print!("{}", render::get_human(&note, &turns, color, width));
+            } else {
+                print!("{}", render::get_agent(&note, &turns));
+            }
             Ok(())
         }
         Cmd::Index {
@@ -336,6 +406,98 @@ async fn main() -> Result<()> {
     }
 }
 
+/// The hit selector after a human recall: prints the numbered menu, then a typed number expands
+/// that hit via `get` (`3 10` widens the window) and the menu reprints — the walk-back. An empty
+/// line, `q`, or end-of-input quits.
+async fn select_hits(store: &hub::Store, hits: &[(Hit, f64)], color: bool, width: usize) -> Result<()> {
+    let menu = render::recall_human("", hits, color, width, chrono::Utc::now());
+    let hint = render::dim(
+        "type a number to expand a hit (`3 10` widens the context) — enter or q quits",
+        color,
+    );
+    print!("{menu}");
+    println!("{hint}");
+    let mut line = String::new();
+    loop {
+        print!("› ");
+        std::io::stdout().flush().ok();
+        line.clear();
+        if std::io::stdin().read_line(&mut line)? == 0 {
+            println!();
+            return Ok(());
+        }
+        match parse_selection(line.trim(), hits.len()) {
+            Selection::Quit => return Ok(()),
+            Selection::Help => {
+                println!(
+                    "1–{} expands a hit (`3 10` widens the context); enter or q quits",
+                    hits.len()
+                )
+            }
+            Selection::Expand { ordinal, window } => {
+                let h = &hits[ordinal - 1].0;
+                match recall::get_turns(store.clone(), h.session_id.clone(), h.turn_uuid.clone(), window).await {
+                    Ok((note, turns)) if turns.is_empty() => {
+                        print!("{note}");
+                        println!("turn {} not found in session {}", h.turn_uuid, h.session_id);
+                    }
+                    Ok((note, turns)) => {
+                        print!("{}", render::get_human(&note, &turns, color, width));
+                        println!(
+                            "{}",
+                            render::dim(
+                                &format!(
+                                    "funes get {} {} --window {window} --store {}",
+                                    h.session_id,
+                                    h.turn_uuid,
+                                    store.label()
+                                ),
+                                color
+                            )
+                        );
+                    }
+                    // A transient failure (say, the remote dropped) shouldn't kill the session.
+                    Err(e) => println!("get failed: {e:#}"),
+                }
+                // Back to the picker: the expansion pushed the menu out of view.
+                println!();
+                print!("{menu}");
+                println!("{hint}");
+            }
+        }
+    }
+}
+
+/// One parsed selection.
+enum Selection {
+    Quit,
+    Help,
+    Expand { ordinal: usize, window: i64 },
+}
+
+/// `""`/`q`/`quit` quit; `N` expands hit N with the default window; `N W` widens it to W.
+fn parse_selection(line: &str, hits: usize) -> Selection {
+    if line.is_empty() || line.eq_ignore_ascii_case("q") || line.eq_ignore_ascii_case("quit") {
+        return Selection::Quit;
+    }
+    let mut parts = line.split_whitespace();
+    let ordinal = match parts.next().and_then(|t| t.parse::<usize>().ok()) {
+        Some(o) if (1..=hits).contains(&o) => o,
+        _ => return Selection::Help,
+    };
+    let window = match parts.next() {
+        None => DEFAULT_WINDOW,
+        Some(t) => match t.parse::<i64>() {
+            Ok(w) if w >= 0 => w,
+            _ => return Selection::Help,
+        },
+    };
+    if parts.next().is_some() {
+        return Selection::Help;
+    }
+    Selection::Expand { ordinal, window }
+}
+
 /// `funes use <store>`: attach a remote (or `local` to detach) and report the next step.
 async fn use_store(spec: String) -> Result<()> {
     let mut cfg = config::load();
@@ -425,7 +587,28 @@ fn prompt_new_store(label: &str, chunks: usize) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::attach_hint;
+    use super::{attach_hint, parse_selection, Selection};
+
+    #[test]
+    fn parse_selection_grammar() {
+        assert!(matches!(parse_selection("", 8), Selection::Quit));
+        assert!(matches!(parse_selection("q", 8), Selection::Quit));
+        assert!(matches!(parse_selection("QUIT", 8), Selection::Quit));
+        assert!(matches!(
+            parse_selection("3", 8),
+            Selection::Expand { ordinal: 3, window: 3 }
+        ));
+        assert!(matches!(
+            parse_selection("3 10", 8),
+            Selection::Expand { ordinal: 3, window: 10 }
+        ));
+        // Out of range, not a number, negative window, trailing junk.
+        assert!(matches!(parse_selection("9", 8), Selection::Help));
+        assert!(matches!(parse_selection("0", 8), Selection::Help));
+        assert!(matches!(parse_selection("x", 8), Selection::Help));
+        assert!(matches!(parse_selection("3 -1", 8), Selection::Help));
+        assert!(matches!(parse_selection("3 10 zzz", 8), Selection::Help));
+    }
 
     #[test]
     fn attach_hint_covers_each_state() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,6 +82,21 @@ enum Cmd {
         /// Output format. Default: human in a terminal, agent when piped.
         #[arg(long, value_enum)]
         format: Option<OutputFormat>,
+        /// Highlight this text in the human rendering (matched whitespace-insensitively).
+        #[arg(long)]
+        highlight: Option<String>,
+        #[command(flatten)]
+        store: StoreOpts,
+    },
+    /// Browse a session's turns in fzf — the hit picker's drill-down.
+    #[command(hide = true)]
+    Turns {
+        session_id: String,
+        /// The turn to mark in the list (the recall hit).
+        turn_uuid: String,
+        /// The matched chunk, highlighted in previews and pages.
+        #[arg(long)]
+        highlight: Option<String>,
         #[command(flatten)]
         store: StoreOpts,
     },
@@ -294,6 +309,7 @@ async fn main() -> Result<()> {
             turn_uuid,
             window,
             format,
+            highlight,
             store,
         } => {
             let format = OutputFormat::resolve(format);
@@ -304,12 +320,21 @@ async fn main() -> Result<()> {
                 println!("turn {turn_uuid} not found in session {session_id}");
             } else if matches!(format, OutputFormat::Human) {
                 let (color, width) = human_io();
-                print!("{}", render::get_human(&note, &turns, color, width));
+                print!(
+                    "{}",
+                    render::get_human(&note, &turns, color, width, highlight.as_deref())
+                );
             } else {
                 print!("{}", render::get_agent(&note, &turns));
             }
             Ok(())
         }
+        Cmd::Turns {
+            session_id,
+            turn_uuid,
+            highlight,
+            store,
+        } => select_turns_fzf(store.resolve(), session_id, turn_uuid, highlight).await,
         Cmd::Index {
             path,
             harness,
@@ -456,7 +481,9 @@ async fn select_hits(store: &hub::Store, hits: &[(Hit, f64)], color: bool, width
                         println!("turn {} not found in session {}", h.turn_uuid, h.session_id);
                     }
                     Ok((note, turns)) => {
-                        print!("{}", render::get_human(&note, &turns, color, width));
+                        // Mark the matched chunk so it stands out of the surrounding turns.
+                        let mark: String = h.text.split_whitespace().collect::<Vec<_>>().join(" ");
+                        print!("{}", render::get_human(&note, &turns, color, width, Some(&mark)));
                         println!(
                             "{}",
                             render::dim(
@@ -483,21 +510,23 @@ async fn select_hits(store: &hub::Store, hits: &[(Hit, f64)], color: bool, width
 }
 
 /// fzf-driven hit selector, the human default when fzf is installed: the list pane holds one row
-/// per hit, the preview pane runs `get` on the highlighted one, enter opens that expansion in the
-/// pager and leaving it returns to the picker — the walk-back; Esc quits. Each row carries hidden
-/// tab columns — session id and turn uuid for the `get` command, plus a searchable blob so a
-/// query matches content beyond the visible scent.
+/// per hit, the preview pane shows the matched chunk, enter drills into the session's turn
+/// browser and leaving it returns here — the walk-back; Esc quits. Each row carries hidden tab
+/// columns — session id and turn uuid for the drill-down, plus the matched chunk, which doubles
+/// as search text (a query matches content beyond the visible scent) and as the preview.
 fn select_hits_fzf(store: &hub::Store, hits: &[(Hit, f64)], color: bool, width: usize) -> Result<()> {
     let rows = render::recall_rows(hits, color, width, chrono::Utc::now());
     let mut lines = String::new();
     for ((h, _), row) in hits.iter().zip(&rows) {
+        // Field 4 is the matched chunk, whitespace-collapsed: fzf searches it (a query matches
+        // content beyond the visible scent) and the preview leads with it.
         let blob: String = h
             .text
             .split_whitespace()
             .collect::<Vec<_>>()
             .join(" ")
             .chars()
-            .take(500)
+            .take(2000)
             .collect();
         lines.push_str(&format!(
             "{}\t{}\t{}\t{}\n",
@@ -508,11 +537,6 @@ fn select_hits_fzf(store: &hub::Store, hits: &[(Hit, f64)], color: bool, width: 
         ));
     }
     let exe = std::env::current_exe()?;
-    let get_cmd = format!(
-        "'{}' get {{2}} {{3}} --format human --store '{}'",
-        exe.display(),
-        store.label()
-    );
     let mut fzf = std::process::Command::new("fzf")
         .args([
             "--ansi",
@@ -523,19 +547,107 @@ fn select_hits_fzf(store: &hub::Store, hits: &[(Hit, f64)], color: bool, width: 
             "--with-nth",
             "1",
             "--preview",
-            &get_cmd,
+            // The matched chunk, nothing else — the turn browser behind enter owns the context.
+            // Rendering the turn here too would show the match's text twice in different shapes
+            // (or, for a tool hit, not at all: the turn view compresses tool blocks).
+            "echo {4} | fold -s -w $FZF_PREVIEW_COLUMNS",
             "--preview-window",
             "right:60%:wrap",
             "--bind",
-            &format!("enter:execute:{get_cmd} | ${{PAGER:-less}}"),
+            // fzf shell-escapes {4} (the matched chunk) itself.
+            &format!(
+                "enter:execute:'{}' turns {{2}} {{3}} --store '{}' --highlight {{4}}",
+                exe.display(),
+                store.label()
+            ),
         ])
         .stdin(std::process::Stdio::piped())
         .spawn()?;
     fzf.stdin.take().expect("stdin is piped").write_all(lines.as_bytes())?;
-    // Enter never terminates fzf (it pages the expansion and comes back); the picker ends on
-    // Esc or Ctrl-C, so any exit status just means "done browsing".
+    // Enter never terminates fzf (it drills into the turn browser and comes back); the picker
+    // ends on Esc or Ctrl-C, so any exit status just means "done browsing".
     fzf.wait()?;
     Ok(())
+}
+
+/// The turn browser behind enter in the hit picker: one fzf row per turn of the session, oldest
+/// first, the recall hit's turn marked `▶`; the highlighted turn shows whole in the preview pane
+/// — the matched chunk reverse-videoed within it — and enter pages it. Esc walks back to the hit
+/// picker.
+async fn select_turns_fzf(
+    store: hub::Store,
+    session_id: String,
+    center: String,
+    highlight: Option<String>,
+) -> Result<()> {
+    let (note, turns) = recall::get_turns(store.clone(), session_id.clone(), center.clone(), i64::MAX).await?;
+    if turns.is_empty() {
+        print!("{note}");
+        println!("turn {center} not found in session {session_id}");
+        return Ok(());
+    }
+    let (color, width) = human_io();
+    let rows = render::turn_rows(&turns, color, width);
+    let mut lines = String::new();
+    for (t, row) in turns.iter().zip(&rows) {
+        let marker = if t.turn_uuid == center { "▶ " } else { "  " };
+        lines.push_str(&format!(
+            "{marker}{}\t{}\t{}\n",
+            row.replace('\t', " "),
+            session_id,
+            t.turn_uuid
+        ));
+    }
+    let exe = std::env::current_exe()?;
+    let mut turn_cmd = format!(
+        "'{}' get {{2}} {{3}} --format human --window 0 --store '{}'",
+        exe.display(),
+        store.label()
+    );
+    if let Some(h) = &highlight {
+        turn_cmd.push_str(&format!(" --highlight {}", sh_quote(h)));
+    }
+    let mut cmd = std::process::Command::new("fzf");
+    cmd.args([
+        "--ansi",
+        "--layout=reverse",
+        "--no-sort",
+        "--delimiter",
+        "\t",
+        "--with-nth",
+        "1",
+        "--preview",
+        &turn_cmd,
+        "--preview-window",
+        "right:60%:wrap",
+        "--bind",
+        // `less -R` passes the highlight's ANSI marks through.
+        &format!("enter:execute:{turn_cmd} | ${{PAGER:-less -R}}"),
+    ]);
+    // Land on the hit's turn rather than the top of a possibly huge session. `pos` needs
+    // fzf 0.36; older ones still get the `▶` marker to search for.
+    if let Some(idx) = turns.iter().position(|t| t.turn_uuid == center) {
+        if fzf_version().is_some_and(|v| v >= (0, 36)) {
+            cmd.args(["--bind", &format!("load:pos({})", idx + 1)]);
+        }
+    }
+    let mut fzf = cmd.stdin(std::process::Stdio::piped()).spawn()?;
+    fzf.stdin.take().expect("stdin is piped").write_all(lines.as_bytes())?;
+    fzf.wait()?;
+    Ok(())
+}
+
+/// `s` single-quoted for a shell command line.
+fn sh_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+/// The installed fzf's (major, minor), or None when it can't be read.
+fn fzf_version() -> Option<(u32, u32)> {
+    let out = std::process::Command::new("fzf").arg("--version").output().ok()?;
+    let s = String::from_utf8_lossy(&out.stdout);
+    let mut parts = s.split_whitespace().next()?.split('.');
+    Some((parts.next()?.parse().ok()?, parts.next()?.parse().ok()?))
 }
 
 /// True when fzf is on PATH and `FUNES_NO_FZF` is unset (presence opts out, like `NO_COLOR`).

--- a/src/recall.rs
+++ b/src/recall.rs
@@ -1,7 +1,8 @@
 //! The read surface: `recall`, `list`, `get`, `status` over the existing index.
 //! Recall pipeline: hybrid (vector + BM25, fused by reciprocal rank) → cross-encoder rerank →
-//! recency reweight → neighbor expansion. Every command returns a `String` so the CLI
-//! prints it and the MCP server returns it verbatim.
+//! recency reweight → neighbor expansion. `recall`/`get` return results rendered in the agent
+//! format; `recall_hits`/`get_turns` return the structured results for other renderings
+//! (see `render`).
 
 use crate::chunk;
 use crate::dataset;
@@ -39,24 +40,33 @@ type NeighborRow = (String, i64, String, i64, i64, String, String, String);
 type TurnRow = (i64, String, String, String, i64, i64, String);
 
 /// One adjacent chunk pulled in to give a hit some surrounding context.
-struct Neighbor {
-    seq: i64,
-    role: String,
-    block_type: String,
-    text: String,
+pub struct Neighbor {
+    pub seq: i64,
+    pub role: String,
+    pub block_type: String,
+    pub text: String,
 }
 
 /// One candidate row carried from retrieval through rerank to display.
-struct Hit {
-    text: String,
-    session_id: String,
-    project: String,
-    turn_uuid: String,
-    seq: i64,
-    ts: String,
-    block_type: String,
-    harness: String,
-    neighbors: Vec<Neighbor>,
+pub struct Hit {
+    pub text: String,
+    pub session_id: String,
+    pub project: String,
+    pub turn_uuid: String,
+    pub seq: i64,
+    pub ts: String,
+    pub block_type: String,
+    pub harness: String,
+    pub neighbors: Vec<Neighbor>,
+}
+
+/// One reassembled turn from `get`: its blocks in order, splits stitched back together.
+pub struct Turn {
+    pub seq: i64,
+    pub turn_uuid: String,
+    pub ts: String,
+    pub role: String,
+    pub blocks: Vec<String>,
 }
 
 fn scol<'a>(b: &'a RecordBatch, name: &str) -> Option<&'a StringArray> {
@@ -271,7 +281,7 @@ async fn models() -> Result<&'static Mutex<Models>> {
         .await
 }
 
-/// Run the recall pipeline over one store and return the formatted results as text.
+/// Run the recall pipeline over one store and return the results rendered in the agent format.
 #[allow(clippy::too_many_arguments)]
 pub async fn recall(
     store: Store,
@@ -284,6 +294,36 @@ pub async fn recall(
     project: Option<String>,
     harness: Option<String>,
 ) -> Result<String> {
+    let (note, store_label, hits) = recall_hits(
+        store, query, k, candidates, half_life, neighbors, block_type, project, harness,
+    )
+    .await?;
+    if hits.is_empty() {
+        return Ok(format!("{note}no results"));
+    }
+    Ok(crate::render::recall_agent(
+        &note,
+        &store_hint(store_label.as_deref()),
+        &hits,
+    ))
+}
+
+/// Run the recall pipeline over one store: hybrid retrieval → rerank → recency reweight →
+/// neighbor expansion. Returns the degradation note (empty when the store opened normally), the
+/// label of the store actually read (`None` for the built-in guide), and the scored hits, best
+/// first — rendering is the caller's choice.
+#[allow(clippy::too_many_arguments)]
+pub async fn recall_hits(
+    store: Store,
+    query: String,
+    k: usize,
+    candidates: usize,
+    half_life: f64,
+    neighbors: i64,
+    block_type: Option<String>,
+    project: Option<String>,
+    harness: Option<String>,
+) -> Result<(String, Option<String>, Vec<(Hit, f64)>)> {
     // `--harness` accepts the same spellings as `index`/`add` (claude|codex|pi); normalize to the
     // stored facet (Claude's is `claude_code`) so `--harness claude` filters instead of silently
     // matching nothing, and an unknown value errors here rather than returning zero hits.
@@ -318,7 +358,7 @@ pub async fn recall(
     // recall then falls back to vector-only.
     let hits = hybrid_candidates(ds, &qv, &query, candidates, where_clause.as_deref()).await?;
     if hits.is_empty() {
-        return Ok(format!("{note}no results"));
+        return Ok((note, read.store_label.clone(), Vec::new()));
     }
 
     let docs: Vec<&str> = hits.iter().map(|h| h.text.as_str()).collect();
@@ -349,25 +389,7 @@ pub async fn recall(
         attach_neighbors(ds, &mut refs, neighbors).await?;
     }
 
-    let store_arg = store_hint(read.store_label.as_deref());
-    let mut out = note;
-    for (h, score) in &top {
-        let s8 = &h.session_id[..h.session_id.len().min(8)];
-        let _ = writeln!(
-            out,
-            "[{}] {} {}/{} {}  score={:.3}",
-            h.ts, h.harness, h.project, s8, h.block_type, score
-        );
-        let _ = writeln!(out, "  → get {} {}{}", h.session_id, h.turn_uuid, store_arg);
-        let preview: String = h.text.chars().take(400).collect();
-        let _ = writeln!(out, "{preview}");
-        for n in &h.neighbors {
-            let np: String = n.text.chars().take(160).collect();
-            let _ = writeln!(out, "  ~ [{} {} seq{}] {}", n.role, n.block_type, n.seq, np);
-        }
-        let _ = writeln!(out, "---");
-    }
-    Ok(out)
+    Ok((note, read.store_label.clone(), top))
 }
 
 /// Vector ANN + BM25 candidates fused by reciprocal rank, top `candidates`. The FTS leg is
@@ -644,9 +666,25 @@ pub async fn list(store: Store, project: Option<String>, limit: usize) -> Result
     Ok(format!("{note}{out}"))
 }
 
-/// Drill down on a recall hit: the named turn plus the turns within `window` of it, each
-/// reassembled (blocks in order, splits de-overlapped) into one readable passage.
+/// Drill down on a recall hit: the named turn plus the turns within `window` of it, rendered in
+/// the agent format.
 pub async fn get(store: Store, session_id: String, turn_uuid: String, window: i64) -> Result<String> {
+    let (note, turns) = get_turns(store, session_id.clone(), turn_uuid.clone(), window).await?;
+    if turns.is_empty() {
+        return Ok(format!("{note}turn {turn_uuid} not found in session {session_id}\n"));
+    }
+    Ok(crate::render::get_agent(&note, &turns))
+}
+
+/// The turns behind `get`: the named one plus those within `window` of it, each reassembled
+/// (blocks in order, splits de-overlapped). Returns the degradation note and the turns — empty
+/// when the turn isn't in the session; rendering is the caller's choice.
+pub async fn get_turns(
+    store: Store,
+    session_id: String,
+    turn_uuid: String,
+    window: i64,
+) -> Result<(String, Vec<Turn>)> {
     let read = open_read(&store, None).await?;
     let note = read.note.clone().unwrap_or_default();
     let ds = &read.ds;
@@ -684,7 +722,7 @@ pub async fn get(store: Store, session_id: String, turn_uuid: String, window: i6
 
     let center = match rows.iter().find(|r| r.1 == turn_uuid) {
         Some(r) => r.0,
-        None => return Ok(format!("{note}turn {turn_uuid} not found in session {session_id}\n")),
+        None => return Ok((note, Vec::new())),
     };
 
     // Group selected rows by (seq, turn_uuid).
@@ -693,7 +731,7 @@ pub async fn get(store: Store, session_id: String, turn_uuid: String, window: i6
         groups.entry((r.0, r.1.clone())).or_default().push(r);
     }
 
-    let mut out = String::new();
+    let mut turns = Vec::new();
     for ((seq, turn), mut chunks) in groups {
         chunks.sort_by_key(|r| (r.4, r.5)); // block_idx, split_idx
         let head = chunks[0];
@@ -718,11 +756,15 @@ pub async fn get(store: Store, session_id: String, turn_uuid: String, window: i6
         if !cur.is_empty() {
             blocks.push(cur);
         }
-        let _ = writeln!(out, "[{}] {} seq{} turn={}", head.2, head.3, seq, turn);
-        let _ = writeln!(out, "{}", blocks.join("\n\n"));
-        let _ = writeln!(out, "---");
+        turns.push(Turn {
+            seq,
+            turn_uuid: turn,
+            ts: head.2.clone(),
+            role: head.3.clone(),
+            blocks,
+        });
     }
-    Ok(format!("{note}{out}"))
+    Ok((note, turns))
 }
 
 pub async fn status(store: Store) -> Result<String> {

--- a/src/recall.rs
+++ b/src/recall.rs
@@ -252,7 +252,7 @@ async fn degrade_offline(uri: &str, embedder: Option<&mut TextEmbedding>) -> Res
 
 /// The store suffix for a hit's `→ get` hint: every hit names the store it was read from, so the
 /// hint drills into that store from any context. The built-in guide has no store to name.
-fn store_hint(read: Option<&str>) -> String {
+pub fn store_hint(read: Option<&str>) -> String {
     match read {
         Some(label) => format!(" --store {label}"),
         None => String::new(),

--- a/src/render.rs
+++ b/src/render.rs
@@ -44,6 +44,23 @@ pub fn recall_agent(note: &str, store_arg: &str, hits: &[(Hit, f64)]) -> String 
 /// `width`. Metadata dims when `color` is set; `now` anchors the date labels (years show only
 /// when some hit is from another year).
 pub fn recall_human(note: &str, hits: &[(Hit, f64)], color: bool, width: usize, now: DateTime<Utc>) -> String {
+    let mut out = note.to_string();
+    // 4 = the ordinal prefix each line carries below.
+    for (i, row) in hit_rows(hits, color, width, now, 4).iter().enumerate() {
+        let _ = writeln!(out, "{:>2}  {}", i + 1, row);
+    }
+    out
+}
+
+/// The human list rows without ordinals — one per hit, for a picker whose pointer does the
+/// numbering.
+pub fn recall_rows(hits: &[(Hit, f64)], color: bool, width: usize, now: DateTime<Utc>) -> Vec<String> {
+    hit_rows(hits, color, width, now, 0)
+}
+
+/// One aligned row per hit — dim `date  agent  project` columns, then the scent, fitted to
+/// `width` minus `indent` (the caller's own per-line prefix).
+fn hit_rows(hits: &[(Hit, f64)], color: bool, width: usize, now: DateTime<Utc>, indent: usize) -> Vec<String> {
     let with_year = hits.iter().any(|(h, _)| {
         DateTime::parse_from_rfc3339(&h.ts)
             .map(|t| t.year() != now.year())
@@ -63,14 +80,15 @@ pub fn recall_human(note: &str, hits: &[(Hit, f64)], color: bool, width: usize, 
     let hw = rows.iter().map(|r| r.1.chars().count()).max().unwrap_or(0);
     let pw = rows.iter().map(|r| r.2.chars().count()).max().unwrap_or(0);
 
-    let mut out = note.to_string();
-    for (i, ((h, _), (date, har, proj))) in hits.iter().zip(&rows).enumerate() {
-        let meta = format!("{date:<dw$}  {har:<hw$}  {proj:<pw$}");
-        let budget = width.saturating_sub(4 + meta.chars().count() + 2).max(20);
-        let line = ellipsize(&scent(&h.block_type, &h.text), budget);
-        let _ = writeln!(out, "{:>2}  {}  {}", i + 1, dim(&meta, color), line);
-    }
-    out
+    hits.iter()
+        .zip(&rows)
+        .map(|((h, _), (date, har, proj))| {
+            let meta = format!("{date:<dw$}  {har:<hw$}  {proj:<pw$}");
+            let budget = width.saturating_sub(indent + meta.chars().count() + 2).max(20);
+            let line = ellipsize(&scent(&h.block_type, &h.text), budget);
+            format!("{}  {}", dim(&meta, color), line)
+        })
+        .collect()
 }
 
 /// The agent `get` format: `[ts] role seqN turn=…` headers over reassembled blocks. Byte-stable.

--- a/src/render.rs
+++ b/src/render.rs
@@ -176,19 +176,21 @@ pub fn get_human(note: &str, turns: &[Turn], color: bool, width: usize, mark: Op
 }
 
 /// The global word-index range where `mark`'s word sequence occurs in `text`, matched
-/// whitespace-insensitively. A chunk can be cut mid-word at its start, so the first mark word is
-/// also tried dropped; the match anchors on the next 6 words and extends as far as the sequences
-/// agree. None when nothing anchors — the mark belongs to some other turn.
+/// whitespace-insensitively. The match anchors on the first 6 words — or the whole mark when
+/// shorter — and extends as far as the sequences agree. A chunk can be cut mid-word at its start,
+/// so a long mark is also tried with its first word dropped; a short explicit mark must match
+/// whole. None when nothing anchors — the mark belongs to some other turn.
 fn word_span(text: &str, mark: &str) -> Option<std::ops::Range<usize>> {
     let words: Vec<&str> = text.split_whitespace().collect();
     let mark_words: Vec<&str> = mark.split_whitespace().collect();
     for skip in 0..=1usize.min(mark_words.len()) {
         let needle = &mark_words[skip..];
-        if needle.len() < 6 {
+        if needle.is_empty() || (skip > 0 && needle.len() < 6) {
             break;
         }
-        if let Some(i) = words.windows(6).position(|w| w == &needle[..6]) {
-            let mut n = 6;
+        let anchor = needle.len().min(6);
+        if let Some(i) = words.windows(anchor).position(|w| w == &needle[..anchor]) {
+            let mut n = anchor;
             while n < needle.len() && i + n < words.len() && words[i + n] == needle[n] {
                 n += 1;
             }
@@ -555,6 +557,18 @@ mod tests {
             Some("entirely unrelated words that never anchor anywhere at all"),
         );
         assert!(!plain.contains("\u{1b}[7m"));
+    }
+
+    #[test]
+    fn word_span_anchors_short_and_cut_marks() {
+        let text = "alpha beta gamma delta epsilon zeta eta theta";
+        // Shorter than the 6-word anchor: the whole mark must match.
+        assert_eq!(word_span(text, "gamma delta"), Some(2..4));
+        assert_eq!(word_span(text, "theta"), Some(7..8));
+        // A short mark is not retried with its first word dropped.
+        assert_eq!(word_span(text, "nope delta"), None);
+        // A long mark cut mid-word at its start still anchors via the skip.
+        assert_eq!(word_span(text, "pha beta gamma delta epsilon zeta eta"), Some(1..7));
     }
 
     #[test]

--- a/src/render.rs
+++ b/src/render.rs
@@ -91,6 +91,34 @@ fn hit_rows(hits: &[(Hit, f64)], color: bool, width: usize, now: DateTime<Utc>, 
         .collect()
 }
 
+/// One row per turn — dim `stamp  role` columns, then a scent of the first block. For a picker's
+/// list pane over a session's turns.
+pub fn turn_rows(turns: &[Turn], color: bool, width: usize) -> Vec<String> {
+    let rw = turns.iter().map(|t| t.role.chars().count()).max().unwrap_or(0);
+    turns
+        .iter()
+        .map(|t| {
+            let stamp: String = t.ts.chars().take(16).collect::<String>().replace('T', " ");
+            let meta = format!("{stamp}  {:<rw$}", t.role);
+            let budget = width.saturating_sub(meta.chars().count() + 4).max(20);
+            let first = t.blocks.first().map(String::as_str).unwrap_or("");
+            let line = ellipsize(&block_scent(first), budget);
+            format!("{}  {}", dim(&meta, color), line)
+        })
+        .collect()
+}
+
+/// Scent for a reassembled block: its type is recovered from the chunk label prefix.
+fn block_scent(b: &str) -> String {
+    if b.starts_with("[tool_use") {
+        scent("tool_use", b)
+    } else if b.starts_with("[tool_result") {
+        scent("tool_result", b)
+    } else {
+        scent("text", b)
+    }
+}
+
 /// The agent `get` format: `[ts] role seqN turn=…` headers over reassembled blocks. Byte-stable.
 pub fn get_agent(note: &str, turns: &[Turn]) -> String {
     let mut out = note.to_string();
@@ -104,8 +132,10 @@ pub fn get_agent(note: &str, turns: &[Turn]) -> String {
 
 /// The human `get` view: a dim `── time · role ──` header per turn, prose blocks wrapped in full,
 /// tool blocks compressed to a one-liner plus the payload head (an Edit's `new_string`, a Write's
-/// `content`, a Bash command).
-pub fn get_human(note: &str, turns: &[Turn], color: bool, width: usize) -> String {
+/// `content`, a Bash command). A `mark` (a matched chunk, whitespace-collapsed) is located in the
+/// prose whitespace-insensitively and reverse-videoed — marks render regardless of `color`, since
+/// highlighting is their whole point.
+pub fn get_human(note: &str, turns: &[Turn], color: bool, width: usize, mark: Option<&str>) -> String {
     let mut out = note.to_string();
     for t in turns {
         let stamp: String = t.ts.chars().take(16).collect::<String>().replace('T', " ");
@@ -132,6 +162,8 @@ pub fn get_human(note: &str, turns: &[Turn], color: bool, width: usize) -> Strin
             } else if b.starts_with("[tool_result") {
                 let line = scent("tool_result", b);
                 let _ = writeln!(out, "  {}", dim(&ellipsize(&line, width.saturating_sub(2)), color));
+            } else if let Some(span) = mark.and_then(|m| word_span(b, m)) {
+                write_wrapped_marked(&mut out, b, width, span);
             } else {
                 for l in b.lines() {
                     write_wrapped(&mut out, l, width, "");
@@ -141,6 +173,67 @@ pub fn get_human(note: &str, turns: &[Turn], color: bool, width: usize) -> Strin
         }
     }
     out
+}
+
+/// The global word-index range where `mark`'s word sequence occurs in `text`, matched
+/// whitespace-insensitively. A chunk can be cut mid-word at its start, so the first mark word is
+/// also tried dropped; the match anchors on the next 6 words and extends as far as the sequences
+/// agree. None when nothing anchors — the mark belongs to some other turn.
+fn word_span(text: &str, mark: &str) -> Option<std::ops::Range<usize>> {
+    let words: Vec<&str> = text.split_whitespace().collect();
+    let mark_words: Vec<&str> = mark.split_whitespace().collect();
+    for skip in 0..=1usize.min(mark_words.len()) {
+        let needle = &mark_words[skip..];
+        if needle.len() < 6 {
+            break;
+        }
+        if let Some(i) = words.windows(6).position(|w| w == &needle[..6]) {
+            let mut n = 6;
+            while n < needle.len() && i + n < words.len() && words[i + n] == needle[n] {
+                n += 1;
+            }
+            return Some(i..i + n);
+        }
+    }
+    None
+}
+
+/// Word-wrap a whole block to `width`, reverse-videoing the words whose global index falls in
+/// `mark`. Blank lines survive; unlike [`write_wrapped`], every line is re-flowed (word indices
+/// must line up with [`word_span`]'s counting).
+fn write_wrapped_marked(out: &mut String, text: &str, width: usize, mark: std::ops::Range<usize>) {
+    let width = width.max(20);
+    let mut wi = 0usize;
+    for line in text.lines() {
+        if line.trim().is_empty() {
+            out.push('\n');
+            continue;
+        }
+        let mut cur = String::new();
+        let mut cur_len = 0usize;
+        for word in line.split_whitespace() {
+            let wlen = word.chars().count();
+            if cur_len > 0 && cur_len + 1 + wlen > width {
+                let _ = writeln!(out, "{cur}");
+                cur.clear();
+                cur_len = 0;
+            }
+            if cur_len > 0 {
+                cur.push(' ');
+                cur_len += 1;
+            }
+            if mark.contains(&wi) {
+                let _ = write!(cur, "\x1b[7m{word}\x1b[0m");
+            } else {
+                cur.push_str(word);
+            }
+            cur_len += wlen;
+            wi += 1;
+        }
+        if !cur.is_empty() {
+            let _ = writeln!(out, "{cur}");
+        }
+    }
 }
 
 /// `s` dimmed with ANSI escapes when `color` is set, verbatim otherwise.
@@ -436,6 +529,59 @@ mod tests {
     }
 
     #[test]
+    fn get_human_marks_the_matched_chunk() {
+        let turn = |block: &str| Turn {
+            seq: 1,
+            turn_uuid: "t".to_string(),
+            ts: "2026-06-19T01:29:59.000Z".to_string(),
+            role: "assistant".to_string(),
+            blocks: vec![block.to_string()],
+        };
+        let block = "The scores are computed first. The test checks that no future positions \
+                     are selected, so the implementation must mask out future keys. Then we go on.";
+        // A real chunk is cut mid-word at its start ("st" from "test") — the first mark word is
+        // dropped and the rest anchors.
+        let mark = "st checks that no future positions are selected, so the implementation";
+        let out = get_human("", &[turn(block)], false, 100, Some(mark));
+        assert!(out.contains("\u{1b}[7mchecks\u{1b}[0m"), "got: {out}");
+        assert!(out.contains("\u{1b}[7mimplementation\u{1b}[0m"));
+        assert!(out.contains("The scores are computed"));
+        // A mark that anchors nowhere renders the turn plain.
+        let plain = get_human(
+            "",
+            &[turn(block)],
+            false,
+            100,
+            Some("entirely unrelated words that never anchor anywhere at all"),
+        );
+        assert!(!plain.contains("\u{1b}[7m"));
+    }
+
+    #[test]
+    fn turn_rows_are_one_line_each() {
+        let turns = vec![
+            Turn {
+                seq: 1,
+                turn_uuid: "t1".to_string(),
+                ts: "2026-06-19T01:29:59.000Z".to_string(),
+                role: "assistant".to_string(),
+                blocks: vec!["some reasoning about the mask".to_string()],
+            },
+            Turn {
+                seq: 2,
+                turn_uuid: "t2".to_string(),
+                ts: "2026-06-19T01:30:10.000Z".to_string(),
+                role: "user".to_string(),
+                blocks: vec!["[tool_result Edit] file updated".to_string()],
+            },
+        ];
+        let rows = turn_rows(&turns, false, 100);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0], "2026-06-19 01:29  assistant  some reasoning about the mask");
+        assert_eq!(rows[1], "2026-06-19 01:30  user       Edit ⇒ file updated");
+    }
+
+    #[test]
     fn get_agent_is_byte_stable() {
         let t = Turn {
             seq: 3,
@@ -579,7 +725,7 @@ mod tests {
                 "[tool_result Edit] The file was updated".to_string(),
             ],
         };
-        let out = get_human("", &[t], false, 100);
+        let out = get_human("", &[t], false, 100, None);
         assert!(out.contains("── 2026-06-19 01:29 · assistant ──"));
         assert!(out.contains("plain reasoning text"));
         // Headline plus payload lines, not raw JSON.
@@ -602,7 +748,7 @@ mod tests {
                 r#"[tool_use Write] {{"file_path":"/a.rs","content":"{payload}"}}"#
             )],
         };
-        let out = get_human("", &[t], false, 100);
+        let out = get_human("", &[t], false, 100, None);
         assert!(out.contains("l6"));
         assert!(!out.contains("l7"));
         assert!(out.contains('…'));

--- a/src/render.rs
+++ b/src/render.rs
@@ -267,8 +267,10 @@ fn collapse(s: &str) -> String {
     out
 }
 
+/// Prose scent: whitespace-collapsed head. A split fragment of a tool chunk carries JSON-escaped
+/// whitespace as literal `\n`/`\t` — treat those as separators too.
 fn prose_head(s: &str) -> String {
-    collapse(s)
+    collapse(&s.replace("\\n", " ").replace("\\t", " "))
 }
 
 /// Truncate to `max` chars, backing up to a word boundary when one lands past the midpoint,
@@ -466,6 +468,13 @@ mod tests {
         // split_idx > 0 chunks carry no [tool_use …] label.
         let s = scent("tool_use", "  continuation   of a\nsplit blob  ");
         assert_eq!(s, "continuation of a split blob");
+    }
+
+    #[test]
+    fn scent_flattens_escaped_whitespace_in_fragments() {
+        // A fragment cut from inside a JSON string carries \n as two literal characters.
+        let s = scent("tool_use", r"ormed input.\n\n**Callers:** `Block.forward`");
+        assert_eq!(s, "ormed input. **Callers:** `Block.forward`");
     }
 
     #[test]

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,0 +1,598 @@
+//! Rendering for the read commands, over `recall`'s structured results.
+//!
+//! Two layouts over the same hits: [`recall_agent`]/[`get_agent`] are the machine format —
+//! byte-stable, its layout is a published contract (the `→ get` lines are parsed) and must not
+//! change. [`recall_human`]/[`get_human`] render for a terminal: one scannable line per hit, tool
+//! chunks compressed to a deterministic one-liner, scores and UUIDs left out.
+
+use crate::recall::{Hit, Turn};
+use chrono::{DateTime, Datelike, Utc};
+use std::fmt::Write as _;
+
+/// Longest scent ever built — beyond any line budget, so final truncation is [`ellipsize`]'s job.
+const SCENT_CAP: usize = 240;
+
+/// Payload lines a tool block shows in the human `get` view before folding.
+const PAYLOAD_LINES: usize = 6;
+
+/// The agent `recall` format: provenance header with score, a `→ get` line carrying `store_arg`
+/// (the pre-rendered ` --store <label>` suffix, empty for the built-in guide), a 400-char
+/// preview, and truncated neighbor lines per hit. Byte-stable — the layout is a published
+/// contract.
+pub fn recall_agent(note: &str, store_arg: &str, hits: &[(Hit, f64)]) -> String {
+    let mut out = note.to_string();
+    for (h, score) in hits {
+        let s8 = &h.session_id[..h.session_id.len().min(8)];
+        let _ = writeln!(
+            out,
+            "[{}] {} {}/{} {}  score={:.3}",
+            h.ts, h.harness, h.project, s8, h.block_type, score
+        );
+        let _ = writeln!(out, "  → get {} {}{}", h.session_id, h.turn_uuid, store_arg);
+        let preview: String = h.text.chars().take(400).collect();
+        let _ = writeln!(out, "{preview}");
+        for n in &h.neighbors {
+            let np: String = n.text.chars().take(160).collect();
+            let _ = writeln!(out, "  ~ [{} {} seq{}] {}", n.role, n.block_type, n.seq, np);
+        }
+        let _ = writeln!(out, "---");
+    }
+    out
+}
+
+/// The human `recall` list: `N  date  agent  project  scent`, one line per hit, fitted to
+/// `width`. Metadata dims when `color` is set; `now` anchors the date labels (years show only
+/// when some hit is from another year).
+pub fn recall_human(note: &str, hits: &[(Hit, f64)], color: bool, width: usize, now: DateTime<Utc>) -> String {
+    let with_year = hits.iter().any(|(h, _)| {
+        DateTime::parse_from_rfc3339(&h.ts)
+            .map(|t| t.year() != now.year())
+            .unwrap_or(false)
+    });
+    let rows: Vec<(String, &str, String)> = hits
+        .iter()
+        .map(|(h, _)| {
+            (
+                date_label(&h.ts, with_year),
+                harness_display(&h.harness),
+                ellipsize(project_display(&h.project), 24),
+            )
+        })
+        .collect();
+    let dw = rows.iter().map(|r| r.0.chars().count()).max().unwrap_or(0);
+    let hw = rows.iter().map(|r| r.1.chars().count()).max().unwrap_or(0);
+    let pw = rows.iter().map(|r| r.2.chars().count()).max().unwrap_or(0);
+
+    let mut out = note.to_string();
+    for (i, ((h, _), (date, har, proj))) in hits.iter().zip(&rows).enumerate() {
+        let meta = format!("{date:<dw$}  {har:<hw$}  {proj:<pw$}");
+        let budget = width.saturating_sub(4 + meta.chars().count() + 2).max(20);
+        let line = ellipsize(&scent(&h.block_type, &h.text), budget);
+        let _ = writeln!(out, "{:>2}  {}  {}", i + 1, dim(&meta, color), line);
+    }
+    out
+}
+
+/// The agent `get` format: `[ts] role seqN turn=…` headers over reassembled blocks. Byte-stable.
+pub fn get_agent(note: &str, turns: &[Turn]) -> String {
+    let mut out = note.to_string();
+    for t in turns {
+        let _ = writeln!(out, "[{}] {} seq{} turn={}", t.ts, t.role, t.seq, t.turn_uuid);
+        let _ = writeln!(out, "{}", t.blocks.join("\n\n"));
+        let _ = writeln!(out, "---");
+    }
+    out
+}
+
+/// The human `get` view: a dim `── time · role ──` header per turn, prose blocks wrapped in full,
+/// tool blocks compressed to a one-liner plus the payload head (an Edit's `new_string`, a Write's
+/// `content`, a Bash command).
+pub fn get_human(note: &str, turns: &[Turn], color: bool, width: usize) -> String {
+    let mut out = note.to_string();
+    for t in turns {
+        let stamp: String = t.ts.chars().take(16).collect::<String>().replace('T', " ");
+        let _ = writeln!(out, "{}", dim(&format!("── {stamp} · {} ──", t.role), color));
+        for b in &t.blocks {
+            if b.starts_with("[tool_use") {
+                let payload = tool_payload(b);
+                // With a payload shown below, the one-liner stays a headline; without one it
+                // carries the detail itself.
+                let line = match payload {
+                    Some(_) => tool_use_headline(b).unwrap_or_else(|| scent("tool_use", b)),
+                    None => scent("tool_use", b),
+                };
+                let _ = writeln!(out, "  {}", dim(&ellipsize(&line, width.saturating_sub(2)), color));
+                if let Some(p) = payload {
+                    let lines: Vec<&str> = p.lines().collect();
+                    for l in lines.iter().take(PAYLOAD_LINES) {
+                        write_wrapped(&mut out, l, width.saturating_sub(2), "  ");
+                    }
+                    if lines.len() > PAYLOAD_LINES {
+                        let _ = writeln!(out, "  {}", dim("…", color));
+                    }
+                }
+            } else if b.starts_with("[tool_result") {
+                let line = scent("tool_result", b);
+                let _ = writeln!(out, "  {}", dim(&ellipsize(&line, width.saturating_sub(2)), color));
+            } else {
+                for l in b.lines() {
+                    write_wrapped(&mut out, l, width, "");
+                }
+            }
+            out.push('\n');
+        }
+    }
+    out
+}
+
+/// `s` dimmed with ANSI escapes when `color` is set, verbatim otherwise.
+pub fn dim(s: &str, color: bool) -> String {
+    if color {
+        format!("\x1b[2m{s}\x1b[0m")
+    } else {
+        s.to_string()
+    }
+}
+
+/// One line of scent for a chunk: tool chunks compress to `verb target — detail`, prose collapses
+/// to its head. `text` is the chunk as stored (`[tool_use Name] {json}` for tool blocks; a split
+/// fragment carries no label and reads as prose).
+fn scent(block_type: &str, text: &str) -> String {
+    match block_type {
+        "tool_use" => tool_use_scent(text).unwrap_or_else(|| prose_head(text)),
+        "tool_result" => tool_result_scent(text).unwrap_or_else(|| prose_head(text)),
+        _ => prose_head(text),
+    }
+}
+
+/// `Edit docs/functions.md — <new text>`, `Bash — <description> — <command>`, or `Name — <args>`;
+/// None when the `[tool_use …]` label is absent (a split fragment).
+fn tool_use_scent(text: &str) -> Option<String> {
+    let (name, args) = tool_use_parts(text)?;
+    Some(join_scent(
+        &headline(name, args),
+        detail(name, args).map(|d| collapse(&d)),
+    ))
+}
+
+/// The headline half of a tool one-liner — verb and target, no content.
+fn tool_use_headline(text: &str) -> Option<String> {
+    let (name, args) = tool_use_parts(text)?;
+    Some(headline(name, args))
+}
+
+/// Split `[tool_use Name] {json}` into name and args.
+fn tool_use_parts(text: &str) -> Option<(&str, &str)> {
+    let rest = text.strip_prefix("[tool_use ")?;
+    let (name, args) = rest.split_once(']')?;
+    Some((name, args.trim_start()))
+}
+
+fn headline(name: &str, args: &str) -> String {
+    match json_str(args, "file_path").as_deref().map(short_path) {
+        Some(p) => format!("{name} {p}"),
+        None => join_scent(name, json_str(args, "description").map(|d| collapse(&d))),
+    }
+}
+
+/// The content payload of a tool call, newlines intact — what the human `get` view prints under
+/// the headline.
+fn detail(name: &str, args: &str) -> Option<String> {
+    match name {
+        "Edit" | "MultiEdit" => json_str(args, "new_string").or_else(|| json_str(args, "old_string")),
+        "Write" => json_str(args, "content"),
+        "Bash" => json_str(args, "command"),
+        // The headline already names the target file; otherwise fall back to the raw args.
+        _ => match json_str(args, "file_path") {
+            Some(_) => None,
+            None => {
+                let a = collapse(args);
+                (!a.is_empty()).then_some(a)
+            }
+        },
+    }
+}
+
+/// `Name ⇒ <first of the result>`; None when the `[tool_result…]` label is absent.
+fn tool_result_scent(text: &str) -> Option<String> {
+    let rest = text.strip_prefix("[tool_result")?;
+    let (label, body) = rest.split_once(']')?;
+    let name = label.trim();
+    let head = collapse(body);
+    Some(if name.is_empty() {
+        format!("⇒ {head}")
+    } else {
+        format!("{name} ⇒ {head}")
+    })
+}
+
+/// The payload a tool block shows in the human `get` view; None for tools whose args aren't
+/// content (Read, unknown tools).
+fn tool_payload(text: &str) -> Option<String> {
+    let (name, args) = tool_use_parts(text)?;
+    match name {
+        "Edit" | "MultiEdit" | "Write" | "Bash" => detail(name, args).filter(|d| !d.trim().is_empty()),
+        _ => None,
+    }
+}
+
+fn join_scent(head: &str, detail: Option<String>) -> String {
+    match detail.filter(|d| !d.is_empty()) {
+        Some(d) => format!("{} — {}", head.trim(), d),
+        None => head.trim().to_string(),
+    }
+}
+
+/// The string value of `"key"` in a JSON-ish blob, decoded loosely and tolerant of truncation: a
+/// chunk split can cut the JSON mid-string, so a missing closing quote returns the partial value.
+fn json_str(s: &str, key: &str) -> Option<String> {
+    let pat = format!("\"{key}\"");
+    let at = s.find(&pat)? + pat.len();
+    let rest = s[at..].trim_start().strip_prefix(':')?.trim_start().strip_prefix('"')?;
+    let mut out = String::new();
+    let mut chars = rest.chars();
+    while let Some(c) = chars.next() {
+        match c {
+            '"' => break,
+            '\\' => match chars.next() {
+                Some('n') => out.push('\n'),
+                Some('t') => out.push('\t'),
+                Some(e) => out.push(e),
+                None => break,
+            },
+            _ => out.push(c),
+        }
+    }
+    Some(out)
+}
+
+/// The last two path components — enough to place a file without the machine prefix.
+fn short_path(p: &str) -> String {
+    let parts: Vec<&str> = p.rsplit('/').filter(|s| !s.is_empty()).take(2).collect();
+    parts.into_iter().rev().collect::<Vec<_>>().join("/")
+}
+
+/// Whitespace-collapsed head of `s`, capped at [`SCENT_CAP`].
+fn collapse(s: &str) -> String {
+    let mut out = String::new();
+    for w in s.split_whitespace() {
+        if !out.is_empty() {
+            out.push(' ');
+        }
+        out.push_str(w);
+        if out.chars().count() >= SCENT_CAP {
+            break;
+        }
+    }
+    out
+}
+
+fn prose_head(s: &str) -> String {
+    collapse(s)
+}
+
+/// Truncate to `max` chars, backing up to a word boundary when one lands past the midpoint,
+/// appending `…`.
+fn ellipsize(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let cut: String = s.chars().take(max.saturating_sub(1)).collect();
+    let kept = match cut.rfind(' ') {
+        Some(i) if i * 2 > cut.len() => &cut[..i],
+        _ => cut.as_str(),
+    };
+    format!("{}…", kept.trim_end())
+}
+
+/// `Jun 19`, or `Jun 19 2025` when years matter; an unparseable ts falls back to its date prefix.
+fn date_label(ts: &str, with_year: bool) -> String {
+    match DateTime::parse_from_rfc3339(ts) {
+        Ok(t) if with_year => t.format("%b %e %Y").to_string(),
+        Ok(t) => t.format("%b %e").to_string(),
+        Err(_) => ts.chars().take(10).collect(),
+    }
+}
+
+/// The stored harness facet in its short spelling.
+fn harness_display(h: &str) -> &str {
+    match h {
+        "claude_code" => "claude",
+        other => other,
+    }
+}
+
+/// A munged absolute path (Claude project dirs turn `/` into `-`, so they start with `-`) shows
+/// its last segment; any other project name shows whole.
+fn project_display(p: &str) -> &str {
+    if p.starts_with('-') {
+        p.rsplit('-').find(|s| !s.is_empty()).unwrap_or(p)
+    } else {
+        p
+    }
+}
+
+/// Write one logical line word-wrapped to `width`, each row prefixed with `indent`; a blank line
+/// stays blank. Lines already within `width` pass through verbatim (indentation intact).
+fn write_wrapped(out: &mut String, line: &str, width: usize, indent: &str) {
+    if line.trim().is_empty() {
+        out.push('\n');
+        return;
+    }
+    if line.chars().count() <= width {
+        let _ = writeln!(out, "{indent}{line}");
+        return;
+    }
+    let width = width.max(20);
+    let mut cur = String::new();
+    let mut cur_len = 0usize;
+    for word in line.split_whitespace() {
+        let wlen = word.chars().count();
+        if wlen > width {
+            if cur_len > 0 {
+                let _ = writeln!(out, "{indent}{cur}");
+            }
+            let cs: Vec<char> = word.chars().collect();
+            let mut i = 0;
+            while cs.len() - i > width {
+                let row: String = cs[i..i + width].iter().collect();
+                let _ = writeln!(out, "{indent}{row}");
+                i += width;
+            }
+            cur = cs[i..].iter().collect();
+            cur_len = cur.chars().count();
+            continue;
+        }
+        if cur_len > 0 && cur_len + 1 + wlen > width {
+            let _ = writeln!(out, "{indent}{cur}");
+            cur.clear();
+            cur_len = 0;
+        }
+        if cur_len > 0 {
+            cur.push(' ');
+            cur_len += 1;
+        }
+        cur.push_str(word);
+        cur_len += wlen;
+    }
+    if !cur.is_empty() {
+        let _ = writeln!(out, "{indent}{cur}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::recall::Neighbor;
+    use chrono::TimeZone;
+
+    fn hit(ts: &str, block_type: &str, text: &str) -> Hit {
+        Hit {
+            text: text.to_string(),
+            session_id: "0123456789abcdef".to_string(),
+            project: "-home-u-funes".to_string(),
+            turn_uuid: "aaaa-bbbb".to_string(),
+            seq: 7,
+            ts: ts.to_string(),
+            block_type: block_type.to_string(),
+            harness: "claude_code".to_string(),
+            neighbors: vec![],
+        }
+    }
+
+    // The agent format is a published contract — its `→ get` line is parsed. Pin it
+    // byte-for-byte.
+    #[test]
+    fn agent_format_is_byte_stable() {
+        let mut h = hit("2026-06-19T01:29:59.000Z", "text", "the decision was made");
+        h.neighbors.push(Neighbor {
+            seq: 5,
+            role: "assistant".to_string(),
+            block_type: "text".to_string(),
+            text: "hello".to_string(),
+        });
+        let out = recall_agent("", " --store hf://datasets/acme/kb", &[(h, 0.5781)]);
+        assert_eq!(
+            out,
+            "[2026-06-19T01:29:59.000Z] claude_code -home-u-funes/01234567 text  score=0.578\n\
+             \x20 → get 0123456789abcdef aaaa-bbbb --store hf://datasets/acme/kb\n\
+             the decision was made\n\
+             \x20 ~ [assistant text seq5] hello\n\
+             ---\n"
+        );
+        // The built-in guide has no store to name: an empty suffix keeps the hint bare.
+        let bare = recall_agent("", "", &[(hit("2026-06-19T01:29:59.000Z", "text", "x"), 0.5)]);
+        assert!(bare.contains("  → get 0123456789abcdef aaaa-bbbb\n"), "got: {bare}");
+    }
+
+    #[test]
+    fn agent_prepends_note_and_truncates_preview() {
+        let long: String = "x".repeat(500);
+        let out = recall_agent("remote down\n", "", &[(hit("bad-ts", "text", &long), 1.0)]);
+        assert!(out.starts_with("remote down\n[bad-ts]"));
+        // 400-char preview cap.
+        assert!(out.contains(&"x".repeat(400)));
+        assert!(!out.contains(&"x".repeat(401)));
+    }
+
+    #[test]
+    fn get_agent_is_byte_stable() {
+        let t = Turn {
+            seq: 3,
+            turn_uuid: "t-1".to_string(),
+            ts: "2026-06-19T01:29:59.000Z".to_string(),
+            role: "assistant".to_string(),
+            blocks: vec!["first".to_string(), "second".to_string()],
+        };
+        assert_eq!(
+            get_agent("", &[t]),
+            "[2026-06-19T01:29:59.000Z] assistant seq3 turn=t-1\nfirst\n\nsecond\n---\n"
+        );
+    }
+
+    #[test]
+    fn scent_compresses_an_edit() {
+        let s = scent(
+            "tool_use",
+            r####"[tool_use Edit] {"file_path":"/home/lane/MythosMini/docs/functions.md","old_string":"a","new_string":"### Attention.attend_selected\n\n**Purpose:** Computes sparse attention"}"####,
+        );
+        assert_eq!(
+            s,
+            "Edit docs/functions.md — ### Attention.attend_selected **Purpose:** Computes sparse attention"
+        );
+    }
+
+    #[test]
+    fn scent_bash_prefers_description() {
+        let s = scent(
+            "tool_use",
+            r#"[tool_use Bash] {"command":"cargo test -q","description":"Run the suite"}"#,
+        );
+        assert_eq!(s, "Bash — Run the suite — cargo test -q");
+    }
+
+    #[test]
+    fn scent_survives_json_cut_mid_string() {
+        // A chunk split can end the stored text in the middle of a JSON string.
+        let s = scent(
+            "tool_use",
+            r#"[tool_use Edit] {"file_path":"/a/b/c.rs","new_string":"let x = compute("#,
+        );
+        assert_eq!(s, "Edit b/c.rs — let x = compute(");
+    }
+
+    #[test]
+    fn scent_unlabeled_fragment_reads_as_prose() {
+        // split_idx > 0 chunks carry no [tool_use …] label.
+        let s = scent("tool_use", "  continuation   of a\nsplit blob  ");
+        assert_eq!(s, "continuation of a split blob");
+    }
+
+    #[test]
+    fn scent_tool_result_takes_the_head() {
+        let s = scent("tool_result", "[tool_result Edit] The file was updated\nmore lines");
+        assert_eq!(s, "Edit ⇒ The file was updated more lines");
+        assert_eq!(scent("tool_result", "[tool_result] ok"), "⇒ ok");
+    }
+
+    #[test]
+    fn scent_prose_collapses_whitespace() {
+        assert_eq!(scent("thinking", " a\n b\t c "), "a b c");
+    }
+
+    #[test]
+    fn human_is_one_line_per_hit_with_columns() {
+        let now = Utc.with_ymd_and_hms(2026, 7, 6, 0, 0, 0).unwrap();
+        let hits = vec![
+            (
+                hit(
+                    "2026-06-19T01:29:59.000Z",
+                    "thinking",
+                    "apply top-k selection per query token",
+                ),
+                0.9,
+            ),
+            (
+                hit(
+                    "2026-06-18T01:00:00.000Z",
+                    "tool_use",
+                    r#"[tool_use Read] {"file_path":"/x/y.rs"}"#,
+                ),
+                0.8,
+            ),
+        ];
+        let out = recall_human("", &hits, false, 100, now);
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines.len(), 2);
+        assert_eq!(
+            lines[0],
+            " 1  Jun 19  claude  funes  apply top-k selection per query token"
+        );
+        assert_eq!(lines[1], " 2  Jun 18  claude  funes  Read x/y.rs");
+        // No agent plumbing in the human list.
+        assert!(!out.contains("score=") && !out.contains("→ get"));
+    }
+
+    #[test]
+    fn human_shows_years_when_hits_span_them() {
+        let now = Utc.with_ymd_and_hms(2026, 7, 6, 0, 0, 0).unwrap();
+        let hits = vec![(hit("2025-12-09T01:00:00.000Z", "text", "old"), 0.5)];
+        let out = recall_human("", &hits, false, 100, now);
+        assert!(out.contains("Dec  9 2025"), "got: {out}");
+    }
+
+    #[test]
+    fn human_dims_metadata_when_colored() {
+        let now = Utc.with_ymd_and_hms(2026, 7, 6, 0, 0, 0).unwrap();
+        let hits = vec![(hit("2026-06-19T01:29:59.000Z", "text", "x"), 0.5)];
+        assert!(recall_human("", &hits, true, 100, now).contains("\x1b[2m"));
+        assert!(!recall_human("", &hits, false, 100, now).contains("\x1b[2m"));
+    }
+
+    #[test]
+    fn human_fits_width() {
+        let now = Utc.with_ymd_and_hms(2026, 7, 6, 0, 0, 0).unwrap();
+        let long = "word ".repeat(100);
+        let hits = vec![(hit("2026-06-19T01:29:59.000Z", "text", &long), 0.5)];
+        for line in recall_human("", &hits, false, 80, now).lines() {
+            assert!(line.chars().count() <= 80, "overlong: {line}");
+        }
+    }
+
+    #[test]
+    fn get_human_compresses_tool_blocks_and_wraps_prose() {
+        let t = Turn {
+            seq: 3,
+            turn_uuid: "t-1".to_string(),
+            ts: "2026-06-19T01:29:59.000Z".to_string(),
+            role: "assistant".to_string(),
+            blocks: vec![
+                "plain reasoning text".to_string(),
+                r#"[tool_use Edit] {"file_path":"/a/docs/f.md","new_string":"line one\nline two"}"#.to_string(),
+                "[tool_result Edit] The file was updated".to_string(),
+            ],
+        };
+        let out = get_human("", &[t], false, 100);
+        assert!(out.contains("── 2026-06-19 01:29 · assistant ──"));
+        assert!(out.contains("plain reasoning text"));
+        // Headline plus payload lines, not raw JSON.
+        assert!(out.contains("  Edit docs/f.md"));
+        assert!(out.contains("  line one"));
+        assert!(out.contains("  line two"));
+        assert!(!out.contains("file_path"));
+        assert!(out.contains("  Edit ⇒ The file was updated"));
+    }
+
+    #[test]
+    fn get_human_folds_long_payloads() {
+        let payload: String = (1..=10).map(|i| format!("l{i}\\n")).collect();
+        let t = Turn {
+            seq: 1,
+            turn_uuid: "t".to_string(),
+            ts: "2026-06-19T01:29:59.000Z".to_string(),
+            role: "assistant".to_string(),
+            blocks: vec![format!(
+                r#"[tool_use Write] {{"file_path":"/a.rs","content":"{payload}"}}"#
+            )],
+        };
+        let out = get_human("", &[t], false, 100);
+        assert!(out.contains("l6"));
+        assert!(!out.contains("l7"));
+        assert!(out.contains('…'));
+    }
+
+    #[test]
+    fn project_display_unmangles_claude_dirs() {
+        assert_eq!(project_display("-Users-dcorvoysier-dev-funes"), "funes");
+        assert_eq!(project_display("Fable-5-traces"), "Fable-5-traces");
+    }
+
+    #[test]
+    fn ellipsize_prefers_word_boundaries() {
+        assert_eq!(ellipsize("short", 10), "short");
+        let e = ellipsize("alpha beta gamma delta", 15);
+        assert!(e.chars().count() <= 15);
+        assert!(e.ends_with('…'));
+        assert_eq!(e, "alpha beta…");
+    }
+}

--- a/src/render.rs
+++ b/src/render.rs
@@ -45,9 +45,10 @@ pub fn recall_agent(note: &str, store_arg: &str, hits: &[(Hit, f64)]) -> String 
 /// when some hit is from another year).
 pub fn recall_human(note: &str, hits: &[(Hit, f64)], color: bool, width: usize, now: DateTime<Utc>) -> String {
     let mut out = note.to_string();
-    // 4 = the ordinal prefix each line carries below.
-    for (i, row) in hit_rows(hits, color, width, now, 4).iter().enumerate() {
-        let _ = writeln!(out, "{:>2}  {}", i + 1, row);
+    // The ordinal column grows with the hit count; hit_rows budgets around it.
+    let ow = hits.len().to_string().len().max(2);
+    for (i, row) in hit_rows(hits, color, width, now, ow + 2).iter().enumerate() {
+        let _ = writeln!(out, "{:>ow$}  {}", i + 1, row);
     }
     out
 }
@@ -720,7 +721,10 @@ mod tests {
     fn human_fits_width() {
         let now = Utc.with_ymd_and_hms(2026, 7, 6, 0, 0, 0).unwrap();
         let long = "word ".repeat(100);
-        let hits = vec![(hit("2026-06-19T01:29:59.000Z", "text", &long), 0.5)];
+        // 105 hits: the 3-digit ordinals must widen the budget, not overflow it.
+        let hits: Vec<(Hit, f64)> = (0..105)
+            .map(|_| (hit("2026-06-19T01:29:59.000Z", "text", &long), 0.5))
+            .collect();
         for line in recall_human("", &hits, false, 80, now).lines() {
             assert!(line.chars().count() <= 80, "overlong: {line}");
         }


### PR DESCRIPTION
This pull request introduces a new, well-documented agent interface contract for `funes`, and significantly refactors the CLI to support both human-friendly and agent-stable output formats. It adds interactive hit selection and session browsing via fzf, and centralizes rendering logic. These changes improve usability for both human users and agent integrations, and clarify the supported interface.