### PR TITLE
fix(release): switch the dist profile to thin LTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,15 +54,15 @@ path = "benchmark/bench_index.rs"
 [profile.release]
 opt-level = 3
 
-# Distribution profile — what the release workflow publishes. fat LTO + a single codegen unit
-# give cross-crate dead-code elimination (funes links the full lance/DataFusion, arrow and ONNX
-# Runtime stacks but exercises a narrow slice of each), and strip drops the symbol table; together
-# ~222 MiB -> ~119 MiB. The final whole-program link is slow (~20 min) and uncacheable, so it runs
-# only for published builds — everyday `cargo build --release` keeps the fast profile above.
+# Distribution profile — what the release workflow publishes. thin LTO gives cross-crate
+# dead-code elimination (funes links the full lance/DataFusion, arrow and ONNX Runtime stacks but
+# exercises a narrow slice of each) and strip drops the symbol table, while fitting a 16 GiB CI
+# runner — fat LTO with one codegen unit merges the whole graph into a single module and gets the
+# build killed there mid-link. The LTO pass is uncacheable, so it runs only for published builds —
+# everyday `cargo build --release` keeps the fast profile above.
 [profile.dist]
 inherits = "release"
-lto = "fat"
-codegen-units = 1
+lto = "thin"
 strip = "symbols"
 
 # CI build profile. Keeps line numbers for our own code so test backtraces stay useful, but strips debuginfo


### PR DESCRIPTION
fat LTO with codegen-units=1 merges the whole lance/arrow/ort graph into one module while compiling the final crate; on a 16 GiB hosted runner that peak gets the build killed from outside (exit 143, no compiler error — seen in run 28822808279 six minutes into compiling funes itself, and the previous release only passed on retry). thin LTO keeps most of the cross-crate dead-code elimination at a fraction of the memory and wall time; the binary may grow some over fat's ~119 MiB.