### PR TITLE
Make ONNX dependency optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           # smaller caches that survive GitHub's 10 GB/repo limit instead of evicting.
           shared-key: ci
 
-      # Faster, lower-memory linker — keeps the heavy lance/onnxruntime link in budget.
+      # Faster, lower-memory linker — keeps the heavy lance link in budget.
       - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
 
       # lance-encoding (via lancedb) compiles protobuf in its build script.
@@ -58,8 +58,14 @@ jobs:
       - name: Format check
         run: cargo +nightly-2026-04-22 fmt --check
 
+      # Both backend variants, so a PR can't leave either failing fmt or a bumped linter — the
+      # onnx build/test job below only runs on merges. (fmt is feature-independent: one check
+      # covers both.)
       - name: Clippy
         run: cargo clippy --all-targets --profile ci -- -D warnings
+
+      - name: Clippy (onnx backend)
+        run: cargo clippy --all-targets --profile ci --no-default-features --features onnx -- -D warnings
 
       # trufflehog for the secret-scan unit tests, pinned to the version used locally.
       - name: Install trufflehog
@@ -102,14 +108,17 @@ jobs:
           curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin v3.95.5
           trufflehog --version
 
-      # Embedder/reranker weights (~hundreds of MB). Cache on main only — PRs restore
-      # main's copy, so there's no duplicate per-PR copy eating the 10 GB cache budget.
-      - name: Restore fastembed models
-        id: fastembed
+      # Embedder/reranker weights for the default (blas) backend (~1.2 GB of safetensors; funes
+      # downloads them into the HF cache on first use). Cache on main only — PRs restore main's
+      # copy, so there's no duplicate per-PR copy eating the 10 GB cache budget.
+      - name: Restore model weights
+        id: models
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: .fastembed_cache
-          key: fastembed-models-v1
+          path: |
+            ~/.cache/huggingface/hub/models--BAAI--bge-small-en-v1.5
+            ~/.cache/huggingface/hub/models--BAAI--bge-reranker-base
+          key: hf-models-blas-v1
 
       - name: Integration test
         run: cargo test --profile ci --test index_recall -- --nocapture
@@ -131,8 +140,56 @@ jobs:
           HF_FUNES_TEST_TOKEN: ${{ secrets.HF_FUNES_TEST_TOKEN }}
         run: cargo test --profile ci --test push_round_trip -- --nocapture
 
+      - name: Save model weights
+        if: ${{ !cancelled() && github.ref == 'refs/heads/main' && steps.models.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cache/huggingface/hub/models--BAAI--bge-small-en-v1.5
+            ~/.cache/huggingface/hub/models--BAAI--bge-reranker-base
+          key: hf-models-blas-v1
+
+  # The ONNX backend is an opt-in feature. Its lint runs on every PR (in lint-test above);
+  # the build + real-model integration test here run only on merges to main, so pull requests
+  # don't spend runners testing a backend they don't change.
+  onnx-variant:
+    name: ONNX Variant (merge only)
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    needs: lint-test
+    timeout-minutes: 45
+    env:
+      RUST_MIN_STACK: "16777216"
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          # Its own cache: the onnx feature set has different dependency fingerprints than the
+          # default jobs' `ci` key, so sharing would evict one to store the other.
+          shared-key: ci-onnx
+
+      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      # ONNX model files (fastembed's own cache, distinct from the safetensors the blas
+      # backend uses). This job only runs on main, so save directly on miss.
+      - name: Restore fastembed models
+        id: fastembed
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .fastembed_cache
+          key: fastembed-models-v1
+
+      - name: Integration test (onnx backend)
+        run: cargo test --profile ci --no-default-features --features onnx --test index_recall -- --nocapture
+
       - name: Save fastembed models
-        if: ${{ !cancelled() && github.ref == 'refs/heads/main' && steps.fastembed.outputs.cache-hit != 'true' }}
+        if: ${{ !cancelled() && steps.fastembed.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .fastembed_cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,10 +103,13 @@ jobs:
       !cancelled() &&
       (startsWith(github.ref, 'refs/tags/') || needs.compute.result == 'success'
         || github.event_name == 'pull_request' || github.ref == 'refs/heads/main')
-    # 24.04 (glibc 2.39): the prebuilt onnxruntime pulled by ort_sys/fastembed needs the
-    # glibc 2.38+ __isoc23_* symbols, so linking fails on 22.04.
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
+    # glibc compatibility is one-way: a binary runs on any glibc >= the one it was built against.
+    # Building inside 22.04 pins the floor at glibc 2.35 — on the 24.04 runner image, C deps
+    # compiled during the build would bind __isoc23_*@GLIBC_2.38 symbols. A check below enforces
+    # the floor on every build.
+    container: ubuntu:22.04
+    timeout-minutes: 90
     # Published builds (a dispatch release or a tag push) get the optimized `dist` profile; PR/main
     # validation builds use the fast `release` profile. Dispatch is the primary release path — it
     # builds before `publish` creates the tag — so gating on tags alone would ship unoptimized.
@@ -118,10 +121,22 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             arch: x86_64
+            objdump: objdump
           - target: aarch64-unknown-linux-gnu
             arch: aarch64
             features: --features vendored-openssl
+            objdump: aarch64-linux-gnu-objdump
     steps:
+      # Everything the bare container lacks: compilers and binutils, git for checkout/rust-cache,
+      # perl for the version stamp, curl/ca-certificates for the toolchain installs, wget for
+      # setup-mold, pkg-config + libssl-dev for the native x86_64 TLS link, cmake for zstd-sys,
+      # unzip for bootstrap-protoc, zstd for rust-cache compression.
+      - name: Install build dependencies
+        run: |
+          apt-get update
+          DEBIAN_FRONTEND=noninteractive apt-get install -y \
+            build-essential git perl curl ca-certificates pkg-config libssl-dev cmake unzip wget zstd
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
@@ -132,22 +147,28 @@ jobs:
         with:
           # Keyed by profile: fat-LTO deps have different fingerprints than the fast profile's, so a
           # shared key would make each profile's build restore the other's artifacts and recompile.
-          key: release-${{ matrix.target }}-${{ env.PROFILE }}
+          # The container tag is in the key because cargo fingerprints don't see the build image: a
+          # cache from another image would restore C objects bound to its newer glibc symbols.
+          key: release-ubuntu22.04-${{ matrix.target }}-${{ env.PROFILE }}
 
-      # Faster, lower-memory linker — keeps the heavy lance/onnxruntime link in budget.
+      # Faster, lower-memory linker — keeps the heavy lance link in budget. The action runs as
+      # root inside the container (no sudo) and downloads with wget, installed above.
       - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
 
+      # 22.04's packaged protoc is too old for the lance protos; bootstrap the pinned one.
       - name: Install protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+        run: |
+          ./scripts/bootstrap-protoc.sh
+          echo "PROTOC=$PWD/.tools/protoc/bin/protoc" >> "$GITHUB_ENV"
 
-      # aarch64 is cross-compiled on the x86_64 runner. gcc-aarch64-linux-gnu links the binary
-      # and (via the cc crate) builds vendored OpenSSL for the target; g++-aarch64-linux-gnu
-      # brings the target libstdc++ that onnxruntime (ort, C++) links against. cc derives the
-      # tool names from the target triple, so installing the packages is enough.
+      # aarch64 is cross-compiled inside the same 22.04 container, so its sysroot pins the same
+      # glibc 2.35 floor. gcc-aarch64-linux-gnu links the binary and (via the cc crate) builds
+      # vendored OpenSSL for the target; g++-aarch64-linux-gnu brings the target libstdc++.
+      # cc derives the tool names from the target triple, so installing the packages is enough.
       - name: Install aarch64 cross toolchain
         if: matrix.arch == 'aarch64'
         run: |
-          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+          DEBIAN_FRONTEND=noninteractive apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
           mkdir -p ~/.cargo
           {
             echo '[target.aarch64-unknown-linux-gnu]'
@@ -162,6 +183,17 @@ jobs:
 
       - name: Build
         run: cargo build --profile ${{ env.PROFILE }} --target ${{ matrix.target }} ${{ matrix.features }}
+
+      # The point of the container build: fail loudly if anything drags the floor above 22.04.
+      - name: Check the glibc floor
+        run: |
+          BIN="target/${{ matrix.target }}/${{ env.PROFILE }}/funes"
+          MAX=$(${{ matrix.objdump }} -T "$BIN" | grep -o 'GLIBC_[0-9.]*' | sort -V | tail -1)
+          echo "max glibc symbol version: $MAX"
+          if [ "$(printf '%s\n' "${MAX#GLIBC_}" 2.35 | sort -V | tail -1)" != "2.35" ]; then
+            echo "::error::binary requires $MAX, above the glibc 2.35 floor (Ubuntu 22.04)"
+            exit 1
+          fi
 
       - name: Package
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,3 +77,9 @@ Building needs `protoc` (lance compiles protobuf at build time): system package,
 `./scripts/bootstrap-protoc.sh` then `export PROTOC="$PWD/.tools/protoc/bin/protoc"`. Before
 calling work done: `cargo fmt && cargo clippy && cargo test` (the integration tests download the
 embedder/reranker weights on first run).
+
+Inference has two backends behind the `Embedder`/`Reranker` traits (`src/inference.rs`): the
+default `blas` (src/blas.rs, hand-written forward on Accelerate/faer) and the opt-in `onnx`
+(fastembed/ort). CI lints both on every PR, so also run
+`cargo clippy --all-targets --no-default-features --features onnx` before calling work done;
+`cargo run --release --features onnx --example bench_backends` A/Bs them (latency + agreement).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2681,6 +2681,9 @@ name = "esaxx-rs"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "ethnum"
@@ -2898,10 +2901,12 @@ dependencies = [
  "openssl-sys",
  "parquet",
  "rmcp",
+ "safetensors",
  "serde",
  "serde_json",
  "sha1 0.10.6",
  "tempfile",
+ "tokenizers",
  "tokio",
  "walkdir",
 ]
@@ -7842,6 +7847,7 @@ dependencies = [
  "derive_builder",
  "esaxx-rs",
  "getrandom 0.3.4",
+ "indicatif",
  "itertools 0.14.0",
  "log",
  "macro_rules_attribute",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,7 +58,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
 dependencies = [
- "equator",
+ "equator 0.4.2",
 ]
 
 [[package]]
@@ -501,6 +501,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "atomic-wait"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55b94919229f2c42292fd71ffa4b75e83193bffdd77b1e858cd55fd2d0b0ea8"
+dependencies = [
+ "libc",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1172,6 +1182,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "byteorder"
@@ -1594,6 +1618,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if 1.0.4",
+]
+
+[[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2448,6 +2485,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "defer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "930c7171c8df9fb1782bdf9b918ed9ed2d33d1d22300abb754f9085bc48bf8e8"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2610,6 +2653,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "dyn-stack"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c4713e43e2886ba72b8271aa66c93d722116acf7a75555cce11dcde84388fe8"
+dependencies = [
+ "bytemuck",
+ "dyn-stack-macros",
+]
+
+[[package]]
+name = "dyn-stack-macros"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
+
+[[package]]
 name = "earcutr"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2641,12 +2700,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "equator"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c35da53b5a021d2484a7cc49b2ac7f2d840f8236a286f84202369bd338d761ea"
+dependencies = [
+ "equator-macro 0.2.1",
+]
+
+[[package]]
 name = "equator"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
 dependencies = [
- "equator-macro",
+ "equator-macro 0.4.2",
+]
+
+[[package]]
+name = "equator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02da895aab06bbebefb6b2595f6d637b18c9ff629b4cd840965bb3164e4194b0"
+dependencies = [
+ "equator-macro 0.6.0",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf679796c0322556351f287a51b49e48f7c4986e727b5dd78c972d30e2e16cc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2659,6 +2759,12 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
+
+[[package]]
+name = "equator-macro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b14b339eb76d07f052cdbad76ca7c1310e56173a138095d3bf42a23c06ef5d8"
 
 [[package]]
 name = "equivalent"
@@ -2725,6 +2831,46 @@ dependencies = [
  "rayon-core",
  "smallvec",
  "zune-inflate",
+]
+
+[[package]]
+name = "faer"
+version = "0.24.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ab6df3dd147fe8d702a288b95bcd8fcc499ab572fc80da6828f60cd4d524d67"
+dependencies = [
+ "bytemuck",
+ "dyn-stack",
+ "equator 0.6.0",
+ "faer-traits",
+ "gemm",
+ "generativity",
+ "libm",
+ "nano-gemm",
+ "num-complex",
+ "num-traits",
+ "private-gemm-x86",
+ "pulp",
+ "rayon",
+ "reborrow",
+ "spindle",
+]
+
+[[package]]
+name = "faer-traits"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b87d23ed7ab1f26c0cba0e5b9e061a796fbb7dc170fa8bee6970055a1308bb0f"
+dependencies = [
+ "bytemuck",
+ "dyn-stack",
+ "generativity",
+ "libm",
+ "num-complex",
+ "num-traits",
+ "pulp",
+ "qd",
+ "reborrow",
 ]
 
 [[package]]
@@ -2889,6 +3035,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "faer",
  "fastembed",
  "futures",
  "hex",
@@ -2897,6 +3044,7 @@ dependencies = [
  "lance-index",
  "lance-io",
  "lance-linalg",
+ "multiversion",
  "object_store",
  "openssl-sys",
  "parquet",
@@ -3013,6 +3161,131 @@ checksum = "c8cf82cf76cd16485e56295a1377c775ce708c9f1a0be6b029076d60a245d213"
 dependencies = [
  "cfg-if 0.1.10",
 ]
+
+[[package]]
+name = "gemm"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa0673db364b12263d103b68337a68fbecc541d6f6b61ba72fe438654709eacb"
+dependencies = [
+ "dyn-stack",
+ "gemm-c32",
+ "gemm-c64",
+ "gemm-common",
+ "gemm-f16",
+ "gemm-f32",
+ "gemm-f64",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c32"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "086936dbdcb99e37aad81d320f98f670e53c1e55a98bee70573e83f95beb128c"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c64"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c8aeeeec425959bda4d9827664029ba1501a90a0d1e6228e48bef741db3a3f"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-common"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88027625910cc9b1085aaaa1c4bc46bb3a36aad323452b33c25b5e4e7c8e2a3e"
+dependencies = [
+ "bytemuck",
+ "dyn-stack",
+ "half",
+ "libm",
+ "num-complex",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "pulp",
+ "raw-cpuid",
+ "rayon",
+ "seq-macro",
+ "sysctl",
+]
+
+[[package]]
+name = "gemm-f16"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3df7a55202e6cd6739d82ae3399c8e0c7e1402859b30e4cb780e61525d9486e"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "gemm-f32",
+ "half",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "rayon",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f32"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e0b8c9da1fbec6e3e3ab2ce6bc259ef18eb5f6f0d3e4edf54b75f9fd41a81c"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f64"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "056131e8f2a521bfab322f804ccd652520c79700d81209e9d9275bbdecaadc6a"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "generativity"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c81fb5260e37854d09d5c87183309fd8c555b75289427884b25660bc87a85e"
 
 [[package]]
 name = "generator"
@@ -3288,6 +3561,7 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
+ "bytemuck",
  "cfg-if 1.0.4",
  "crunchy",
  "num-traits",
@@ -3900,6 +4174,17 @@ name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
+name = "interpol"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb58032ba748f4010d15912a1855a8a0b1ba9eaad3395b0c171c09b3b356ae50"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "interpolate_name"
@@ -4988,6 +5273,98 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "multiversion"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edb7f0ff51249dfda9ab96b5823695e15a052dc15074c9dbf3d118afaf2c201"
+dependencies = [
+ "multiversion-macros",
+ "target-features",
+]
+
+[[package]]
+name = "multiversion-macros"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b093064383341eb3271f42e381cb8f10a01459478446953953c75d24bd339fc0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "target-features",
+]
+
+[[package]]
+name = "nano-gemm"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e04345dc84b498ff89fe0d38543d1f170da9e43a2c2bcee73a0f9069f72d081"
+dependencies = [
+ "equator 0.2.2",
+ "nano-gemm-c32",
+ "nano-gemm-c64",
+ "nano-gemm-codegen",
+ "nano-gemm-core",
+ "nano-gemm-f32",
+ "nano-gemm-f64",
+ "num-complex",
+]
+
+[[package]]
+name = "nano-gemm-c32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0775b1e2520e64deee8fc78b7732e3091fb7585017c0b0f9f4b451757bbbc562"
+dependencies = [
+ "nano-gemm-codegen",
+ "nano-gemm-core",
+ "num-complex",
+]
+
+[[package]]
+name = "nano-gemm-c64"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9af49a20d58816e6b5ee65f64142e50edb5eba152678d4bb7377fcbf63f8437a"
+dependencies = [
+ "nano-gemm-codegen",
+ "nano-gemm-core",
+ "num-complex",
+]
+
+[[package]]
+name = "nano-gemm-codegen"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cc8d495c791627779477a2cf5df60049f5b165342610eb0d76bee5ff5c5d74c"
+
+[[package]]
+name = "nano-gemm-core"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d998dfa644de87a0f8660e5ea511d7cb5c33b5a2d9847b7af57a2565105089f0"
+
+[[package]]
+name = "nano-gemm-f32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879d962e79bc8952e4ad21ca4845a21132540ed3f5e01184b2ff7f720e666523"
+dependencies = [
+ "nano-gemm-codegen",
+ "nano-gemm-core",
+]
+
+[[package]]
+name = "nano-gemm-f64"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9a513473dce7dc00c7e7c318481ca4494034e76997218d8dad51bd9f007a815"
+dependencies = [
+ "nano-gemm-codegen",
+ "nano-gemm-core",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5124,6 +5501,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
+ "bytemuck",
  "num-traits",
 ]
 
@@ -6020,6 +6398,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "private-gemm-x86"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0af8c3e5087969c323f667ccb4b789fa0954f5aa650550e38e81cf9108be21b5"
+dependencies = [
+ "crossbeam",
+ "defer",
+ "interpol",
+ "num_cpus",
+ "raw-cpuid",
+ "rayon",
+ "spindle",
+ "sysctl",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6108,10 +6502,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulp"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046aa45b989642ec2e4717c8e72d677b13edd831a4d3b6cf37d9a3e54912496a"
+dependencies = [
+ "bytemuck",
+ "cfg-if 1.0.4",
+ "libm",
+ "num-complex",
+ "paste",
+ "pulp-wasm-simd-flag",
+ "raw-cpuid",
+ "reborrow",
+ "version_check",
+]
+
+[[package]]
+name = "pulp-wasm-simd-flag"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d8f70e07b9c3962945a74e59ca1c511bba65b6419468acc217c457d93f3c740"
+
+[[package]]
 name = "pxfm"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "qd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f1304a5aecdcfe9ee72fbba90aa37b3aa067a69d14cb7f3d9deada0be7c07c"
+dependencies = [
+ "bytemuck",
+ "libm",
+ "num-traits",
+ "pulp",
+]
 
 [[package]]
 name = "qoi"
@@ -6405,6 +6834,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6440,6 +6878,12 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "reborrow"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
 name = "redb"
@@ -7469,6 +7913,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "spindle"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aaca3d8aa5387a6eba861fbf984af5348d9df5d940c25c6366b19556fdf64"
+dependencies = [
+ "atomic-wait",
+ "crossbeam",
+ "equator 0.4.2",
+ "loom",
+ "rayon",
+]
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7628,6 +8085,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysctl"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "enum-as-inner",
+ "libc",
+ "thiserror 1.0.69",
+ "walkdir",
+]
+
+[[package]]
 name = "sysinfo"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7673,6 +8144,12 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "target-features"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1bbb9f3c5c463a01705937a24fdabc5047929ac764b2d5b9cf681c1f5041ed5"
 
 [[package]]
 name = "tempfile"
@@ -8665,6 +9142,21 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -8734,6 +9226,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -8746,6 +9244,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -8755,6 +9259,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8782,6 +9292,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -8791,6 +9307,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -8806,6 +9328,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -8815,6 +9343,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,11 +43,17 @@ openssl-sys = { version = "0.9", optional = true }
 tokenizers = { version = "0.22", optional = true }  # already in the tree via fastembed
 safetensors = { version = "0.8", optional = true }  # already in the tree; unify (no duplicate)
 
+# The `blas` backend's Linux seam. Both are pure Rust with runtime CPU dispatch, so release
+# binaries stay baseline x86-64/aarch64 yet use AVX2/AVX-512/NEON where the host has them.
+[target.'cfg(target_os = "linux")'.dependencies]
+faer = { version = "0.24", optional = true, default-features = false, features = ["std", "rayon"] }  # GEMM ("std" pulls its fast x86 kernels)
+multiversion = { version = "0.8", optional = true }  # per-CPU clones of the vectorized exp
+
 [features]
 vendored-openssl = ["openssl-sys/vendored"]
-# BLAS inference backend (src/blas.rs). macOS wires it to Accelerate (see build.rs);
-# Linux is a marked TODO. Off by default — funes uses the ONNX backend unless this is enabled.
-blas = ["dep:tokenizers", "dep:safetensors"]
+# BLAS inference backend (src/blas.rs). macOS wires it to Accelerate (see build.rs); Linux to
+# faer + a polynomial exp. Off by default — funes uses the ONNX backend unless this is enabled.
+blas = ["dep:tokenizers", "dep:safetensors", "dep:faer", "dep:multiversion"]
 
 # Benchmarks live under benchmark/ alongside their README; run via `cargo run --example <name>`.
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ hex = "0.4"
 walkdir = "2"                    # recursive *.jsonl walk
 rmcp = { version = "1", features = ["server", "macros", "transport-io", "schemars"] }  # MCP stdio server
 tempfile = "3"                   # temp dir for the pre-publish secret scan; temp files/dirs in tests
-hf-hub = { version = "1.0.0-rc.1", features = ["rustls-tls"] }  # native create_commit + parent_commit CAS + Xet upload
+hf-hub = { version = "1.0.0-rc.1", features = ["rustls-tls", "blocking"] }  # native create_commit + parent_commit CAS + Xet upload; blocking: model download in the blas backend
 # Optional handle on the transitively-pulled openssl-sys (native-tls, via fastembed + lance).
 # The `vendored-openssl` feature builds OpenSSL from source so the aarch64-linux cross-build
 # needs no target sysroot. Off by default — native and macOS builds keep their system TLS.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,12 @@ path = "benchmark/bench_recall.rs"
 name = "bench_index"
 path = "benchmark/bench_index.rs"
 
+# A/B the inference backends (ONNX vs BLAS). Run with the backend feature:
+#   cargo run --release --features blas --example bench_backends
+[[example]]
+name = "bench_backends"
+path = "benchmark/bench_backends.rs"
+
 [profile.release]
 opt-level = 3
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,9 +38,16 @@ hf-hub = { version = "1.0.0-rc.1", features = ["rustls-tls"] }  # native create_
 # The `vendored-openssl` feature builds OpenSSL from source so the aarch64-linux cross-build
 # needs no target sysroot. Off by default — native and macOS builds keep their system TLS.
 openssl-sys = { version = "0.9", optional = true }
+# The `blas` backend (feature below): a from-scratch forward that loads safetensors weights
+# and tokenizes itself, as an alternative to fastembed/ort. macOS runs it on Accelerate.
+tokenizers = { version = "0.22", optional = true }  # already in the tree via fastembed
+safetensors = { version = "0.8", optional = true }  # already in the tree; unify (no duplicate)
 
 [features]
 vendored-openssl = ["openssl-sys/vendored"]
+# BLAS inference backend (src/blas.rs). macOS wires it to Accelerate (see build.rs);
+# Linux is a marked TODO. Off by default — funes uses the ONNX backend unless this is enabled.
+blas = ["dep:tokenizers", "dep:safetensors"]
 
 # Benchmarks live under benchmark/ alongside their README; run via `cargo run --example <name>`.
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,9 @@ license = "Apache-2.0"
 repository = "https://github.com/huggingface/funes"
 
 [dependencies]
-fastembed = "5"                  # local CPU embeddings + rerank (ONNX/ort)
+# The `onnx` backend (feature below): embeddings + rerank on the ONNX Runtime. Off by default —
+# ort ships prebuilt against glibc 2.38, above the glibc 2.35 floor releases target (Ubuntu 22.04).
+fastembed = { version = "5", optional = true }
 arrow-array = "58"               # RecordBatch types (must match lance's arrow version)
 arrow-schema = "58"              # Schema/Field/DataType for building batches
 arrow-select = "58"              # filter_record_batch: drop secret-bearing rows before a push
@@ -34,14 +36,14 @@ walkdir = "2"                    # recursive *.jsonl walk
 rmcp = { version = "1", features = ["server", "macros", "transport-io", "schemars"] }  # MCP stdio server
 tempfile = "3"                   # temp dir for the pre-publish secret scan; temp files/dirs in tests
 hf-hub = { version = "1.0.0-rc.1", features = ["rustls-tls", "blocking"] }  # native create_commit + parent_commit CAS + Xet upload; blocking: model download in the blas backend
-# Optional handle on the transitively-pulled openssl-sys (native-tls, via fastembed + lance).
+# Optional handle on the transitively-pulled openssl-sys (native-tls, via lance).
 # The `vendored-openssl` feature builds OpenSSL from source so the aarch64-linux cross-build
 # needs no target sysroot. Off by default — native and macOS builds keep their system TLS.
 openssl-sys = { version = "0.9", optional = true }
 # The `blas` backend (feature below): a from-scratch forward that loads safetensors weights
-# and tokenizes itself, as an alternative to fastembed/ort. macOS runs it on Accelerate.
-tokenizers = { version = "0.22", optional = true }  # already in the tree via fastembed
-safetensors = { version = "0.8", optional = true }  # already in the tree; unify (no duplicate)
+# and tokenizes itself. macOS runs it on Accelerate, Linux on faer.
+tokenizers = { version = "0.22", optional = true }
+safetensors = { version = "0.8", optional = true }
 
 # The `blas` backend's Linux seam. Both are pure Rust with runtime CPU dispatch, so release
 # binaries stay baseline x86-64/aarch64 yet use AVX2/AVX-512/NEON where the host has them.
@@ -50,10 +52,14 @@ faer = { version = "0.24", optional = true, default-features = false, features =
 multiversion = { version = "0.8", optional = true }  # per-CPU clones of the vectorized exp
 
 [features]
+default = ["blas"]
 vendored-openssl = ["openssl-sys/vendored"]
-# BLAS inference backend (src/blas.rs). macOS wires it to Accelerate (see build.rs); Linux to
-# faer + a polynomial exp. Off by default — funes uses the ONNX backend unless this is enabled.
+# BLAS inference backend (src/blas.rs), the default: macOS wires it to Accelerate (see build.rs),
+# Linux to faer + a polynomial exp.
 blas = ["dep:tokenizers", "dep:safetensors", "dep:faer", "dep:multiversion"]
+# ONNX inference backend (fastembed/ort). When both backends are compiled in, `blas` is the one
+# funes runs; the ONNX types are the reference backend for bench_backends.
+onnx = ["dep:fastembed"]
 
 # Benchmarks live under benchmark/ alongside their README; run via `cargo run --example <name>`.
 [[example]]
@@ -64,8 +70,8 @@ path = "benchmark/bench_recall.rs"
 name = "bench_index"
 path = "benchmark/bench_index.rs"
 
-# A/B the inference backends (ONNX vs BLAS). Run with the backend feature:
-#   cargo run --release --features blas --example bench_backends
+# A/B the inference backends (BLAS vs ONNX as reference). Needs both compiled in:
+#   cargo run --release --features onnx --example bench_backends
 [[example]]
 name = "bench_backends"
 path = "benchmark/bench_backends.rs"
@@ -74,7 +80,7 @@ path = "benchmark/bench_backends.rs"
 opt-level = 3
 
 # Distribution profile — what the release workflow publishes. thin LTO gives cross-crate
-# dead-code elimination (funes links the full lance/DataFusion, arrow and ONNX Runtime stacks but
+# dead-code elimination (funes links the full lance/DataFusion and arrow stacks but
 # exercises a narrow slice of each) and strip drops the symbol table, while fitting a 16 GiB CI
 # runner — fat LTO with one codegen unit merges the whole graph into a single module and gets the
 # build killed there mid-link. The LTO pass is uncacheable, so it runs only for published builds —

--- a/README.md
+++ b/README.md
@@ -201,6 +201,15 @@ export PROTOC="$PWD/.tools/protoc/bin/protoc"
 Then `cargo build --release` (binary at `target/release/funes`); `cargo test` runs the suite. The
 integration test downloads the embedder/reranker weights on first run.
 
+Inference (embedding + reranking) runs on a built-in backend — Accelerate on macOS, pure Rust on
+Linux — so the default build has no ML runtime dependency and runs on any glibc ≥ 2.35 (Ubuntu
+22.04). An ONNX Runtime backend is available as an opt-in variant:
+
+```bash
+cargo build --release --no-default-features --features onnx   # ONNX backend instead
+cargo run --release --features onnx --example bench_backends  # A/B both backends
+```
+
 ## Notes
 
 - **Embedding model is pinned** and stamped into the store; querying with a different embedding

--- a/benchmark/bench_backends.rs
+++ b/benchmark/bench_backends.rs
@@ -1,15 +1,14 @@
 //! A/B the inference backends behind the `Embedder`/`Reranker` traits: latency + agreement (does a
 //! faster backend embed/rank the same as the reference?). Backend-agnostic and cross-platform — it
-//! compares whatever backends are compiled in. ONNX (fastembed) is always present and is the
-//! reference; enable others via features:
-//!   cargo run --release --features blas --example bench_backends
+//! compares whatever backends are compiled in, with ONNX (fastembed) as the reference when present:
+//!   cargo run --release --features onnx --example bench_backends
 //!
 //! Adding a backend = impl Embedder+Reranker, gate it behind a feature, and push it in `backends()`.
 
 use std::time::Instant;
 
 use anyhow::Result;
-use funes::inference::{Embedder, OnnxEmbedder, OnnxReranker, Reranker};
+use funes::inference::{Embedder, Reranker};
 
 const QUERY: &str = "why did we move the reranker off the onnx runtime";
 
@@ -42,12 +41,16 @@ struct Backend {
 
 fn backends() -> Result<Vec<Backend>> {
     let mut v: Vec<Backend> = Vec::new();
-    // ONNX is always available and serves as the agreement reference.
-    v.push(Backend {
-        name: "onnx",
-        emb: Box::new(OnnxEmbedder::new()?),
-        rr: Box::new(OnnxReranker::new()?),
-    });
+    // ONNX first when compiled in: the first backend is the agreement reference.
+    #[cfg(feature = "onnx")]
+    {
+        use funes::inference::{OnnxEmbedder, OnnxReranker};
+        v.push(Backend {
+            name: "onnx",
+            emb: Box::new(OnnxEmbedder::new()?),
+            rr: Box::new(OnnxReranker::new()?),
+        });
+    }
     #[cfg(feature = "blas")]
     {
         use funes::blas::{BlasEmbedder, BlasReranker};
@@ -82,7 +85,7 @@ fn main() -> Result<()> {
     let docs = docs();
     let mut backs = backends()?;
     if backs.len() < 2 {
-        eprintln!("note: only the `onnx` backend is compiled — enable another to compare, e.g. --features blas\n");
+        eprintln!("note: only one backend is compiled — build with `--features onnx` to A/B against the reference\n");
     }
 
     // Run each backend once for correctness, then time it. Reference = the first backend (onnx).

--- a/benchmark/bench_backends.rs
+++ b/benchmark/bench_backends.rs
@@ -3,6 +3,10 @@
 //! compares whatever backends are compiled in, with ONNX (fastembed) as the reference when present:
 //!   cargo run --release --features onnx --example bench_backends
 //!
+//! Two workloads, because they stress different things: a batch of short docs is dominated by
+//! per-call overheads (tokenization, thread spawns), while 30 docs at the 512-token truncation
+//! cap — recall's rerank worst case — is dominated by GEMM throughput and memory behavior.
+//!
 //! Adding a backend = impl Embedder+Reranker, gate it behind a feature, and push it in `backends()`.
 
 use std::time::Instant;
@@ -12,8 +16,8 @@ use funes::inference::{Embedder, Reranker};
 
 const QUERY: &str = "why did we move the reranker off the onnx runtime";
 
-fn docs() -> Vec<&'static str> {
-    vec![
+fn short_docs() -> Vec<String> {
+    [
         "the reranker is a cross-encoder scoring query-passage pairs jointly.",
         "onnx runtime uses MLAS on the CPU, which on Apple Silicon runs on NEON, not AMX.",
         "a hand-written forward calls Accelerate cblas_sgemm, which reaches the AMX matrix units.",
@@ -31,6 +35,16 @@ fn docs() -> Vec<&'static str> {
         "the marathon route winds through six neighborhoods before the riverside finish.",
         "hf-hub fetches whole files because the xet cdn taxes every byte-range read.",
     ]
+    .map(String::from)
+    .to_vec()
+}
+
+fn long_docs() -> Vec<String> {
+    let sent = "recall fuses vector ann and bm25 hits by reciprocal rank before the cross-encoder \
+                rescores each candidate against the query using joint attention over the pair. ";
+    // ~500 tokens after tokenization, truncated at 512 — recall's rerank candidates at the cap.
+    let doc = sent.repeat(18);
+    vec![doc; 30]
 }
 
 struct Backend {
@@ -63,15 +77,15 @@ fn backends() -> Result<Vec<Backend>> {
     Ok(v)
 }
 
-fn time<F: FnMut()>(mut f: F) -> f64 {
-    for _ in 0..2 {
+fn time<F: FnMut()>(warmups: usize, iters: usize, mut f: F) -> f64 {
+    for _ in 0..warmups {
         f();
     }
     let t = Instant::now();
-    for _ in 0..5 {
+    for _ in 0..iters {
         f();
     }
-    t.elapsed().as_secs_f64() * 1000.0 / 5.0
+    t.elapsed().as_secs_f64() * 1000.0 / iters as f64
 }
 
 fn cosine(a: &[f32], b: &[f32]) -> f32 {
@@ -82,43 +96,52 @@ fn cosine(a: &[f32], b: &[f32]) -> f32 {
 }
 
 fn main() -> Result<()> {
-    let docs = docs();
     let mut backs = backends()?;
     if backs.len() < 2 {
         eprintln!("note: only one backend is compiled — build with `--features onnx` to A/B against the reference\n");
     }
 
-    // Run each backend once for correctness, then time it. Reference = the first backend (onnx).
-    let mut emb_out: Vec<Vec<Vec<f32>>> = Vec::new();
-    let mut rr_out: Vec<Vec<f32>> = Vec::new();
+    // (label, docs, warmups, timed iters) — fewer iterations for the long shape, where a single
+    // forward runs for seconds.
+    let workloads = [("16×short", short_docs(), 2, 5), ("30×~500tok", long_docs(), 1, 3)];
+
     println!(
-        "{:<12} {:>10} {:>11} {:>16} {:>16}",
-        "backend", "embed ms", "rerank ms", "embed cos↔onnx", "rerank Δ↔onnx"
+        "{:<12} {:<12} {:>10} {:>11} {:>16} {:>16}",
+        "workload", "backend", "embed ms", "rerank ms", "embed cos↔ref", "rerank Δ↔ref"
     );
-    for b in backs.iter_mut() {
-        let e = b.emb.embed(&docs)?;
-        let r = b.rr.rerank(QUERY, &docs)?;
-        let ems = time(|| {
-            b.emb.embed(&docs).unwrap();
-        });
-        let rms = time(|| {
-            b.rr.rerank(QUERY, &docs).unwrap();
-        });
-        let (ecos, rdiff) = if emb_out.is_empty() {
-            ("(ref)".to_string(), "(ref)".to_string())
-        } else {
-            let ref_e = &emb_out[0];
-            let cos_min = e.iter().zip(ref_e).map(|(a, b)| cosine(a, b)).fold(1f32, f32::min);
-            let d = r
-                .iter()
-                .zip(&rr_out[0])
-                .map(|(a, b)| (a - b).abs())
-                .fold(0f32, f32::max);
-            (format!("{cos_min:.6}"), format!("{d:.6}"))
-        };
-        println!("{:<12} {ems:>10.1} {rms:>11.1} {ecos:>16} {rdiff:>16}", b.name);
-        emb_out.push(e);
-        rr_out.push(r);
+    for (label, docs, warmups, iters) in &workloads {
+        let docs: Vec<&str> = docs.iter().map(String::as_str).collect();
+        // Run each backend once for correctness, then time it. Reference = the first backend.
+        let mut emb_out: Vec<Vec<Vec<f32>>> = Vec::new();
+        let mut rr_out: Vec<Vec<f32>> = Vec::new();
+        for b in backs.iter_mut() {
+            let e = b.emb.embed(&docs)?;
+            let r = b.rr.rerank(QUERY, &docs)?;
+            let ems = time(*warmups, *iters, || {
+                b.emb.embed(&docs).unwrap();
+            });
+            let rms = time(*warmups, *iters, || {
+                b.rr.rerank(QUERY, &docs).unwrap();
+            });
+            let (ecos, rdiff) = if emb_out.is_empty() {
+                ("(ref)".to_string(), "(ref)".to_string())
+            } else {
+                let ref_e = &emb_out[0];
+                let cos_min = e.iter().zip(ref_e).map(|(a, b)| cosine(a, b)).fold(1f32, f32::min);
+                let d = r
+                    .iter()
+                    .zip(&rr_out[0])
+                    .map(|(a, b)| (a - b).abs())
+                    .fold(0f32, f32::max);
+                (format!("{cos_min:.6}"), format!("{d:.6}"))
+            };
+            println!(
+                "{label:<12} {:<12} {ems:>10.1} {rms:>11.1} {ecos:>16} {rdiff:>16}",
+                b.name
+            );
+            emb_out.push(e);
+            rr_out.push(r);
+        }
     }
     Ok(())
 }

--- a/benchmark/bench_backends.rs
+++ b/benchmark/bench_backends.rs
@@ -1,0 +1,121 @@
+//! A/B the inference backends behind the `Embedder`/`Reranker` traits: latency + agreement (does a
+//! faster backend embed/rank the same as the reference?). Backend-agnostic and cross-platform — it
+//! compares whatever backends are compiled in. ONNX (fastembed) is always present and is the
+//! reference; enable others via features:
+//!   cargo run --release --features blas --example bench_backends
+//!
+//! Adding a backend = impl Embedder+Reranker, gate it behind a feature, and push it in `backends()`.
+
+use std::time::Instant;
+
+use anyhow::Result;
+use funes::inference::{Embedder, OnnxEmbedder, OnnxReranker, Reranker};
+
+const QUERY: &str = "why did we move the reranker off the onnx runtime";
+
+fn docs() -> Vec<&'static str> {
+    vec![
+        "the reranker is a cross-encoder scoring query-passage pairs jointly.",
+        "onnx runtime uses MLAS on the CPU, which on Apple Silicon runs on NEON, not AMX.",
+        "a hand-written forward calls Accelerate cblas_sgemm, which reaches the AMX matrix units.",
+        "the embedding model is bge-small-en-v1.5, a 384-dimensional BERT sentence encoder.",
+        "recall fuses vector ANN and BM25 hits by reciprocal rank before reranking.",
+        "the store is a lance dataset with an IVF_PQ vector index and a full-text index.",
+        "candle's metal backend was missing a layer-norm kernel, so it could not run the model.",
+        "the cat knocked a glass off the counter and it shattered on the floor.",
+        "quarterly revenue rose twelve percent on strong subscription renewals.",
+        "tokenization uses the huggingface tokenizers crate loading the model's tokenizer.json.",
+        "softmax over the attention scores uses a vectorized exp from the platform seam.",
+        "the recipe needs two cups of flour, a teaspoon of salt, and three eggs.",
+        "fp8 has no hardware path on apple silicon, so int8 is the only accelerated low-precision.",
+        "attention masks let the transformer ignore padding tokens in a ragged batch.",
+        "the marathon route winds through six neighborhoods before the riverside finish.",
+        "hf-hub fetches whole files because the xet cdn taxes every byte-range read.",
+    ]
+}
+
+struct Backend {
+    name: &'static str,
+    emb: Box<dyn Embedder>,
+    rr: Box<dyn Reranker>,
+}
+
+fn backends() -> Result<Vec<Backend>> {
+    let mut v: Vec<Backend> = Vec::new();
+    // ONNX is always available and serves as the agreement reference.
+    v.push(Backend {
+        name: "onnx",
+        emb: Box::new(OnnxEmbedder::new()?),
+        rr: Box::new(OnnxReranker::new()?),
+    });
+    #[cfg(feature = "blas")]
+    {
+        use funes::blas::{BlasEmbedder, BlasReranker};
+        v.push(Backend {
+            name: "blas",
+            emb: Box::new(BlasEmbedder::new()?),
+            rr: Box::new(BlasReranker::new()?),
+        });
+    }
+    Ok(v)
+}
+
+fn time<F: FnMut()>(mut f: F) -> f64 {
+    for _ in 0..2 {
+        f();
+    }
+    let t = Instant::now();
+    for _ in 0..5 {
+        f();
+    }
+    t.elapsed().as_secs_f64() * 1000.0 / 5.0
+}
+
+fn cosine(a: &[f32], b: &[f32]) -> f32 {
+    let dot: f32 = a.iter().zip(b).map(|(x, y)| x * y).sum();
+    let na: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+    let nb: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+    dot / (na * nb)
+}
+
+fn main() -> Result<()> {
+    let docs = docs();
+    let mut backs = backends()?;
+    if backs.len() < 2 {
+        eprintln!("note: only the `onnx` backend is compiled — enable another to compare, e.g. --features blas\n");
+    }
+
+    // Run each backend once for correctness, then time it. Reference = the first backend (onnx).
+    let mut emb_out: Vec<Vec<Vec<f32>>> = Vec::new();
+    let mut rr_out: Vec<Vec<f32>> = Vec::new();
+    println!(
+        "{:<12} {:>10} {:>11} {:>16} {:>16}",
+        "backend", "embed ms", "rerank ms", "embed cos↔onnx", "rerank Δ↔onnx"
+    );
+    for b in backs.iter_mut() {
+        let e = b.emb.embed(&docs)?;
+        let r = b.rr.rerank(QUERY, &docs)?;
+        let ems = time(|| {
+            b.emb.embed(&docs).unwrap();
+        });
+        let rms = time(|| {
+            b.rr.rerank(QUERY, &docs).unwrap();
+        });
+        let (ecos, rdiff) = if emb_out.is_empty() {
+            ("(ref)".to_string(), "(ref)".to_string())
+        } else {
+            let ref_e = &emb_out[0];
+            let cos_min = e.iter().zip(ref_e).map(|(a, b)| cosine(a, b)).fold(1f32, f32::min);
+            let d = r
+                .iter()
+                .zip(&rr_out[0])
+                .map(|(a, b)| (a - b).abs())
+                .fold(0f32, f32::max);
+            (format!("{cos_min:.6}"), format!("{d:.6}"))
+        };
+        println!("{:<12} {ems:>10.1} {rms:>11.1} {ecos:>16} {rdiff:>16}", b.name);
+        emb_out.push(e);
+        rr_out.push(r);
+    }
+    Ok(())
+}

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,12 @@
+fn main() {
+    // The BLAS backend's macOS seam calls Accelerate (cblas_sgemm + vForce). Link the framework
+    // only when that backend is actually compiled: feature on AND target is macOS. A default build
+    // (feature off) or a Linux build links nothing here.
+    let blas = std::env::var("CARGO_FEATURE_BLAS").is_ok();
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    if blas && target_os == "macos" {
+        println!("cargo:rustc-link-lib=framework=Accelerate");
+    }
+    // Linux backend (when its seam is implemented): link the BLAS here, e.g.
+    //   if blas && target_os == "linux" { println!("cargo:rustc-link-lib=openblas"); }
+}

--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,10 @@
 fn main() {
     // The BLAS backend's macOS seam calls Accelerate (cblas_sgemm + vForce). Link the framework
     // only when that backend is actually compiled: feature on AND target is macOS. A default build
-    // (feature off) or a Linux build links nothing here.
+    // (feature off) links nothing here; the Linux seam is pure Rust (faer) and needs no link.
     let blas = std::env::var("CARGO_FEATURE_BLAS").is_ok();
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
     if blas && target_os == "macos" {
         println!("cargo:rustc-link-lib=framework=Accelerate");
     }
-    // Linux backend (when its seam is implemented): link the BLAS here, e.g.
-    //   if blas && target_os == "linux" { println!("cargo:rustc-link-lib=openblas"); }
 }

--- a/src/blas.rs
+++ b/src/blas.rs
@@ -308,19 +308,45 @@ fn l2_normalize(v: &mut [f32]) {
     }
 }
 
-/// Shared BERT-family encoder → last_hidden_state [n*l*h]. `mask[s*l+j]` 1=real, 0=pad.
-fn encode(w: &HashMap<String, Vec<f32>>, c: Cfg, ids: &[i64], mask: &[i64], n: usize, l: usize) -> Vec<f32> {
+/// Forward-pass buffers, owned by the model and reused across calls, growing to the high-water
+/// mark. Freeing them between forwards hands the pages back to the OS, and the next call pays a
+/// page fault per 4 KiB rewritten — hundreds of MB per forward (see linear()).
+#[derive(Default)]
+struct Scratch {
+    hid: Vec<f32>,
+    q: Vec<f32>,
+    k: Vec<f32>,
+    v: Vec<f32>,
+    ctx: Vec<f32>,
+    attn: Vec<f32>,
+    inter: Vec<f32>,
+    ffn_out: Vec<f32>,
+}
+
+/// Shared BERT-family encoder → last_hidden_state in `s.hid` [n*l*h]. `mask[s*l+j]` 1=real, 0=pad.
+fn encode(w: &HashMap<String, Vec<f32>>, c: Cfg, ids: &[i64], mask: &[i64], n: usize, l: usize, s: &mut Scratch) {
     let g = |k: &str| w.get(k).unwrap_or_else(|| panic!("missing weight {k}")).as_slice();
     let (h, ffn, hd, heads) = (c.h, c.ffn, c.hd, c.heads);
     let m = n * l;
     let word = g(&format!("{}embeddings.word_embeddings.weight", c.prefix));
     let pos = g(&format!("{}embeddings.position_embeddings.weight", c.prefix));
     let typ = g(&format!("{}embeddings.token_type_embeddings.weight", c.prefix));
-    let mut hid = vec![0f32; m * h];
-    for s in 0..n {
+    for (buf, len) in [
+        (&mut s.hid, m * h),
+        (&mut s.q, m * h),
+        (&mut s.k, m * h),
+        (&mut s.v, m * h),
+        (&mut s.ctx, m * h),
+        (&mut s.attn, m * h),
+        (&mut s.inter, m * ffn),
+        (&mut s.ffn_out, m * h),
+    ] {
+        buf.resize(len, 0.0);
+    }
+    for sq in 0..n {
         let mut run = 0i64;
         for i in 0..l {
-            let id = ids[s * l + i];
+            let id = ids[sq * l + i];
             let posid = if c.bert_pos {
                 i
             } else if id != PAD {
@@ -329,7 +355,7 @@ fn encode(w: &HashMap<String, Vec<f32>>, c: Cfg, ids: &[i64], mask: &[i64], n: u
             } else {
                 PAD as usize
             };
-            let dst = &mut hid[(s * l + i) * h..(s * l + i) * h + h];
+            let dst = &mut s.hid[(sq * l + i) * h..(sq * l + i) * h + h];
             let we = &word[id as usize * h..id as usize * h + h];
             let pe = &pos[posid * h..posid * h + h];
             for cc in 0..h {
@@ -338,56 +364,47 @@ fn encode(w: &HashMap<String, Vec<f32>>, c: Cfg, ids: &[i64], mask: &[i64], n: u
         }
     }
     layernorm(
-        &mut hid,
+        &mut s.hid,
         h,
         g(&format!("{}embeddings.LayerNorm.weight", c.prefix)),
         g(&format!("{}embeddings.LayerNorm.bias", c.prefix)),
     );
 
-    // Layer scratch, allocated once and reused across all layers (see linear()).
-    let mut q = vec![0f32; m * h];
-    let mut k = vec![0f32; m * h];
-    let mut v = vec![0f32; m * h];
-    let mut ctx = vec![0f32; m * h];
-    let mut attn = vec![0f32; m * h];
-    let mut inter = vec![0f32; m * ffn];
-    let mut ffn_out = vec![0f32; m * h];
-
     let scale = 1.0 / (hd as f32).sqrt();
     for ly in 0..c.layers {
         let p = format!("{}encoder.layer.{ly}", c.prefix);
         linear(
-            &hid,
+            &s.hid,
             m,
             h,
             g(&format!("{p}.attention.self.query.weight")),
             g(&format!("{p}.attention.self.query.bias")),
             h,
-            &mut q,
+            &mut s.q,
         );
         linear(
-            &hid,
+            &s.hid,
             m,
             h,
             g(&format!("{p}.attention.self.key.weight")),
             g(&format!("{p}.attention.self.key.bias")),
             h,
-            &mut k,
+            &mut s.k,
         );
         linear(
-            &hid,
+            &s.hid,
             m,
             h,
             g(&format!("{p}.attention.self.value.weight")),
             g(&format!("{p}.attention.self.value.bias")),
             h,
-            &mut v,
+            &mut s.v,
         );
 
         let seqs_per = ceil_div(n, nthreads()).max(1);
-        let (qr, kr, vr, maskr) = (&q, &k, &v, &mask);
+        let (qr, kr, vr, maskr) = (&s.q, &s.k, &s.v, &mask);
         std::thread::scope(|scope| {
-            for (gi, grp) in ctx.chunks_mut(seqs_per * l * h).enumerate() {
+            for (gi, grp) in s.ctx.chunks_mut(seqs_per * l * h).enumerate() {
                 scope.spawn(move || {
                     let mut qh = vec![0f32; l * hd];
                     let mut kh = vec![0f32; l * hd];
@@ -426,50 +443,49 @@ fn encode(w: &HashMap<String, Vec<f32>>, c: Cfg, ids: &[i64], mask: &[i64], n: u
             }
         });
         linear(
-            &ctx,
+            &s.ctx,
             m,
             h,
             g(&format!("{p}.attention.output.dense.weight")),
             g(&format!("{p}.attention.output.dense.bias")),
             h,
-            &mut attn,
+            &mut s.attn,
         );
-        par_add(&mut hid, &attn);
+        par_add(&mut s.hid, &s.attn);
         layernorm(
-            &mut hid,
+            &mut s.hid,
             h,
             g(&format!("{p}.attention.output.LayerNorm.weight")),
             g(&format!("{p}.attention.output.LayerNorm.bias")),
         );
 
         linear(
-            &hid,
+            &s.hid,
             m,
             h,
             g(&format!("{p}.intermediate.dense.weight")),
             g(&format!("{p}.intermediate.dense.bias")),
             ffn,
-            &mut inter,
+            &mut s.inter,
         );
-        gelu(&mut inter);
+        gelu(&mut s.inter);
         linear(
-            &inter,
+            &s.inter,
             m,
             ffn,
             g(&format!("{p}.output.dense.weight")),
             g(&format!("{p}.output.dense.bias")),
             h,
-            &mut ffn_out,
+            &mut s.ffn_out,
         );
-        par_add(&mut hid, &ffn_out);
+        par_add(&mut s.hid, &s.ffn_out);
         layernorm(
-            &mut hid,
+            &mut s.hid,
             h,
             g(&format!("{p}.output.LayerNorm.weight")),
             g(&format!("{p}.output.LayerNorm.bias")),
         );
     }
-    hid
 }
 
 // ---------------------------------------------------------------------------------------------
@@ -548,6 +564,7 @@ fn to_batch(encs: &[tokenizers::Encoding]) -> (Vec<i64>, Vec<i64>, usize, usize)
 pub struct BlasEmbedder {
     w: HashMap<String, Vec<f32>>,
     tok: Tokenizer,
+    scratch: Scratch,
 }
 
 impl BlasEmbedder {
@@ -556,6 +573,7 @@ impl BlasEmbedder {
         Ok(Self {
             w: load_weights(&dir)?,
             tok: load_tokenizer(&dir)?,
+            scratch: Scratch::default(),
         })
     }
 }
@@ -567,7 +585,8 @@ impl Embedder for BlasEmbedder {
             .encode_batch(texts.to_vec(), true)
             .map_err(|e| anyhow!("tokenize: {e}"))?;
         let (ids, mask, n, l) = to_batch(&encs);
-        let hid = encode(&self.w, EMBED, &ids, &mask, n, l);
+        encode(&self.w, EMBED, &ids, &mask, n, l, &mut self.scratch);
+        let hid = &self.scratch.hid;
         let h = EMBED.h;
         Ok((0..n)
             .map(|s| {
@@ -583,6 +602,7 @@ impl Embedder for BlasEmbedder {
 pub struct BlasReranker {
     w: HashMap<String, Vec<f32>>,
     tok: Tokenizer,
+    scratch: Scratch,
 }
 
 impl BlasReranker {
@@ -591,6 +611,7 @@ impl BlasReranker {
         Ok(Self {
             w: load_weights(&dir)?,
             tok: load_tokenizer(&dir)?,
+            scratch: Scratch::default(),
         })
     }
 }
@@ -603,7 +624,8 @@ impl Reranker for BlasReranker {
             .encode_batch(pairs, true)
             .map_err(|e| anyhow!("tokenize: {e}"))?;
         let (ids, mask, n, l) = to_batch(&encs);
-        let hid = encode(&self.w, RERANK, &ids, &mask, n, l);
+        encode(&self.w, RERANK, &ids, &mask, n, l, &mut self.scratch);
+        let hid = &self.scratch.hid;
         let h = RERANK.h;
         let mut cls = vec![0f32; n * h];
         for s in 0..n {

--- a/src/blas.rs
+++ b/src/blas.rs
@@ -38,6 +38,8 @@ mod seam {
             ldc: i32,
         );
         fn vvexpf(y: *mut f32, x: *const f32, n: *const i32);
+        fn vDSP_maxv(a: *const f32, stride: isize, out: *mut f32, n: usize);
+        fn vDSP_sve(a: *const f32, stride: isize, out: *mut f32, n: usize);
     }
     /// C[m,n] = alpha·op(A)·op(B); row-major; ta/tb are CBLAS 111 (NoTrans) / 112 (Trans).
     #[allow(clippy::too_many_arguments)]
@@ -77,6 +79,18 @@ mod seam {
     pub fn vexp(buf: &mut [f32]) {
         let n = buf.len() as i32;
         unsafe { vvexpf(buf.as_mut_ptr(), buf.as_ptr(), &n) };
+    }
+    /// Vectorized max reduction (empty slice → -inf, like the fold it replaces).
+    pub fn vmax(x: &[f32]) -> f32 {
+        let mut out = f32::MIN;
+        unsafe { vDSP_maxv(x.as_ptr(), 1, &mut out, x.len()) };
+        out
+    }
+    /// Vectorized sum reduction.
+    pub fn vsum(x: &[f32]) -> f32 {
+        let mut out = 0f32;
+        unsafe { vDSP_sve(x.as_ptr(), 1, &mut out, x.len()) };
+        out
     }
 }
 
@@ -149,6 +163,40 @@ mod seam {
             let p = (((((C[0] * r + C[1]) * r + C[2]) * r + C[3]) * r + C[4]) * r + 1.0) * r + 1.0;
             *x = p * f32::from_bits((((f as i32) + 127) << 23) as u32);
         }
+    }
+
+    /// A strict-order fold over floats can't be vectorized (reassociation changes the result);
+    /// independent lane accumulators make the reduction order fixed and the loop vectorizable.
+    /// LANES spans two AVX2 registers / four NEON ones.
+    const LANES: usize = 16;
+
+    /// Vectorized max reduction (empty slice → -inf, like the fold it replaces).
+    #[multiversion::multiversion(targets("x86_64+avx512f+avx512bw+avx512dq", "x86_64+avx2+fma"))]
+    pub fn vmax(x: &[f32]) -> f32 {
+        let mut acc = [f32::MIN; LANES];
+        let chunks = x.chunks_exact(LANES);
+        let rem = chunks.remainder();
+        for c in chunks {
+            for (a, v) in acc.iter_mut().zip(c) {
+                *a = a.max(*v);
+            }
+        }
+        let m = rem.iter().copied().fold(f32::MIN, f32::max);
+        acc.into_iter().fold(m, f32::max)
+    }
+
+    /// Vectorized sum reduction.
+    #[multiversion::multiversion(targets("x86_64+avx512f+avx512bw+avx512dq", "x86_64+avx2+fma"))]
+    pub fn vsum(x: &[f32]) -> f32 {
+        let mut acc = [0f32; LANES];
+        let chunks = x.chunks_exact(LANES);
+        let rem = chunks.remainder();
+        for c in chunks {
+            for (a, v) in acc.iter_mut().zip(c) {
+                *a += *v;
+            }
+        }
+        acc.into_iter().sum::<f32>() + rem.iter().sum::<f32>()
     }
 }
 
@@ -311,7 +359,7 @@ fn gelu(v: &mut [f32]) {
 fn softmax_rows(s: &mut [f32], rows: usize, cols: usize) {
     for r in 0..rows {
         let row = &mut s[r * cols..r * cols + cols];
-        let mx = row.iter().copied().fold(f32::MIN, f32::max);
+        let mx = seam::vmax(row);
         for v in row.iter_mut() {
             *v -= mx;
         }
@@ -319,8 +367,7 @@ fn softmax_rows(s: &mut [f32], rows: usize, cols: usize) {
     seam::vexp(s);
     for r in 0..rows {
         let row = &mut s[r * cols..r * cols + cols];
-        let sum: f32 = row.iter().sum();
-        let inv = 1.0 / sum;
+        let inv = 1.0 / seam::vsum(row);
         for v in row.iter_mut() {
             *v *= inv;
         }

--- a/src/blas.rs
+++ b/src/blas.rs
@@ -195,6 +195,13 @@ fn nthreads() -> usize {
     static N: OnceLock<usize> = OnceLock::new();
     *N.get_or_init(|| std::env::var("NT").ok().and_then(|s| s.parse().ok()).unwrap_or(8))
 }
+/// Worker count for compute-bound per-sequence work (attention, embedding gather): one worker per
+/// sequence up to the core count. Unlike the memory-bound `par_*` helpers (see `nthreads`), this
+/// work scales with cores, so it must not be capped by the small NT default.
+fn seq_workers(n: usize) -> usize {
+    let cores = std::thread::available_parallelism().map(|c| c.get()).unwrap_or(8);
+    n.min(cores).max(1)
+}
 fn ceil_div(a: usize, b: usize) -> usize {
     a.div_ceil(b)
 }
@@ -343,26 +350,34 @@ fn encode(w: &HashMap<String, Vec<f32>>, c: Cfg, ids: &[i64], mask: &[i64], n: u
     ] {
         buf.resize(len, 0.0);
     }
-    for sq in 0..n {
-        let mut run = 0i64;
-        for i in 0..l {
-            let id = ids[sq * l + i];
-            let posid = if c.bert_pos {
-                i
-            } else if id != PAD {
-                run += 1;
-                (PAD + run) as usize
-            } else {
-                PAD as usize
-            };
-            let dst = &mut s.hid[(sq * l + i) * h..(sq * l + i) * h + h];
-            let we = &word[id as usize * h..id as usize * h + h];
-            let pe = &pos[posid * h..posid * h + h];
-            for cc in 0..h {
-                dst[cc] = we[cc] + pe[cc] + typ[cc];
-            }
+    let seqs_per = ceil_div(n, seq_workers(n));
+    std::thread::scope(|scope| {
+        for (gi, grp) in s.hid.chunks_mut(seqs_per * l * h).enumerate() {
+            scope.spawn(move || {
+                for (si, seq) in grp.chunks_mut(l * h).enumerate() {
+                    let sq = gi * seqs_per + si;
+                    let mut run = 0i64;
+                    for i in 0..l {
+                        let id = ids[sq * l + i];
+                        let posid = if c.bert_pos {
+                            i
+                        } else if id != PAD {
+                            run += 1;
+                            (PAD + run) as usize
+                        } else {
+                            PAD as usize
+                        };
+                        let dst = &mut seq[i * h..i * h + h];
+                        let we = &word[id as usize * h..id as usize * h + h];
+                        let pe = &pos[posid * h..posid * h + h];
+                        for cc in 0..h {
+                            dst[cc] = we[cc] + pe[cc] + typ[cc];
+                        }
+                    }
+                }
+            });
         }
-    }
+    });
     layernorm(
         &mut s.hid,
         h,
@@ -401,7 +416,7 @@ fn encode(w: &HashMap<String, Vec<f32>>, c: Cfg, ids: &[i64], mask: &[i64], n: u
             &mut s.v,
         );
 
-        let seqs_per = ceil_div(n, nthreads()).max(1);
+        let seqs_per = ceil_div(n, seq_workers(n));
         let (qr, kr, vr, maskr) = (&s.q, &s.k, &s.v, &mask);
         std::thread::scope(|scope| {
             for (gi, grp) in s.ctx.chunks_mut(seqs_per * l * h).enumerate() {

--- a/src/blas.rs
+++ b/src/blas.rs
@@ -1,0 +1,573 @@
+//! A from-scratch forward for funes' two models — a BLAS-backed alternative to the ONNX backend
+//! (see `inference`). Every matmul goes through a small platform **seam** (`sgemm`/`vexp`); today
+//! macOS wires it to Accelerate (cblas_sgemm on AMX + vForce vvexpf), and Linux is a marked TODO
+//! (OpenBLAS/MKL + a vectorized exp). Everything else — the encoder, tokenization, the trait impls —
+//! is shared, cross-platform source. Gated behind the `blas` feature.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, bail, Context, Result};
+use safetensors::SafeTensors;
+use tokenizers::{PaddingParams, PaddingStrategy, Tokenizer, TruncationParams};
+
+use crate::inference::{Embedder, Reranker};
+
+// ---------------------------------------------------------------------------------------------
+// Platform seam: the ONLY OS-specific code. A Linux backend implements just these two functions
+// (plus the link in build.rs) and inherits the entire encoder below.
+// ---------------------------------------------------------------------------------------------
+#[cfg(target_os = "macos")]
+mod seam {
+    const ROW: i32 = 101;
+    extern "C" {
+        fn cblas_sgemm(
+            order: i32,
+            ta: i32,
+            tb: i32,
+            m: i32,
+            n: i32,
+            k: i32,
+            alpha: f32,
+            a: *const f32,
+            lda: i32,
+            b: *const f32,
+            ldb: i32,
+            beta: f32,
+            c: *mut f32,
+            ldc: i32,
+        );
+        fn vvexpf(y: *mut f32, x: *const f32, n: *const i32);
+    }
+    /// C[m,n] = alpha·op(A)·op(B); row-major; ta/tb are CBLAS 111 (NoTrans) / 112 (Trans).
+    #[allow(clippy::too_many_arguments)]
+    pub fn sgemm(
+        ta: i32,
+        tb: i32,
+        m: usize,
+        n: usize,
+        k: usize,
+        alpha: f32,
+        a: &[f32],
+        lda: usize,
+        b: &[f32],
+        ldb: usize,
+        y: &mut [f32],
+    ) {
+        unsafe {
+            cblas_sgemm(
+                ROW,
+                ta,
+                tb,
+                m as i32,
+                n as i32,
+                k as i32,
+                alpha,
+                a.as_ptr(),
+                lda as i32,
+                b.as_ptr(),
+                ldb as i32,
+                0.0,
+                y.as_mut_ptr(),
+                n as i32,
+            );
+        }
+    }
+    /// In-place vectorized exp: buf[i] = e^{buf[i]}.
+    pub fn vexp(buf: &mut [f32]) {
+        let n = buf.len() as i32;
+        unsafe { vvexpf(buf.as_mut_ptr(), buf.as_ptr(), &n) };
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod seam {
+    // TODO(linux backend): wire these to a fast BLAS + vectorized exp, then add the library link in
+    // build.rs (e.g. `cargo:rustc-link-lib=openblas`). cblas_sgemm has the *same* signature in
+    // OpenBLAS/BLIS/MKL as Accelerate — this is the only new code the Linux port needs.
+    #[allow(clippy::too_many_arguments)]
+    pub fn sgemm(
+        _ta: i32,
+        _tb: i32,
+        _m: usize,
+        _n: usize,
+        _k: usize,
+        _alpha: f32,
+        _a: &[f32],
+        _lda: usize,
+        _b: &[f32],
+        _ldb: usize,
+        _y: &mut [f32],
+    ) {
+        todo!("Linux: cblas_sgemm via OpenBLAS/MKL (+ link in build.rs)")
+    }
+    pub fn vexp(_buf: &mut [f32]) {
+        todo!("Linux: vectorized expf (MKL vsExp or a SIMD exp)")
+    }
+}
+
+const NO_T: i32 = 111;
+const T: i32 = 112;
+const EPS: f32 = 1e-5;
+const PAD: i64 = 1;
+const GELU_P: f32 = 0.3275911;
+const GELU_A: [f32; 5] = [0.254_829_6, -0.284_496_72, 1.421_413_8, -1.453_152_1, 1.061_405_4];
+const INV_SQRT2: f32 = std::f32::consts::FRAC_1_SQRT_2;
+
+/// A BERT-family encoder config. Reranker is XLM-R (pad-offset positions); embedder is BERT.
+#[derive(Clone, Copy)]
+struct Cfg {
+    prefix: &'static str,
+    h: usize,
+    heads: usize,
+    hd: usize,
+    ffn: usize,
+    layers: usize,
+    bert_pos: bool,
+}
+const RERANK: Cfg = Cfg {
+    prefix: "roberta.",
+    h: 768,
+    heads: 12,
+    hd: 64,
+    ffn: 3072,
+    layers: 12,
+    bert_pos: false,
+};
+const EMBED: Cfg = Cfg {
+    prefix: "",
+    h: 384,
+    heads: 12,
+    hd: 32,
+    ffn: 1536,
+    layers: 12,
+    bert_pos: true,
+};
+
+fn nthreads() -> usize {
+    use std::sync::OnceLock;
+    static N: OnceLock<usize> = OnceLock::new();
+    *N.get_or_init(|| std::env::var("NT").ok().and_then(|s| s.parse().ok()).unwrap_or(8))
+}
+fn ceil_div(a: usize, b: usize) -> usize {
+    a.div_ceil(b)
+}
+
+fn par_chunks<F: Fn(&mut [f32]) + Sync>(x: &mut [f32], f: F) {
+    let cs = ceil_div(x.len(), nthreads()).max(1);
+    std::thread::scope(|s| {
+        for chunk in x.chunks_mut(cs) {
+            let f = &f;
+            s.spawn(move || f(chunk));
+        }
+    });
+}
+fn par_rows<F: Fn(&mut [f32]) + Sync>(x: &mut [f32], row_len: usize, f: F) {
+    let cr = ceil_div(x.len() / row_len, nthreads()).max(1);
+    std::thread::scope(|s| {
+        for chunk in x.chunks_mut(cr * row_len) {
+            let f = &f;
+            s.spawn(move || {
+                for row in chunk.chunks_mut(row_len) {
+                    f(row);
+                }
+            });
+        }
+    });
+}
+fn par_add(dst: &mut [f32], src: &[f32]) {
+    let cs = ceil_div(dst.len(), nthreads()).max(1);
+    std::thread::scope(|s| {
+        for (d, sc) in dst.chunks_mut(cs).zip(src.chunks(cs)) {
+            s.spawn(move || {
+                for i in 0..d.len() {
+                    d[i] += sc[i];
+                }
+            });
+        }
+    });
+}
+
+/// y[m,out] = x[m,in] · W[out,in]ᵀ + b[out]
+fn linear(x: &[f32], m: usize, in_: usize, w: &[f32], b: &[f32], out: usize) -> Vec<f32> {
+    let mut y = vec![0f32; m * out];
+    seam::sgemm(NO_T, T, m, out, in_, 1.0, x, in_, w, in_, &mut y);
+    for r in 0..m {
+        let row = &mut y[r * out..r * out + out];
+        for c in 0..out {
+            row[c] += b[c];
+        }
+    }
+    y
+}
+
+fn layernorm(x: &mut [f32], h: usize, g: &[f32], b: &[f32]) {
+    par_rows(x, h, |row| {
+        let hf = row.len() as f32;
+        let mean: f32 = row.iter().sum::<f32>() / hf;
+        let var: f32 = row.iter().map(|v| (v - mean) * (v - mean)).sum::<f32>() / hf;
+        let inv = 1.0 / (var + EPS).sqrt();
+        for c in 0..row.len() {
+            row[c] = (row[c] - mean) * inv * g[c] + b[c];
+        }
+    });
+}
+
+/// Exact GELU: 0.5·x·(1+erf(x/√2)); erf via Abramowitz-Stegun 7.1.26, exp via the seam.
+fn gelu(v: &mut [f32]) {
+    par_chunks(v, |chunk| {
+        let n = chunk.len();
+        let mut e: Vec<f32> = chunk
+            .iter()
+            .map(|&x| {
+                let u = x * INV_SQRT2;
+                -u * u
+            })
+            .collect();
+        seam::vexp(&mut e);
+        for i in 0..n {
+            let x = chunk[i];
+            let u = x * INV_SQRT2;
+            let s = if u < 0.0 { -1.0 } else { 1.0 };
+            let t = 1.0 / (1.0 + GELU_P * u.abs());
+            let poly = ((((GELU_A[4] * t + GELU_A[3]) * t + GELU_A[2]) * t + GELU_A[1]) * t + GELU_A[0]) * t;
+            let erf = s * (1.0 - poly * e[i]);
+            chunk[i] = 0.5 * x * (1.0 + erf);
+        }
+    });
+}
+
+fn softmax_rows(s: &mut [f32], rows: usize, cols: usize) {
+    for r in 0..rows {
+        let row = &mut s[r * cols..r * cols + cols];
+        let mx = row.iter().copied().fold(f32::MIN, f32::max);
+        for v in row.iter_mut() {
+            *v -= mx;
+        }
+    }
+    seam::vexp(s);
+    for r in 0..rows {
+        let row = &mut s[r * cols..r * cols + cols];
+        let sum: f32 = row.iter().sum();
+        let inv = 1.0 / sum;
+        for v in row.iter_mut() {
+            *v *= inv;
+        }
+    }
+}
+
+fn l2_normalize(v: &mut [f32]) {
+    let norm = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+    for x in v.iter_mut() {
+        *x /= norm;
+    }
+}
+
+/// Shared BERT-family encoder → last_hidden_state [n*l*h]. `mask[s*l+j]` 1=real, 0=pad.
+fn encode(w: &HashMap<String, Vec<f32>>, c: Cfg, ids: &[i64], mask: &[i64], n: usize, l: usize) -> Vec<f32> {
+    let g = |k: &str| w.get(k).unwrap_or_else(|| panic!("missing weight {k}")).as_slice();
+    let (h, ffn, hd, heads) = (c.h, c.ffn, c.hd, c.heads);
+    let m = n * l;
+    let word = g(&format!("{}embeddings.word_embeddings.weight", c.prefix));
+    let pos = g(&format!("{}embeddings.position_embeddings.weight", c.prefix));
+    let typ = g(&format!("{}embeddings.token_type_embeddings.weight", c.prefix));
+    let mut hid = vec![0f32; m * h];
+    for s in 0..n {
+        let mut run = 0i64;
+        for i in 0..l {
+            let id = ids[s * l + i];
+            let posid = if c.bert_pos {
+                i
+            } else if id != PAD {
+                run += 1;
+                (PAD + run) as usize
+            } else {
+                PAD as usize
+            };
+            let dst = &mut hid[(s * l + i) * h..(s * l + i) * h + h];
+            let we = &word[id as usize * h..id as usize * h + h];
+            let pe = &pos[posid * h..posid * h + h];
+            for cc in 0..h {
+                dst[cc] = we[cc] + pe[cc] + typ[cc];
+            }
+        }
+    }
+    layernorm(
+        &mut hid,
+        h,
+        g(&format!("{}embeddings.LayerNorm.weight", c.prefix)),
+        g(&format!("{}embeddings.LayerNorm.bias", c.prefix)),
+    );
+
+    let scale = 1.0 / (hd as f32).sqrt();
+    for ly in 0..c.layers {
+        let p = format!("{}encoder.layer.{ly}", c.prefix);
+        let q = linear(
+            &hid,
+            m,
+            h,
+            g(&format!("{p}.attention.self.query.weight")),
+            g(&format!("{p}.attention.self.query.bias")),
+            h,
+        );
+        let k = linear(
+            &hid,
+            m,
+            h,
+            g(&format!("{p}.attention.self.key.weight")),
+            g(&format!("{p}.attention.self.key.bias")),
+            h,
+        );
+        let v = linear(
+            &hid,
+            m,
+            h,
+            g(&format!("{p}.attention.self.value.weight")),
+            g(&format!("{p}.attention.self.value.bias")),
+            h,
+        );
+
+        let mut ctx = vec![0f32; m * h];
+        let seqs_per = ceil_div(n, nthreads()).max(1);
+        let (qr, kr, vr, maskr) = (&q, &k, &v, &mask);
+        std::thread::scope(|scope| {
+            for (gi, grp) in ctx.chunks_mut(seqs_per * l * h).enumerate() {
+                scope.spawn(move || {
+                    let mut qh = vec![0f32; l * hd];
+                    let mut kh = vec![0f32; l * hd];
+                    let mut vh = vec![0f32; l * hd];
+                    let mut sc = vec![0f32; l * l];
+                    let mut ch = vec![0f32; l * hd];
+                    let s0 = gi * seqs_per;
+                    let nseq = grp.len() / (l * h);
+                    for si in 0..nseq {
+                        let s = s0 + si;
+                        for head in 0..heads {
+                            for i in 0..l {
+                                let src = (s * l + i) * h + head * hd;
+                                qh[i * hd..i * hd + hd].copy_from_slice(&qr[src..src + hd]);
+                                kh[i * hd..i * hd + hd].copy_from_slice(&kr[src..src + hd]);
+                                vh[i * hd..i * hd + hd].copy_from_slice(&vr[src..src + hd]);
+                            }
+                            seam::sgemm(NO_T, T, l, l, hd, scale, &qh, hd, &kh, hd, &mut sc);
+                            let mrow = &maskr[s * l..s * l + l];
+                            for j in 0..l {
+                                if mrow[j] == 0 {
+                                    for i in 0..l {
+                                        sc[i * l + j] += -1e30f32;
+                                    }
+                                }
+                            }
+                            softmax_rows(&mut sc, l, l);
+                            seam::sgemm(NO_T, NO_T, l, hd, l, 1.0, &sc, l, &vh, hd, &mut ch);
+                            for i in 0..l {
+                                let dst = (si * l + i) * h + head * hd;
+                                grp[dst..dst + hd].copy_from_slice(&ch[i * hd..i * hd + hd]);
+                            }
+                        }
+                    }
+                });
+            }
+        });
+        let attn = linear(
+            &ctx,
+            m,
+            h,
+            g(&format!("{p}.attention.output.dense.weight")),
+            g(&format!("{p}.attention.output.dense.bias")),
+            h,
+        );
+        par_add(&mut hid, &attn);
+        layernorm(
+            &mut hid,
+            h,
+            g(&format!("{p}.attention.output.LayerNorm.weight")),
+            g(&format!("{p}.attention.output.LayerNorm.bias")),
+        );
+
+        let mut inter = linear(
+            &hid,
+            m,
+            h,
+            g(&format!("{p}.intermediate.dense.weight")),
+            g(&format!("{p}.intermediate.dense.bias")),
+            ffn,
+        );
+        gelu(&mut inter);
+        let ffn_out = linear(
+            &inter,
+            m,
+            ffn,
+            g(&format!("{p}.output.dense.weight")),
+            g(&format!("{p}.output.dense.bias")),
+            h,
+        );
+        par_add(&mut hid, &ffn_out);
+        layernorm(
+            &mut hid,
+            h,
+            g(&format!("{p}.output.LayerNorm.weight")),
+            g(&format!("{p}.output.LayerNorm.bias")),
+        );
+    }
+    hid
+}
+
+// ---------------------------------------------------------------------------------------------
+// Model loading + tokenization (cross-platform)
+// ---------------------------------------------------------------------------------------------
+
+/// Resolve a local HF hub snapshot dir for `repo` (e.g. "BAAI/bge-small-en-v1.5"). Populated by any
+/// standard HF download; errors with the command to fetch it if absent.
+fn hf_snapshot(repo: &str) -> Result<PathBuf> {
+    let base = std::env::var("HF_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from(std::env::var("HOME").unwrap_or_default()).join(".cache/huggingface"));
+    let snaps = base
+        .join("hub")
+        .join(format!("models--{}", repo.replace('/', "--")))
+        .join("snapshots");
+    let entries = std::fs::read_dir(&snaps)
+        .with_context(|| format!("no local snapshot for {repo}; run: huggingface-cli download {repo}"))?;
+    for e in entries {
+        let p = e?.path();
+        if p.join("model.safetensors").exists() {
+            return Ok(p);
+        }
+    }
+    bail!(
+        "no model.safetensors under {}; run: huggingface-cli download {repo}",
+        snaps.display()
+    )
+}
+
+fn load_weights(dir: &Path) -> Result<HashMap<String, Vec<f32>>> {
+    let bytes = std::fs::read(dir.join("model.safetensors"))?;
+    let st = SafeTensors::deserialize(&bytes)?;
+    let mut w = HashMap::new();
+    for (name, view) in st.tensors() {
+        if view.dtype() == safetensors::Dtype::F32 {
+            let f: Vec<f32> = view
+                .data()
+                .chunks_exact(4)
+                .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+                .collect();
+            w.insert(name, f);
+        }
+    }
+    Ok(w)
+}
+
+fn load_tokenizer(dir: &Path) -> Result<Tokenizer> {
+    let mut tok = Tokenizer::from_file(dir.join("tokenizer.json")).map_err(|e| anyhow!("load tokenizer: {e}"))?;
+    tok.with_truncation(Some(TruncationParams {
+        max_length: 512,
+        ..Default::default()
+    }))
+    .map_err(|e| anyhow!("set truncation: {e}"))?;
+    tok.with_padding(Some(PaddingParams {
+        strategy: PaddingStrategy::BatchLongest,
+        ..Default::default()
+    }));
+    Ok(tok)
+}
+
+/// Tokenized batch → (ids, mask, n, l), both flattened row-major, padded to the batch's longest.
+fn to_batch(encs: &[tokenizers::Encoding]) -> (Vec<i64>, Vec<i64>, usize, usize) {
+    let n = encs.len();
+    let l = encs[0].get_ids().len();
+    let mut ids = Vec::with_capacity(n * l);
+    let mut mask = Vec::with_capacity(n * l);
+    for e in encs {
+        ids.extend(e.get_ids().iter().map(|&x| x as i64));
+        mask.extend(e.get_attention_mask().iter().map(|&x| x as i64));
+    }
+    (ids, mask, n, l)
+}
+
+/// bge-small-en-v1.5 embedder: BERT encoder → CLS → L2-normalize.
+pub struct BlasEmbedder {
+    w: HashMap<String, Vec<f32>>,
+    tok: Tokenizer,
+}
+
+impl BlasEmbedder {
+    pub fn new() -> Result<Self> {
+        let dir = hf_snapshot("BAAI/bge-small-en-v1.5")?;
+        Ok(Self {
+            w: load_weights(&dir)?,
+            tok: load_tokenizer(&dir)?,
+        })
+    }
+}
+
+impl Embedder for BlasEmbedder {
+    fn embed(&mut self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+        let encs = self
+            .tok
+            .encode_batch(texts.to_vec(), true)
+            .map_err(|e| anyhow!("tokenize: {e}"))?;
+        let (ids, mask, n, l) = to_batch(&encs);
+        let hid = encode(&self.w, EMBED, &ids, &mask, n, l);
+        let h = EMBED.h;
+        Ok((0..n)
+            .map(|s| {
+                let mut e = hid[(s * l) * h..(s * l) * h + h].to_vec();
+                l2_normalize(&mut e);
+                e
+            })
+            .collect())
+    }
+}
+
+/// bge-reranker-base cross-encoder: XLM-R encoder → CLS → out_proj(tanh(dense(cls))).
+pub struct BlasReranker {
+    w: HashMap<String, Vec<f32>>,
+    tok: Tokenizer,
+}
+
+impl BlasReranker {
+    pub fn new() -> Result<Self> {
+        let dir = hf_snapshot("BAAI/bge-reranker-base")?;
+        Ok(Self {
+            w: load_weights(&dir)?,
+            tok: load_tokenizer(&dir)?,
+        })
+    }
+}
+
+impl Reranker for BlasReranker {
+    fn rerank(&mut self, query: &str, docs: &[&str]) -> Result<Vec<f32>> {
+        let pairs: Vec<(&str, &str)> = docs.iter().map(|d| (query, *d)).collect();
+        let encs = self
+            .tok
+            .encode_batch(pairs, true)
+            .map_err(|e| anyhow!("tokenize: {e}"))?;
+        let (ids, mask, n, l) = to_batch(&encs);
+        let hid = encode(&self.w, RERANK, &ids, &mask, n, l);
+        let h = RERANK.h;
+        let mut cls = vec![0f32; n * h];
+        for s in 0..n {
+            cls[s * h..s * h + h].copy_from_slice(&hid[(s * l) * h..(s * l) * h + h]);
+        }
+        let mut d = linear(
+            &cls,
+            n,
+            h,
+            self.w["classifier.dense.weight"].as_slice(),
+            self.w["classifier.dense.bias"].as_slice(),
+            h,
+        );
+        for v in d.iter_mut() {
+            *v = v.tanh();
+        }
+        Ok(linear(
+            &d,
+            n,
+            h,
+            self.w["classifier.out_proj.weight"].as_slice(),
+            self.w["classifier.out_proj.bias"].as_slice(),
+            1,
+        ))
+    }
+}

--- a/src/blas.rs
+++ b/src/blas.rs
@@ -608,7 +608,9 @@ fn hf_snapshot(repo: &str) -> Result<PathBuf> {
     Ok(dir)
 }
 
-/// The newest cached snapshot of `repo` holding both files the forward needs, if any.
+/// A cached snapshot of `repo` holding both files the forward needs, if any. With several
+/// snapshots cached the pick is arbitrary — fine here: any complete copy of these frozen model
+/// repos is interchangeable.
 fn local_snapshot(repo: &str) -> Option<PathBuf> {
     let base = std::env::var("HF_HOME")
         .map(PathBuf::from)

--- a/src/blas.rs
+++ b/src/blas.rs
@@ -206,7 +206,14 @@ fn ceil_div(a: usize, b: usize) -> usize {
     a.div_ceil(b)
 }
 
+/// Below this many elements the par_* helpers run inline: spawning nthreads() scoped threads
+/// costs more than the memory pass it would split.
+const PAR_MIN: usize = 1 << 16;
+
 fn par_chunks<F: Fn(&mut [f32]) + Sync>(x: &mut [f32], f: F) {
+    if x.len() <= PAR_MIN {
+        return f(x);
+    }
     let cs = ceil_div(x.len(), nthreads()).max(1);
     std::thread::scope(|s| {
         for chunk in x.chunks_mut(cs) {
@@ -216,6 +223,12 @@ fn par_chunks<F: Fn(&mut [f32]) + Sync>(x: &mut [f32], f: F) {
     });
 }
 fn par_rows<F: Fn(&mut [f32]) + Sync>(x: &mut [f32], row_len: usize, f: F) {
+    if x.len() <= PAR_MIN {
+        for row in x.chunks_mut(row_len) {
+            f(row);
+        }
+        return;
+    }
     let cr = ceil_div(x.len() / row_len, nthreads()).max(1);
     std::thread::scope(|s| {
         for chunk in x.chunks_mut(cr * row_len) {
@@ -229,6 +242,12 @@ fn par_rows<F: Fn(&mut [f32]) + Sync>(x: &mut [f32], row_len: usize, f: F) {
     });
 }
 fn par_add(dst: &mut [f32], src: &[f32]) {
+    if dst.len() <= PAR_MIN {
+        for (d, sc) in dst.iter_mut().zip(src) {
+            *d += sc;
+        }
+        return;
+    }
     let cs = ceil_div(dst.len(), nthreads()).max(1);
     std::thread::scope(|s| {
         for (d, sc) in dst.chunks_mut(cs).zip(src.chunks(cs)) {

--- a/src/blas.rs
+++ b/src/blas.rs
@@ -1,8 +1,8 @@
 //! A from-scratch forward for funes' two models — a BLAS-backed alternative to the ONNX backend
-//! (see `inference`). Every matmul goes through a small platform **seam** (`sgemm`/`vexp`); today
-//! macOS wires it to Accelerate (cblas_sgemm on AMX + vForce vvexpf), and Linux is a marked TODO
-//! (OpenBLAS/MKL + a vectorized exp). Everything else — the encoder, tokenization, the trait impls —
-//! is shared, cross-platform source. Gated behind the `blas` feature.
+//! (see `inference`). Every matmul goes through a small platform **seam** (`sgemm`/`vexp`): macOS
+//! wires it to Accelerate (cblas_sgemm on AMX + vForce vvexpf), Linux to faer's pure-Rust GEMM
+//! plus a runtime-dispatched polynomial exp. Everything else — the encoder, tokenization, the
+//! trait impls — is shared, cross-platform source. Gated behind the `blas` feature.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -14,8 +14,8 @@ use tokenizers::{PaddingParams, PaddingStrategy, Tokenizer, TruncationParams};
 use crate::inference::{Embedder, Reranker};
 
 // ---------------------------------------------------------------------------------------------
-// Platform seam: the ONLY OS-specific code. A Linux backend implements just these two functions
-// (plus the link in build.rs) and inherits the entire encoder below.
+// Platform seam: the ONLY OS-specific code. A platform backend implements just these two
+// functions (plus any library link in build.rs) and inherits the entire encoder below.
 // ---------------------------------------------------------------------------------------------
 #[cfg(target_os = "macos")]
 mod seam {
@@ -82,27 +82,73 @@ mod seam {
 
 #[cfg(target_os = "linux")]
 mod seam {
-    // TODO(linux backend): wire these to a fast BLAS + vectorized exp, then add the library link in
-    // build.rs (e.g. `cargo:rustc-link-lib=openblas`). cblas_sgemm has the *same* signature in
-    // OpenBLAS/BLIS/MKL as Accelerate — this is the only new code the Linux port needs.
+    use faer::linalg::matmul::matmul;
+    use faer::{Accum, MatMut, MatRef, Par};
+
+    /// Below this many flops a GEMM runs sequentially: the small per-head attention GEMMs come
+    /// from worker threads that already own the parallelism; only the big batched linears
+    /// (called from the main thread) benefit from faer's rayon splitting.
+    const PAR_FLOPS: f64 = 1e8;
+
+    /// C[m,n] = alpha·op(A)·op(B); row-major; ta/tb are CBLAS 111 (NoTrans) / 112 (Trans).
     #[allow(clippy::too_many_arguments)]
     pub fn sgemm(
-        _ta: i32,
-        _tb: i32,
-        _m: usize,
-        _n: usize,
-        _k: usize,
-        _alpha: f32,
-        _a: &[f32],
-        _lda: usize,
-        _b: &[f32],
-        _ldb: usize,
-        _y: &mut [f32],
+        ta: i32,
+        tb: i32,
+        m: usize,
+        n: usize,
+        k: usize,
+        alpha: f32,
+        a: &[f32],
+        lda: usize,
+        b: &[f32],
+        ldb: usize,
+        y: &mut [f32],
     ) {
-        todo!("Linux: cblas_sgemm via OpenBLAS/MKL (+ link in build.rs)")
+        // op(A) is m×k, op(B) is k×n; a transposed operand swaps its (row, col) strides.
+        let (ars, acs) = if ta == super::NO_T {
+            (lda as isize, 1)
+        } else {
+            (1, lda as isize)
+        };
+        let (brs, bcs) = if tb == super::NO_T {
+            (ldb as isize, 1)
+        } else {
+            (1, ldb as isize)
+        };
+        let par = if 2.0 * m as f64 * n as f64 * k as f64 >= PAR_FLOPS {
+            Par::rayon(0)
+        } else {
+            Par::Seq
+        };
+        unsafe {
+            let a = MatRef::from_raw_parts(a.as_ptr(), m, k, ars, acs);
+            let b = MatRef::from_raw_parts(b.as_ptr(), k, n, brs, bcs);
+            let y = MatMut::from_raw_parts_mut(y.as_mut_ptr(), m, n, n as isize, 1);
+            matmul(y, Accum::Replace, a, b, alpha, par);
+        }
     }
-    pub fn vexp(_buf: &mut [f32]) {
-        todo!("Linux: vectorized expf (MKL vsExp or a SIMD exp)")
+
+    /// In-place vectorized exp: buf[i] = e^{buf[i]}. exp(x) = 2^f·exp(r), f = round(x/ln2), with
+    /// exp(r) a degree-6 Taylor on |r| ≤ ln2/2 and 2^f built in the float's exponent bits — all
+    /// branch-free so LLVM auto-vectorizes; multiversion picks the widest clone the CPU runs.
+    /// Max relative error 2.5e-7.
+    #[multiversion::multiversion(targets("x86_64+avx512f+avx512bw+avx512dq", "x86_64+avx2+fma"))]
+    pub fn vexp(buf: &mut [f32]) {
+        const LOG2E: f32 = std::f32::consts::LOG2_E;
+        // The digits are load-bearing: 355/512 is exactly representable, so f·LN2_HI is exact.
+        #[allow(clippy::excessive_precision)]
+        const LN2_HI: f32 = 0.693359375;
+        const LN2_LO: f32 = -2.121_944_4e-4;
+        const MAGIC: f32 = 12582912.0; // 1.5·2^23: add then subtract rounds to nearest integer
+        const C: [f32; 5] = [1.0 / 720.0, 1.0 / 120.0, 1.0 / 24.0, 1.0 / 6.0, 0.5];
+        for x in buf.iter_mut() {
+            let c = (*x).clamp(-87.336, 88.722);
+            let f = (c * LOG2E + MAGIC) - MAGIC;
+            let r = c - f * LN2_HI - f * LN2_LO;
+            let p = (((((C[0] * r + C[1]) * r + C[2]) * r + C[3]) * r + C[4]) * r + 1.0) * r + 1.0;
+            *x = p * f32::from_bits((((f as i32) + 127) << 23) as u32);
+        }
     }
 }
 

--- a/src/blas.rs
+++ b/src/blas.rs
@@ -234,17 +234,16 @@ fn par_add(dst: &mut [f32], src: &[f32]) {
     });
 }
 
-/// y[m,out] = x[m,in] · W[out,in]ᵀ + b[out]
-fn linear(x: &[f32], m: usize, in_: usize, w: &[f32], b: &[f32], out: usize) -> Vec<f32> {
-    let mut y = vec![0f32; m * out];
-    seam::sgemm(NO_T, T, m, out, in_, 1.0, x, in_, w, in_, &mut y);
-    for r in 0..m {
-        let row = &mut y[r * out..r * out + out];
-        for c in 0..out {
-            row[c] += b[c];
+/// y[m,out] = x[m,in] · W[out,in]ᵀ + b[out]. The caller owns y (m·out): buffers are reused
+/// across layers — a fresh allocation per call makes the allocator release and re-fault
+/// hundreds of MB per layer on platforms that return large frees to the OS.
+fn linear(x: &[f32], m: usize, in_: usize, w: &[f32], b: &[f32], out: usize, y: &mut [f32]) {
+    seam::sgemm(NO_T, T, m, out, in_, 1.0, x, in_, w, in_, y);
+    par_rows(y, out, |row| {
+        for (c, bc) in row.iter_mut().zip(b) {
+            *c += bc;
         }
-    }
-    y
+    });
 }
 
 fn layernorm(x: &mut [f32], h: usize, g: &[f32], b: &[f32]) {
@@ -345,35 +344,46 @@ fn encode(w: &HashMap<String, Vec<f32>>, c: Cfg, ids: &[i64], mask: &[i64], n: u
         g(&format!("{}embeddings.LayerNorm.bias", c.prefix)),
     );
 
+    // Layer scratch, allocated once and reused across all layers (see linear()).
+    let mut q = vec![0f32; m * h];
+    let mut k = vec![0f32; m * h];
+    let mut v = vec![0f32; m * h];
+    let mut ctx = vec![0f32; m * h];
+    let mut attn = vec![0f32; m * h];
+    let mut inter = vec![0f32; m * ffn];
+    let mut ffn_out = vec![0f32; m * h];
+
     let scale = 1.0 / (hd as f32).sqrt();
     for ly in 0..c.layers {
         let p = format!("{}encoder.layer.{ly}", c.prefix);
-        let q = linear(
+        linear(
             &hid,
             m,
             h,
             g(&format!("{p}.attention.self.query.weight")),
             g(&format!("{p}.attention.self.query.bias")),
             h,
+            &mut q,
         );
-        let k = linear(
+        linear(
             &hid,
             m,
             h,
             g(&format!("{p}.attention.self.key.weight")),
             g(&format!("{p}.attention.self.key.bias")),
             h,
+            &mut k,
         );
-        let v = linear(
+        linear(
             &hid,
             m,
             h,
             g(&format!("{p}.attention.self.value.weight")),
             g(&format!("{p}.attention.self.value.bias")),
             h,
+            &mut v,
         );
 
-        let mut ctx = vec![0f32; m * h];
         let seqs_per = ceil_div(n, nthreads()).max(1);
         let (qr, kr, vr, maskr) = (&q, &k, &v, &mask);
         std::thread::scope(|scope| {
@@ -415,13 +425,14 @@ fn encode(w: &HashMap<String, Vec<f32>>, c: Cfg, ids: &[i64], mask: &[i64], n: u
                 });
             }
         });
-        let attn = linear(
+        linear(
             &ctx,
             m,
             h,
             g(&format!("{p}.attention.output.dense.weight")),
             g(&format!("{p}.attention.output.dense.bias")),
             h,
+            &mut attn,
         );
         par_add(&mut hid, &attn);
         layernorm(
@@ -431,22 +442,24 @@ fn encode(w: &HashMap<String, Vec<f32>>, c: Cfg, ids: &[i64], mask: &[i64], n: u
             g(&format!("{p}.attention.output.LayerNorm.bias")),
         );
 
-        let mut inter = linear(
+        linear(
             &hid,
             m,
             h,
             g(&format!("{p}.intermediate.dense.weight")),
             g(&format!("{p}.intermediate.dense.bias")),
             ffn,
+            &mut inter,
         );
         gelu(&mut inter);
-        let ffn_out = linear(
+        linear(
             &inter,
             m,
             ffn,
             g(&format!("{p}.output.dense.weight")),
             g(&format!("{p}.output.dense.bias")),
             h,
+            &mut ffn_out,
         );
         par_add(&mut hid, &ffn_out);
         layernorm(
@@ -596,24 +609,29 @@ impl Reranker for BlasReranker {
         for s in 0..n {
             cls[s * h..s * h + h].copy_from_slice(&hid[(s * l) * h..(s * l) * h + h]);
         }
-        let mut d = linear(
+        let mut d = vec![0f32; n * h];
+        linear(
             &cls,
             n,
             h,
             self.w["classifier.dense.weight"].as_slice(),
             self.w["classifier.dense.bias"].as_slice(),
             h,
+            &mut d,
         );
         for v in d.iter_mut() {
             *v = v.tanh();
         }
-        Ok(linear(
+        let mut scores = vec![0f32; n];
+        linear(
             &d,
             n,
             h,
             self.w["classifier.out_proj.weight"].as_slice(),
             self.w["classifier.out_proj.bias"].as_slice(),
             1,
-        ))
+            &mut scores,
+        );
+        Ok(scores)
     }
 }

--- a/src/blas.rs
+++ b/src/blas.rs
@@ -7,7 +7,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{anyhow, Context, Result};
 use safetensors::SafeTensors;
 use tokenizers::{PaddingParams, PaddingStrategy, Tokenizer, TruncationParams};
 
@@ -526,9 +526,43 @@ fn encode(w: &HashMap<String, Vec<f32>>, c: Cfg, ids: &[i64], mask: &[i64], n: u
 // Model loading + tokenization (cross-platform)
 // ---------------------------------------------------------------------------------------------
 
-/// Resolve a local HF hub snapshot dir for `repo` (e.g. "BAAI/bge-small-en-v1.5"). Populated by any
-/// standard HF download; errors with the command to fetch it if absent.
+/// Resolve a snapshot dir for `repo` (e.g. "BAAI/bge-small-en-v1.5") in the standard HF cache,
+/// downloading the two files the forward needs on first use (like the ONNX backend does).
 fn hf_snapshot(repo: &str) -> Result<PathBuf> {
+    if let Some(dir) = local_snapshot(repo) {
+        return Ok(dir);
+    }
+    eprintln!("downloading {repo} (first use)…");
+    // A dedicated thread: the blocking hf-hub client drives its own runtime with block_on,
+    // which would panic if called from a thread already inside a tokio runtime (the MCP server).
+    let owned = repo.to_string();
+    let dir = std::thread::spawn(move || -> Result<PathBuf> {
+        let (owner, name) = owned
+            .split_once('/')
+            .ok_or_else(|| anyhow!("model repo {owned} is not owner/name"))?;
+        let client = hf_hub::HFClientSync::new().map_err(|e| anyhow!("hf-hub client: {e}"))?;
+        let r = client.model(owner, name);
+        r.download_file()
+            .filename("tokenizer.json")
+            .send()
+            .with_context(|| format!("downloading {owned}/tokenizer.json"))?;
+        let weights = r
+            .download_file()
+            .filename("model.safetensors")
+            .send()
+            .with_context(|| format!("downloading {owned}/model.safetensors"))?;
+        Ok(weights
+            .parent()
+            .ok_or_else(|| anyhow!("downloaded file has no parent dir"))?
+            .to_path_buf())
+    })
+    .join()
+    .map_err(|_| anyhow!("model download thread panicked"))??;
+    Ok(dir)
+}
+
+/// The newest cached snapshot of `repo` holding both files the forward needs, if any.
+fn local_snapshot(repo: &str) -> Option<PathBuf> {
     let base = std::env::var("HF_HOME")
         .map(PathBuf::from)
         .unwrap_or_else(|_| PathBuf::from(std::env::var("HOME").unwrap_or_default()).join(".cache/huggingface"));
@@ -536,18 +570,13 @@ fn hf_snapshot(repo: &str) -> Result<PathBuf> {
         .join("hub")
         .join(format!("models--{}", repo.replace('/', "--")))
         .join("snapshots");
-    let entries = std::fs::read_dir(&snaps)
-        .with_context(|| format!("no local snapshot for {repo}; run: huggingface-cli download {repo}"))?;
-    for e in entries {
-        let p = e?.path();
-        if p.join("model.safetensors").exists() {
-            return Ok(p);
+    for e in std::fs::read_dir(&snaps).ok()?.flatten() {
+        let p = e.path();
+        if p.join("model.safetensors").exists() && p.join("tokenizer.json").exists() {
+            return Some(p);
         }
     }
-    bail!(
-        "no model.safetensors under {}; run: huggingface-cli download {repo}",
-        snaps.display()
-    )
+    None
 }
 
 fn load_weights(dir: &Path) -> Result<HashMap<String, Vec<f32>>> {

--- a/src/hello.rs
+++ b/src/hello.rs
@@ -4,9 +4,9 @@
 use crate::chunk::Chunk;
 use crate::dataset;
 use crate::index::{self, DIM};
+use crate::inference::Embedder;
 use anyhow::Result;
 use arrow_array::RecordBatchIterator;
-use fastembed::TextEmbedding;
 use lance::dataset::Dataset;
 use tempfile::TempDir;
 
@@ -120,7 +120,7 @@ Your indexed sessions stay on your machine until you `funes push`.
 
 /// Build the corpus as an ephemeral lance dataset; the returned temp dir backs it (keep alive
 /// while reading). With an `embedder`, passages get real vectors for search; without, zeros.
-pub async fn dataset(embedder: Option<&mut TextEmbedding>) -> Result<(TempDir, Dataset)> {
+pub async fn dataset(embedder: Option<&mut dyn Embedder>) -> Result<(TempDir, Dataset)> {
     let ts = chrono::Utc::now().to_rfc3339();
     let chunks: Vec<Chunk> = PASSAGES
         .iter()
@@ -146,7 +146,7 @@ pub async fn dataset(embedder: Option<&mut TextEmbedding>) -> Result<(TempDir, D
 
     let texts: Vec<&str> = chunks.iter().map(|c| c.text.as_str()).collect();
     let vectors: Vec<Vec<f32>> = match embedder {
-        Some(e) => e.embed(texts, None)?,
+        Some(e) => e.embed(&texts)?,
         None => vec![vec![0.0; DIM as usize]; chunks.len()],
     };
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -7,12 +7,12 @@
 //! contributes just its new turns, nothing is re-embedded or deleted.
 
 use crate::harness::Harness;
+use crate::inference::{Embedder, OnnxEmbedder};
 use crate::{chunk, dataset, hub, lock, scan, source, trace};
 use anyhow::{anyhow, Result};
 use arrow_array::types::Float32Type;
 use arrow_array::{Array, FixedSizeListArray, Int64Array, RecordBatch, RecordBatchIterator, StringArray};
 use arrow_schema::{DataType, Field, Schema};
-use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
 use lance::dataset::{Dataset, WriteParams};
 use std::collections::{HashMap, HashSet};
 use std::io::{IsTerminal, Write as _};
@@ -92,13 +92,13 @@ pub(crate) fn build_batch(chunks: &[chunk::Chunk], vectors: &[Vec<f32>]) -> Resu
 /// Embed `texts` in batches of [`EMBED_BATCH`], calling `on_batch(embedded_so_far)` after each so a
 /// caller can report progress (or pass a no-op).
 pub(crate) fn embed_batched(
-    embedder: &mut TextEmbedding,
+    embedder: &mut dyn Embedder,
     texts: &[&str],
     mut on_batch: impl FnMut(usize),
 ) -> Result<Vec<Vec<f32>>> {
     let mut vectors: Vec<Vec<f32>> = Vec::with_capacity(texts.len());
     for group in texts.chunks(EMBED_BATCH) {
-        vectors.extend(embedder.embed(group, None)?);
+        vectors.extend(embedder.embed(group)?);
         on_batch(vectors.len());
     }
     Ok(vectors)
@@ -189,7 +189,7 @@ fn unit_summary(turns: &[trace::Turn], key: &str) -> (u64, String) {
 struct Indexer<'a> {
     uri: &'a str,
     ds: Option<Dataset>,
-    embedder: TextEmbedding,
+    embedder: Box<dyn Embedder>,
     scanner: Option<&'a dyn scan::SecretScanner>,
     include_thinking: bool,
 }
@@ -237,7 +237,7 @@ impl Indexer<'_> {
         let n = new_chunks.len();
         let texts: Vec<&str> = new_chunks.iter().map(|c| c.text.as_str()).collect();
         let t0 = Instant::now();
-        let vectors = embed_batched(&mut self.embedder, &texts, |done| {
+        let vectors = embed_batched(self.embedder.as_mut(), &texts, |done| {
             let secs = t0.elapsed().as_secs_f64().max(0.001);
             eprint!("\r    embedded {done}/{n}  ({:.0}/s)   ", done as f64 / secs);
             let _ = std::io::stderr().flush();
@@ -338,7 +338,7 @@ async fn index_sources(sources: Vec<Box<dyn source::TraceSource>>, no_thinking: 
         .and_then(|s| serde_json::from_str(&s).ok())
         .unwrap_or_default();
 
-    let embedder = TextEmbedding::try_new(InitOptions::new(EmbeddingModel::BGESmallENV15))?;
+    let embedder: Box<dyn Embedder> = Box::new(OnnxEmbedder::new()?);
     // Best-effort secret redaction: if the scanner isn't installed, indexing continues unredacted —
     // the push gate still scans, fail-closed, before any upload, so a secret can't reach the Hub.
     let scanner = match scan::Trufflehog::find() {

--- a/src/index.rs
+++ b/src/index.rs
@@ -7,7 +7,7 @@
 //! contributes just its new turns, nothing is re-embedded or deleted.
 
 use crate::harness::Harness;
-use crate::inference::{Embedder, OnnxEmbedder};
+use crate::inference::{self, Embedder};
 use crate::{chunk, dataset, hub, lock, scan, source, trace};
 use anyhow::{anyhow, Result};
 use arrow_array::types::Float32Type;
@@ -338,7 +338,7 @@ async fn index_sources(sources: Vec<Box<dyn source::TraceSource>>, no_thinking: 
         .and_then(|s| serde_json::from_str(&s).ok())
         .unwrap_or_default();
 
-    let embedder: Box<dyn Embedder> = Box::new(OnnxEmbedder::new()?);
+    let embedder: Box<dyn Embedder> = inference::embedder()?;
     // Best-effort secret redaction: if the scanner isn't installed, indexing continues unredacted —
     // the push gate still scans, fail-closed, before any upload, so a secret can't reach the Hub.
     let scanner = match scan::Trufflehog::find() {

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -1,0 +1,57 @@
+//! The inference backend behind funes' two model operations — embedding and reranking. The rest of
+//! funes talks to these traits, not to a concrete ML stack, so an alternative backend (e.g. a
+//! hand-written Accelerate forward on macOS) can slot in behind the same interface, selected by a
+//! build feature, without touching any call site. Today only the ONNX backend (fastembed/ort) is
+//! wired.
+
+use anyhow::Result;
+use fastembed::{EmbeddingModel, InitOptions, RerankInitOptions, RerankerModel, TextEmbedding, TextRerank};
+
+/// Embed each text into a dense vector, in input order.
+pub trait Embedder: Send {
+    fn embed(&mut self, texts: &[&str]) -> Result<Vec<Vec<f32>>>;
+}
+
+/// Score each doc against the query; one score per doc, in input order (higher = more relevant).
+pub trait Reranker: Send {
+    fn rerank(&mut self, query: &str, docs: &[&str]) -> Result<Vec<f32>>;
+}
+
+/// fastembed/ort embedder: BAAI/bge-small-en-v1.5 on the ONNX Runtime CPU EP.
+pub struct OnnxEmbedder(TextEmbedding);
+
+impl OnnxEmbedder {
+    pub fn new() -> Result<Self> {
+        Ok(Self(TextEmbedding::try_new(InitOptions::new(
+            EmbeddingModel::BGESmallENV15,
+        ))?))
+    }
+}
+
+impl Embedder for OnnxEmbedder {
+    fn embed(&mut self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+        self.0.embed(texts, None)
+    }
+}
+
+/// fastembed/ort reranker: BAAI/bge-reranker-base cross-encoder on the ONNX Runtime CPU EP.
+pub struct OnnxReranker(TextRerank);
+
+impl OnnxReranker {
+    pub fn new() -> Result<Self> {
+        Ok(Self(TextRerank::try_new(RerankInitOptions::new(
+            RerankerModel::BGERerankerBase,
+        ))?))
+    }
+}
+
+impl Reranker for OnnxReranker {
+    fn rerank(&mut self, query: &str, docs: &[&str]) -> Result<Vec<f32>> {
+        // fastembed returns results carrying the original index; project back to input order.
+        let mut scores = vec![0f32; docs.len()];
+        for r in self.0.rerank(query, docs, false, None)? {
+            scores[r.index] = r.score;
+        }
+        Ok(scores)
+    }
+}

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -1,11 +1,19 @@
 //! The inference backend behind funes' two model operations — embedding and reranking. The rest of
-//! funes talks to these traits, not to a concrete ML stack, so an alternative backend (e.g. a
-//! hand-written Accelerate forward on macOS) can slot in behind the same interface, selected by a
-//! build feature, without touching any call site. Today only the ONNX backend (fastembed/ort) is
-//! wired.
+//! funes talks to these traits via the [`embedder`]/[`reranker`] factories, never a concrete ML
+//! stack, so an alternative backend slots in behind the same interface. The backend is chosen at
+//! build time in one place — the `Default*` aliases below: default build → ONNX (fastembed/ort);
+//! `--features blas` → a from-scratch forward on the platform BLAS (Accelerate on macOS).
 
 use anyhow::Result;
 use fastembed::{EmbeddingModel, InitOptions, RerankInitOptions, RerankerModel, TextEmbedding, TextRerank};
+
+// The single backend-selection point. One of these alias pairs is compiled; the factories below
+// box whichever it names. The ONNX types stay defined in both builds (the backend benchmark uses
+// them as its reference), so only these aliases — not the call sites — decide what funes runs.
+#[cfg(not(feature = "blas"))]
+use self::{OnnxEmbedder as DefaultEmbedder, OnnxReranker as DefaultReranker};
+#[cfg(feature = "blas")]
+use crate::blas::{BlasEmbedder as DefaultEmbedder, BlasReranker as DefaultReranker};
 
 /// Embed each text into a dense vector, in input order.
 pub trait Embedder: Send {
@@ -15,6 +23,17 @@ pub trait Embedder: Send {
 /// Score each doc against the query; one score per doc, in input order (higher = more relevant).
 pub trait Reranker: Send {
     fn rerank(&mut self, query: &str, docs: &[&str]) -> Result<Vec<f32>>;
+}
+
+/// Build the embedder for the compiled-in backend. Call sites use this instead of naming a
+/// concrete type, so the backend is decided only by the `Default*` alias above.
+pub fn embedder() -> Result<Box<dyn Embedder>> {
+    Ok(Box::new(DefaultEmbedder::new()?))
+}
+
+/// Build the reranker for the compiled-in backend. See [`embedder`].
+pub fn reranker() -> Result<Box<dyn Reranker>> {
+    Ok(Box::new(DefaultReranker::new()?))
 }
 
 /// fastembed/ort embedder: BAAI/bge-small-en-v1.5 on the ONNX Runtime CPU EP.

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -1,19 +1,20 @@
 //! The inference backend behind funes' two model operations — embedding and reranking. The rest of
 //! funes talks to these traits via the [`embedder`]/[`reranker`] factories, never a concrete ML
 //! stack, so an alternative backend slots in behind the same interface. The backend is chosen at
-//! build time in one place — the `Default*` aliases below: default build → ONNX (fastembed/ort);
-//! `--features blas` → a from-scratch forward on the platform BLAS (Accelerate on macOS).
+//! build time in one place — the `Default*` aliases below: default build → BLAS (a from-scratch
+//! forward on Accelerate/faer); `--no-default-features --features onnx` → fastembed/ort.
 
 use anyhow::Result;
-use fastembed::{EmbeddingModel, InitOptions, RerankInitOptions, RerankerModel, TextEmbedding, TextRerank};
 
 // The single backend-selection point. One of these alias pairs is compiled; the factories below
-// box whichever it names. The ONNX types stay defined in both builds (the backend benchmark uses
-// them as its reference), so only these aliases — not the call sites — decide what funes runs.
-#[cfg(not(feature = "blas"))]
+// box whichever it names. When both backends are compiled in (the backend benchmark builds that
+// way to use ONNX as its reference), BLAS is the one funes runs.
+#[cfg(all(feature = "onnx", not(feature = "blas")))]
 use self::{OnnxEmbedder as DefaultEmbedder, OnnxReranker as DefaultReranker};
 #[cfg(feature = "blas")]
 use crate::blas::{BlasEmbedder as DefaultEmbedder, BlasReranker as DefaultReranker};
+#[cfg(not(any(feature = "blas", feature = "onnx")))]
+compile_error!("funes needs an inference backend: feature `blas` (default) or `onnx`");
 
 /// Embed each text into a dense vector, in input order.
 pub trait Embedder: Send {
@@ -37,16 +38,20 @@ pub fn reranker() -> Result<Box<dyn Reranker>> {
 }
 
 /// fastembed/ort embedder: BAAI/bge-small-en-v1.5 on the ONNX Runtime CPU EP.
-pub struct OnnxEmbedder(TextEmbedding);
+#[cfg(feature = "onnx")]
+pub struct OnnxEmbedder(fastembed::TextEmbedding);
 
+#[cfg(feature = "onnx")]
 impl OnnxEmbedder {
     pub fn new() -> Result<Self> {
+        use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
         Ok(Self(TextEmbedding::try_new(InitOptions::new(
             EmbeddingModel::BGESmallENV15,
         ))?))
     }
 }
 
+#[cfg(feature = "onnx")]
 impl Embedder for OnnxEmbedder {
     fn embed(&mut self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
         self.0.embed(texts, None)
@@ -54,16 +59,20 @@ impl Embedder for OnnxEmbedder {
 }
 
 /// fastembed/ort reranker: BAAI/bge-reranker-base cross-encoder on the ONNX Runtime CPU EP.
-pub struct OnnxReranker(TextRerank);
+#[cfg(feature = "onnx")]
+pub struct OnnxReranker(fastembed::TextRerank);
 
+#[cfg(feature = "onnx")]
 impl OnnxReranker {
     pub fn new() -> Result<Self> {
+        use fastembed::{RerankInitOptions, RerankerModel, TextRerank};
         Ok(Self(TextRerank::try_new(RerankInitOptions::new(
             RerankerModel::BGERerankerBase,
         ))?))
     }
 }
 
+#[cfg(feature = "onnx")]
 impl Reranker for OnnxReranker {
     fn rerank(&mut self, query: &str, docs: &[&str]) -> Result<Vec<f32>> {
         // fastembed returns results carrying the original index; project back to input order.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub mod hf_dataset;
 pub mod hf_traces;
 pub mod hub;
 pub mod index;
+pub mod inference;
 pub mod jsonl;
 pub mod lock;
 pub mod mcp;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@
 #[cfg(not(unix))]
 compile_error!("funes is unix-only (Linux/macOS)");
 
+#[cfg(feature = "blas")]
+pub mod blas;
 pub mod capture_store;
 pub mod chunk;
 pub mod claude;

--- a/src/recall.rs
+++ b/src/recall.rs
@@ -9,10 +9,10 @@ use crate::dataset;
 use crate::harness::Harness;
 use crate::hello;
 use crate::hub::{self, Reachability, Store};
+use crate::inference::{Embedder, OnnxEmbedder, OnnxReranker, Reranker};
 use anyhow::{anyhow, Context, Result};
 use arrow_array::{Float32Array, Int64Array, RecordBatch, StringArray, UInt64Array};
 use chrono::{DateTime, Utc};
-use fastembed::{EmbeddingModel, InitOptions, RerankInitOptions, RerankerModel, TextEmbedding, TextRerank};
 use futures::TryStreamExt;
 use lance::dataset::{Dataset, ROW_ID};
 use lance::Error as LanceError;
@@ -205,7 +205,7 @@ fn is_auth_error(e: &anyhow::Error) -> bool {
 /// absent local index serves the guide — so recall keeps working offline and on a fresh install. A
 /// missing or empty remote surfaces as an error from the helper. Passing `embedder` gives the
 /// built-in corpus real vectors for search (recall); `None` suits `get`/`list`.
-async fn open_read(store: &Store, embedder: Option<&mut TextEmbedding>) -> Result<Read> {
+async fn open_read(store: &Store, embedder: Option<&mut dyn Embedder>) -> Result<Read> {
     match open_for_read(store).await? {
         ReadOutcome::Ready(ds) => Ok(Read {
             _hello: None,
@@ -228,7 +228,7 @@ async fn open_read(store: &Store, embedder: Option<&mut TextEmbedding>) -> Resul
 
 /// An unreachable remote degrades to the local index, or to the built-in guide if there's no local
 /// index either, carrying a note that explains what happened.
-async fn degrade_offline(uri: &str, embedder: Option<&mut TextEmbedding>) -> Result<Read> {
+async fn degrade_offline(uri: &str, embedder: Option<&mut dyn Embedder>) -> Result<Read> {
     match open_for_read(&Store::local()).await {
         Ok(ReadOutcome::Ready(ds)) => Ok(Read {
             _hello: None,
@@ -264,8 +264,8 @@ pub fn store_hint(read: Option<&str>) -> String {
 /// after. The `Mutex` serializes recalls (both models run with `&mut`), which is fine: the work is
 /// CPU-bound and the server's calls are serial anyway.
 struct Models {
-    embedder: TextEmbedding,
-    reranker: TextRerank,
+    embedder: Box<dyn Embedder>,
+    reranker: Box<dyn Reranker>,
 }
 
 static MODELS: OnceCell<Mutex<Models>> = OnceCell::const_new();
@@ -274,8 +274,8 @@ static MODELS: OnceCell<Mutex<Models>> = OnceCell::const_new();
 async fn models() -> Result<&'static Mutex<Models>> {
     MODELS
         .get_or_try_init(|| async {
-            let embedder = TextEmbedding::try_new(InitOptions::new(EmbeddingModel::BGESmallENV15))?;
-            let reranker = TextRerank::try_new(RerankInitOptions::new(RerankerModel::BGERerankerBase))?;
+            let embedder: Box<dyn Embedder> = Box::new(OnnxEmbedder::new()?);
+            let reranker: Box<dyn Reranker> = Box::new(OnnxReranker::new()?);
             Ok::<_, anyhow::Error>(Mutex::new(Models { embedder, reranker }))
         })
         .await
@@ -336,12 +336,12 @@ pub async fn recall_hits(
     let Models { embedder, reranker } = &mut *guard;
 
     let qv: Vec<f32> = embedder
-        .embed(vec![query.clone()], None)?
+        .embed(&[query.as_str()])?
         .into_iter()
         .next()
         .context("empty embedding")?;
 
-    let read = open_read(&store, Some(&mut *embedder)).await?;
+    let read = open_read(&store, Some(embedder.as_mut())).await?;
     let note = read.note.clone().unwrap_or_default();
     let ds = &read.ds;
     // A `--harness` filter needs the column; on an un-migrated store it would fail deep inside Lance
@@ -362,14 +362,15 @@ pub async fn recall_hits(
     }
 
     let docs: Vec<&str> = hits.iter().map(|h| h.text.as_str()).collect();
-    let reranked = reranker.rerank(query.as_str(), docs, false, None)?;
+    let scores = reranker.rerank(query.as_str(), &docs)?;
 
     let now = Utc::now();
-    let mut scored: Vec<(usize, f64)> = reranked
+    let mut scored: Vec<(usize, f64)> = scores
         .iter()
-        .map(|r| {
-            let relevance = 1.0 / (1.0 + (-(r.score as f64)).exp());
-            (r.index, relevance * recency_weight(&hits[r.index].ts, now, half_life))
+        .enumerate()
+        .map(|(i, &s)| {
+            let relevance = 1.0 / (1.0 + (-(s as f64)).exp());
+            (i, relevance * recency_weight(&hits[i].ts, now, half_life))
         })
         .collect();
     scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));

--- a/src/recall.rs
+++ b/src/recall.rs
@@ -9,7 +9,7 @@ use crate::dataset;
 use crate::harness::Harness;
 use crate::hello;
 use crate::hub::{self, Reachability, Store};
-use crate::inference::{Embedder, OnnxEmbedder, OnnxReranker, Reranker};
+use crate::inference::{self, Embedder, Reranker};
 use anyhow::{anyhow, Context, Result};
 use arrow_array::{Float32Array, Int64Array, RecordBatch, StringArray, UInt64Array};
 use chrono::{DateTime, Utc};
@@ -274,8 +274,8 @@ static MODELS: OnceCell<Mutex<Models>> = OnceCell::const_new();
 async fn models() -> Result<&'static Mutex<Models>> {
     MODELS
         .get_or_try_init(|| async {
-            let embedder: Box<dyn Embedder> = Box::new(OnnxEmbedder::new()?);
-            let reranker: Box<dyn Reranker> = Box::new(OnnxReranker::new()?);
+            let embedder = inference::embedder()?;
+            let reranker = inference::reranker()?;
             Ok::<_, anyhow::Error>(Mutex::new(Models { embedder, reranker }))
         })
         .await

--- a/src/scrub.rs
+++ b/src/scrub.rs
@@ -3,11 +3,11 @@
 //! re-indexing cannot. Operates only on the local store; it does not touch a published remote.
 
 use crate::index::{build_batch, embed_batched, schema};
+use crate::inference::{Embedder, OnnxEmbedder};
 use crate::{chunk, dataset, lock, scan};
 use anyhow::Result;
 use arrow_array::{BooleanArray, RecordBatch, RecordBatchIterator};
 use arrow_select::filter::filter_record_batch;
-use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
 use lance::dataset::{Dataset, WriteMode, WriteParams};
 use std::collections::HashMap;
 use std::fmt::Write as _;
@@ -81,12 +81,12 @@ pub async fn run() -> Result<()> {
     let replacement_batch = if replacements.is_empty() {
         None
     } else {
-        let mut embedder = TextEmbedding::try_new(InitOptions::new(EmbeddingModel::BGESmallENV15))?;
+        let mut embedder: Box<dyn Embedder> = Box::new(OnnxEmbedder::new()?);
         let rtexts: Vec<&str> = replacements.iter().map(|c| c.text.as_str()).collect();
         let n = rtexts.len();
         eprintln!("re-embedding {n} redacted chunk(s)…");
         let t0 = Instant::now();
-        let vectors = embed_batched(&mut embedder, &rtexts, |done| {
+        let vectors = embed_batched(embedder.as_mut(), &rtexts, |done| {
             let secs = t0.elapsed().as_secs_f64().max(0.001);
             eprint!("\r    embedded {done}/{n}  ({:.0}/s)   ", done as f64 / secs);
             let _ = std::io::stderr().flush();

--- a/src/scrub.rs
+++ b/src/scrub.rs
@@ -3,7 +3,7 @@
 //! re-indexing cannot. Operates only on the local store; it does not touch a published remote.
 
 use crate::index::{build_batch, embed_batched, schema};
-use crate::inference::{Embedder, OnnxEmbedder};
+use crate::inference::{self, Embedder};
 use crate::{chunk, dataset, lock, scan};
 use anyhow::Result;
 use arrow_array::{BooleanArray, RecordBatch, RecordBatchIterator};
@@ -81,7 +81,7 @@ pub async fn run() -> Result<()> {
     let replacement_batch = if replacements.is_empty() {
         None
     } else {
-        let mut embedder: Box<dyn Embedder> = Box::new(OnnxEmbedder::new()?);
+        let mut embedder: Box<dyn Embedder> = inference::embedder()?;
         let rtexts: Vec<&str> = replacements.iter().map(|c| c.text.as_str()).collect();
         let n = rtexts.len();
         eprintln!("re-embedding {n} redacted chunk(s)…");


### PR DESCRIPTION
funes' embedder (bge-small-en-v1.5) and reranker (bge-reranker-base) ran exclusively on ONNX Runtime via fastembed. That one dependency decided two things: ort's prebuilt binaries require glibc ≥ 2.38, locking release binaries out of Ubuntu 22.04, and on Apple Silicon its MLAS kernels run on NEON — well below what the machine's AMX units can do.

## A second inference backend

embed/rerank sit behind `Embedder`/`Reranker` traits (`src/inference.rs`), built through factories so no call site names a concrete ML stack. The `blas` backend (`src/blas.rs`) is a hand-written forward for both models: the encoder, tokenization, and trait impls are shared cross-platform source, and the only OS-specific code is a four-function seam — `sgemm`, `vexp`, `vmax`, `vsum` — wired to Accelerate (cblas on AMX, vForce, vDSP) on macOS and to faer's pure-Rust GEMM plus runtime-dispatched vectorized kernels on Linux. Release binaries stay baseline x86-64/aarch64 and pick AVX2/AVX-512/NEON at runtime. Weights load from safetensors, fetched into the standard HF cache on first use.

`blas` is the default feature; the ONNX backend remains one flag away:

```bash
cargo build --release --no-default-features --features onnx   # ONNX backend instead
cargo run --release --features onnx --example bench_backends  # A/B both backends
```

Building with both compiles ONNX in as the reference for `bench_backends`; funes itself runs blas. A build with neither backend is a compile error.

## Correctness and speed

`bench_backends` runs two workloads — short docs (per-call overheads) and 30 docs at the 512-token cap (recall's rerank worst case, GEMM-bound):

| platform | rerank | embed | agreement |
| --- | --- | --- | --- |
| macOS (Apple Silicon) | **2.3× faster** than ort | **1.9× faster** | max Δ 2.1e-5 / cosine 0.999999 |
| Linux (64-core EPYC) | 0.86× (2.55 s vs 2.19 s at 30×512) | ~parity (1.16 vs 1.13 s) | max Δ 4e-6 / cosine 0.999999 |

On Linux the residual vs MLAS is invisible end-to-end: `funes recall` against a real store measures identical (~6.2 s) with either backend — recall time is search-dominated and real chunks sit well below the token cap.

## Releases run on Ubuntu 22.04

Linux release builds move into an `ubuntu:22.04` container: glibc compatibility is one-way, and even without ort a 24.04-built binary binds `__isoc23_*@GLIBC_2.38` from the C dependencies compiled during the build. A post-build check fails the job if any symbol rises above `GLIBC_2.35`. Replayed locally in docker: floor 2.35, no onnxruntime in the binary, and a real-store recall runs on 22.04.

## CI

Pull requests validate what default builds ship — fmt, clippy, unit and integration tests on the blas backend — and additionally clippy the onnx feature set, so a toolchain bump can't break the opt-in backend silently. Building the onnx variant and running its real-model integration test happen only on pushes to main. Model caches split accordingly: BAAI safetensors for the PR jobs, fastembed's cache for the merge-only job; the release cache keys carry the container tag so images never share compiled C objects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
