### PR TITLE
Add store card

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,11 @@ That second form is also how you query **someone else's** published memories on 
 
 *A project this machine never worked on: the prompt names `dacorvo/funes-Glint-Research-Fable-5` — ~21.6k chunks on the Hub — and pi recalls the past decision straight from it, one `store` argument on the recall call. Nothing attached, no local index.*
 
+On its first publish, `funes push` also writes the repo's **dataset card** — what a funes store
+is, how to recall from it, live stats — tagged `funes`, so every shared store is recognizable
+(and [discoverable](https://huggingface.co/datasets?other=funes)) on the Hub; later pushes keep
+the stats fresh. A card you've written yourself is never touched.
+
 The first push to a store that shares no chunks with your local one (a first push, a new host, or the
 wrong store) asks to confirm before uploading; off a terminal it refuses rather than guess (`--yes`
 overrides). You never need the Hub to use `funes` locally — it's a tier you opt into. Recall over a remote caches whole files to local disk, so warm calls run at local speed ([how caching works](docs/hub-caching.md)).

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -67,6 +67,9 @@ timeout.
 - **Secrets held back.** funes redacts credentials at index time; on push, a separate always-on gate
   withholds any chunk that still contains one and exits non-zero (code `2`). Run `funes scrub`, then
   the next push publishes it.
+- **The card rides along.** A push to a store at the repo root creates the repo's dataset card
+  (tagged `funes`) and keeps its stats fresh — in the same commit as the data. A hand-written
+  card is never touched.
 - **The wrong-store guard.** A first push to a store your local store shares no chunks with (a first
   push, a new host, or the wrong store) is refused off a terminal. `funes add` clears it by doing
   that first push interactively — so on a new host, re-run `funes add <agent> <org>/<repo>` there

--- a/src/card.rs
+++ b/src/card.rs
@@ -12,8 +12,9 @@ const STATS_OPEN: &str = "<!-- funes:stats -->";
 const STATS_CLOSE: &str = "<!-- /funes:stats -->";
 
 /// Frontmatter tags. `funes` is the load-bearing one: it makes every published store
-/// discoverable via `huggingface.co/datasets?other=funes`.
-const TAGS: [&str; 4] = ["funes", "agent-traces", "embeddings", "lance"];
+/// discoverable via `huggingface.co/datasets?other=funes`. `agent-memory` names the category
+/// (no incumbent Hub tag exists — the ecosystem's category word, scoped to agents).
+const TAGS: [&str; 5] = ["funes", "agent-memory", "agent-traces", "embeddings", "lance"];
 
 /// The Hub's `size_categories` bands.
 const SIZE_BANDS: [(u64, &str); 10] = [
@@ -176,6 +177,7 @@ mod tests {
         // Frontmatter: the discovery tag, the computed band.
         assert!(card.starts_with("---\n"), "frontmatter first");
         assert!(card.contains("  - funes\n"));
+        assert!(card.contains("  - agent-memory\n"));
         assert!(card.contains("  - 10K<n<100K\n"));
         // Body: the recall example names this store; the stats region is marker-delimited.
         assert!(card.contains("--store acme/kb"));

--- a/src/card.rs
+++ b/src/card.rs
@@ -1,0 +1,238 @@
+//! The dataset card a published store carries: generated whole on first publish, its stats
+//! refreshed on later pushes — a hand-written card is never touched. The card is what makes a
+//! store on the Hub identifiable (and, via the `funes` tag, discoverable) as a funes store, and
+//! it doubles as usage instructions for whoever lands on the dataset page.
+//!
+//! Pure text in/out: [`plan`] decides what to do from the remote README's current content; the
+//! push path owns fetching that content and committing the result.
+
+/// Opens the region [`plan`] may rewrite; everything outside it belongs to the owner.
+const STATS_OPEN: &str = "<!-- funes:stats -->";
+/// Closes the region [`plan`] may rewrite.
+const STATS_CLOSE: &str = "<!-- /funes:stats -->";
+
+/// Frontmatter tags. `funes` is the load-bearing one: it makes every published store
+/// discoverable via `huggingface.co/datasets?other=funes`.
+const TAGS: [&str; 4] = ["funes", "agent-traces", "embeddings", "lance"];
+
+/// The Hub's `size_categories` bands.
+const SIZE_BANDS: [(u64, &str); 10] = [
+    (1_000, "n<1K"),
+    (10_000, "1K<n<10K"),
+    (100_000, "10K<n<100K"),
+    (1_000_000, "100K<n<1M"),
+    (10_000_000, "1M<n<10M"),
+    (100_000_000, "10M<n<100M"),
+    (1_000_000_000, "100M<n<1B"),
+    (10_000_000_000, "1B<n<10B"),
+    (100_000_000_000, "10B<n<100B"),
+    (1_000_000_000_000, "100B<n<1T"),
+];
+
+/// What the card says about the store.
+pub struct CardCtx<'a> {
+    /// The repo id the card lives in, `<org>/<name>` — named in the recall example.
+    pub repo: &'a str,
+    /// Chunk count after the push this card rides on.
+    pub chunks: u64,
+    /// The store's pinned embedding model (schema metadata `embedding_model`).
+    pub embedding_model: &'a str,
+    /// UTC date of the push, `YYYY-MM-DD`.
+    pub date: &'a str,
+}
+
+/// What a push should do about the card.
+#[derive(Debug, PartialEq)]
+pub enum CardAction {
+    /// No README on the remote: write this full card.
+    Create(String),
+    /// The README carries the stats markers: replace the file with this (only the marker
+    /// region differs).
+    Refresh(String),
+    /// A README without markers (hand-written), or one whose stats are already current.
+    LeaveAlone,
+}
+
+/// Decide what a push does about the card, from the remote README's current content. Ownership
+/// rules: no README → create the full card; markers present → refresh the region between them
+/// (skipping a byte-identical result); markers absent → the file is the owner's, hands off.
+pub fn plan(existing: Option<&str>, ctx: &CardCtx) -> CardAction {
+    let Some(text) = existing else {
+        return CardAction::Create(render(ctx));
+    };
+    let Some(refreshed) = splice(text, ctx) else {
+        return CardAction::LeaveAlone;
+    };
+    if refreshed == text {
+        CardAction::LeaveAlone
+    } else {
+        CardAction::Refresh(refreshed)
+    }
+}
+
+/// The full generated card: frontmatter (tags + size band), what a funes store is, how to
+/// recall from it, and the stats region.
+fn render(ctx: &CardCtx) -> String {
+    let tags = TAGS.map(|t| format!("  - {t}\n")).concat();
+    format!(
+        "---\n\
+         pretty_name: funes memory store\n\
+         tags:\n\
+         {tags}\
+         size_categories:\n  - {band}\n\
+         ---\n\
+         \n\
+         # funes memory store\n\
+         \n\
+         A [funes](https://github.com/huggingface/funes) memory store: agent sessions chunked,\n\
+         embedded, and stored as a [Lance](https://lancedb.github.io/lance/) table — a derived\n\
+         index holding verbatim passages with exact provenance, not raw transcripts.\n\
+         \n\
+         Any agent (or you) can recall from it directly — no local index needed:\n\
+         \n\
+         ```bash\n\
+         funes recall \"what did we decide about …\" --store {repo}\n\
+         ```\n\
+         \n\
+         Get funes:\n\
+         \n\
+         ```bash\n\
+         curl -fsSL https://huggingface.co/buckets/huggingface/funes/resolve/install.sh | sh\n\
+         ```\n\
+         \n\
+         {stats}\n\
+         \n\
+         *Published and kept current by `funes push`.*\n",
+        band = size_category(ctx.chunks),
+        repo = ctx.repo,
+        stats = stats_block(ctx),
+    )
+}
+
+/// The marker-delimited stats region, markers included — the only part a refresh rewrites.
+fn stats_block(ctx: &CardCtx) -> String {
+    format!(
+        "{STATS_OPEN}\n\
+         | | |\n\
+         |---|---|\n\
+         | Chunks | {chunks} |\n\
+         | Embedding model | `{model}` |\n\
+         | Updated | {date} |\n\
+         {STATS_CLOSE}",
+        chunks = thousands(ctx.chunks),
+        model = ctx.embedding_model,
+        date = ctx.date,
+    )
+}
+
+/// Replace the marker region of `text` with fresh stats, or None when the markers aren't there
+/// (the close marker must follow the open one).
+fn splice(text: &str, ctx: &CardCtx) -> Option<String> {
+    let open = text.find(STATS_OPEN)?;
+    let close = open + text[open..].find(STATS_CLOSE)? + STATS_CLOSE.len();
+    Some(format!("{}{}{}", &text[..open], stats_block(ctx), &text[close..]))
+}
+
+/// The Hub `size_categories` band holding `n`.
+fn size_category(n: u64) -> &'static str {
+    SIZE_BANDS
+        .iter()
+        .find(|(upper, _)| n < *upper)
+        .map(|(_, band)| *band)
+        .unwrap_or("n>1T")
+}
+
+/// `21636` → `21,636`.
+fn thousands(n: u64) -> String {
+    let digits = n.to_string();
+    let mut out = String::with_capacity(digits.len() + digits.len() / 3);
+    for (i, c) in digits.chars().enumerate() {
+        if i > 0 && (digits.len() - i).is_multiple_of(3) {
+            out.push(',');
+        }
+        out.push(c);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx(chunks: u64) -> CardCtx<'static> {
+        CardCtx {
+            repo: "acme/kb",
+            chunks,
+            embedding_model: "BAAI/bge-small-en-v1.5",
+            date: "2026-07-16",
+        }
+    }
+
+    #[test]
+    fn create_when_the_remote_has_no_readme() {
+        let CardAction::Create(card) = plan(None, &ctx(21_636)) else {
+            panic!("expected Create");
+        };
+        // Frontmatter: the discovery tag, the computed band.
+        assert!(card.starts_with("---\n"), "frontmatter first");
+        assert!(card.contains("  - funes\n"));
+        assert!(card.contains("  - 10K<n<100K\n"));
+        // Body: the recall example names this store; the stats region is marker-delimited.
+        assert!(card.contains("--store acme/kb"));
+        assert!(card.contains(STATS_OPEN) && card.contains(STATS_CLOSE));
+        assert!(card.contains("| Chunks | 21,636 |"));
+    }
+
+    #[test]
+    fn refresh_rewrites_only_the_marker_region() {
+        // A card the owner has edited around the markers: everything they wrote survives.
+        let owned = format!(
+            "---\nlicense: mit\n---\n\n# My store\n\nMy own intro.\n\n{}\n\nMy own footer.\n",
+            stats_block(&ctx(999))
+        );
+        let CardAction::Refresh(refreshed) = plan(Some(&owned), &ctx(1_500)) else {
+            panic!("expected Refresh");
+        };
+        assert!(refreshed.contains("license: mit"));
+        assert!(refreshed.contains("My own intro."));
+        assert!(refreshed.contains("My own footer."));
+        assert!(refreshed.contains("| Chunks | 1,500 |"));
+        assert!(!refreshed.contains("| Chunks | 999 |"));
+    }
+
+    #[test]
+    fn current_stats_are_left_alone() {
+        let card = render(&ctx(42));
+        assert_eq!(plan(Some(&card), &ctx(42)), CardAction::LeaveAlone);
+    }
+
+    #[test]
+    fn a_card_without_markers_is_never_touched() {
+        let hand = "---\nlicense: agpl-3.0\n---\n\n# Hand-written card\n";
+        assert_eq!(plan(Some(hand), &ctx(7)), CardAction::LeaveAlone);
+    }
+
+    #[test]
+    fn a_close_marker_before_the_open_is_not_a_region() {
+        let broken = format!("{STATS_CLOSE}\nstray\n{STATS_OPEN}\n");
+        assert_eq!(plan(Some(&broken), &ctx(7)), CardAction::LeaveAlone);
+    }
+
+    #[test]
+    fn size_bands_cover_the_edges() {
+        assert_eq!(size_category(0), "n<1K");
+        assert_eq!(size_category(999), "n<1K");
+        assert_eq!(size_category(1_000), "1K<n<10K");
+        assert_eq!(size_category(99_999), "10K<n<100K");
+        assert_eq!(size_category(100_000), "100K<n<1M");
+        assert_eq!(size_category(2_000_000_000_000), "n>1T");
+    }
+
+    #[test]
+    fn thousands_groups_digits() {
+        assert_eq!(thousands(0), "0");
+        assert_eq!(thousands(999), "999");
+        assert_eq!(thousands(21_636), "21,636");
+        assert_eq!(thousands(1_234_567), "1,234,567");
+    }
+}

--- a/src/card.rs
+++ b/src/card.rs
@@ -176,9 +176,13 @@ mod tests {
         };
         // Frontmatter: the discovery tag, the computed band.
         assert!(card.starts_with("---\n"), "frontmatter first");
-        assert!(card.contains("  - funes\n"));
+        // Column-anchored: the `\` line continuations strip leading whitespace, so keys sit at
+        // column one and list items exactly two spaces in — what YAML requires. A reflow of the
+        // literals that breaks this fails here, not on the Hub.
+        assert!(card.contains("\ntags:\n  - funes\n"));
         assert!(card.contains("  - agent-memory\n"));
-        assert!(card.contains("  - 10K<n<100K\n"));
+        assert!(card.contains("\nsize_categories:\n  - 10K<n<100K\n"));
+        assert!(card.contains("\n# funes memory store\n"));
         // Body: the recall example names this store; the stats region is marker-delimited.
         assert!(card.contains("--store acme/kb"));
         assert!(card.contains(STATS_OPEN) && card.contains(STATS_CLOSE));

--- a/src/hf_dataset.rs
+++ b/src/hf_dataset.rs
@@ -81,10 +81,13 @@ pub(crate) enum Reindexed {
 /// Append `batches` to the remote Lance dataset at `dataset_uri` (an `hf://…/<table>.lance` URI)
 /// and land them in one `create_commit` on branch `rev`, guarded by the current head. The append
 /// writes only data — a new fragment, manifest, and transaction — and leaves the new rows
-/// unindexed (refresh the index separately with [`reindex`]). Returns [`Appended::Committed`] with
-/// the new commit oid and the resulting unindexed-row backlog (the largest across the dataset's
-/// indexes — what `push` thresholds on), or [`Appended::Conflict`] if the head moved first — a
-/// single attempt against the head it read, so the caller drives the retry.
+/// unindexed (refresh the index separately with [`reindex`]). `extra_files` (repo path → bytes,
+/// e.g. the dataset card) ride the same guarded commit; cloned per attempt, so a conflict retry
+/// re-attaches them. Returns [`Appended::Committed`] with the new commit oid and the resulting
+/// unindexed-row backlog (the largest across the dataset's indexes — what `push` thresholds on),
+/// or [`Appended::Conflict`] if the head moved first — a single attempt against the head it read,
+/// so the caller drives the retry.
+#[allow(clippy::too_many_arguments)] // internal orchestration, one call site (`push`)
 pub(crate) async fn append(
     repo: &HFRepository<RepoTypeDataset>,
     dataset_uri: &str,
@@ -93,6 +96,7 @@ pub(crate) async fn append(
     message: String,
     batches: Vec<RecordBatch>,
     schema: SchemaRef,
+    extra_files: &BTreeMap<String, Bytes>,
 ) -> Result<Appended> {
     let parent = head_oid(repo, rev).await?;
     let (mut ds, wrapper) = open_capturing(dataset_uri, storage_options).await?;
@@ -104,8 +108,11 @@ pub(crate) async fn append(
 
     // Snapshot the captured writes before reading index stats: `index_statistics` can write a stats
     // migration through the same wrapper, and that must not leak into the data commit.
-    let files = captured_files(&wrapper);
+    let mut files = captured_files(&wrapper);
     let unindexed = max_unindexed_rows(&ds).await;
+    for (path, body) in extra_files {
+        files.insert(path.clone(), body.clone());
+    }
 
     let (ops, _dir) = write_ops(&files)?;
     match send_commit(repo, ops, parent, rev, message).await {

--- a/src/hf_dataset.rs
+++ b/src/hf_dataset.rs
@@ -249,6 +249,23 @@ fn write_ops(files: &BTreeMap<String, Bytes>) -> Result<(Vec<CommitOperation>, t
     Ok((ops, dir))
 }
 
+/// The repo's `README.md` at `rev`, or `None` when it has none — fetched straight to bytes,
+/// never the shared cache, so a push always classifies the dataset card against the branch
+/// head it targets.
+pub(crate) async fn fetch_readme(repo: &HFRepository<RepoTypeDataset>, rev: &str) -> Result<Option<String>> {
+    let fetched = repo
+        .download_file_to_bytes()
+        .filename("README.md")
+        .revision(rev.to_string())
+        .send()
+        .await;
+    match fetched {
+        Ok(bytes) => Ok(Some(String::from_utf8_lossy(&bytes).into_owned())),
+        Err(HFError::EntryNotFound { .. }) => Ok(None),
+        Err(e) => Err(anyhow::Error::new(e).context("reading the remote dataset card")),
+    }
+}
+
 /// One `create_commit` of `ops` on branch `rev`, guarded by `parent`. Returns the raw hf-hub
 /// result so callers can tell a head-moved [`HFError::Conflict`] from other failures.
 async fn send_commit(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ compile_error!("funes is unix-only (Linux/macOS)");
 #[cfg(feature = "blas")]
 pub mod blas;
 pub mod capture_store;
+pub mod card;
 pub mod chunk;
 pub mod claude;
 pub mod claude_traces;

--- a/src/push.rs
+++ b/src/push.rs
@@ -282,7 +282,9 @@ pub async fn run_push(target: Store, project: Option<String>, force_reindex: boo
         }
 
         // The dataset card rides the same commit — created when the repo has none, a
-        // hand-written card left alone (see `card_file`).
+        // hand-written card left alone (see `card_file`). Root stores only: the root README
+        // describes the whole repo, which a prefixed store is only part of (and two stores
+        // sharing a repo would fight over one card's stats) — under a prefix it's the owner's.
         let date = Utc::now().format("%Y-%m-%d").to_string();
         let ctx = CardCtx {
             repo: &repo_id,
@@ -290,7 +292,11 @@ pub async fn run_push(target: Store, project: Option<String>, force_reindex: boo
             embedding_model: embedding_model(&schema),
             date: &date,
         };
-        let (card_body, card_note) = card_file(hf_dataset::fetch_readme(&repo, &rev).await, &ctx);
+        let (card_body, card_note) = if prefix.is_empty() {
+            card_file(hf_dataset::fetch_readme(&repo, &rev).await, &ctx)
+        } else {
+            (None, String::new())
+        };
         if let Some(body) = &card_body {
             let card_path = staging.path().join("README.md");
             std::fs::write(&card_path, body)?;

--- a/src/push.rs
+++ b/src/push.rs
@@ -253,11 +253,12 @@ pub async fn run_push(target: Store, project: Option<String>, force_reindex: boo
     // carries the funes markers, a hand-written card left alone (see `card_file`). Root stores
     // only: the root README describes the whole repo, which a prefixed store is only part of
     // (and two stores sharing a repo would fight over one card's stats) — under a prefix it's
-    // the owner's. The chunk count is the post-push total.
+    // the owner's. The chunk count is the post-push total — best-effort: rows another writer
+    // lands concurrently are missed until the next push refreshes the card.
     let date = Utc::now().format("%Y-%m-%d").to_string();
     let ctx = CardCtx {
         repo: &repo_id,
-        chunks: (remote_ids.len() + n_chunks) as u64,
+        chunks: remote_ids.len() as u64 + n_chunks as u64,
         embedding_model: embedding_model(&schema),
         date: &date,
     };

--- a/src/push.rs
+++ b/src/push.rs
@@ -16,12 +16,14 @@
 //!   crosses [`REINDEX_THRESHOLD`] (best-effort: a head-moved conflict is a warning, the next push
 //!   retries), or eagerly with `--force-reindex` (retried until it lands).
 
+use crate::card::{self, CardAction, CardCtx};
 use crate::hf_dataset::{self, Appended, Reindexed};
 use crate::hub::{self, Store};
 use crate::{chunk, dataset, scan};
 use anyhow::{bail, Context, Result};
 use arrow_array::{BooleanArray, RecordBatch, RecordBatchIterator, StringArray};
 use arrow_select::filter::filter_record_batch;
+use chrono::Utc;
 use hf_hub::repository::CommitOperation;
 use hf_hub::{HFClient, HFError, HFRepository, RepoTypeDataset};
 use lance::dataset::WriteParams;
@@ -191,6 +193,7 @@ pub async fn run_push(target: Store, project: Option<String>, force_reindex: boo
     // 2. HF repo handle. Resolve the target and token before the confirmation, so a bad URI or a
     // missing token fails before we prompt for one.
     let (owner, name, prefix) = hub::parse_hf(&uri)?;
+    let repo_id = format!("{owner}/{name}");
     let token = hub::hf_token().context("no HF token (set HF_TOKEN) — required to push")?;
 
     // When required, ask for confirmation before publishing.
@@ -277,6 +280,23 @@ pub async fn run_push(target: Store, project: Option<String>, force_reindex: boo
         if ops.is_empty() {
             return Ok(format!("{}: nothing new to upload\n", target.label()).into());
         }
+
+        // The dataset card rides the same commit — created when the repo has none, a
+        // hand-written card left alone (see `card_file`).
+        let date = Utc::now().format("%Y-%m-%d").to_string();
+        let ctx = CardCtx {
+            repo: &repo_id,
+            chunks: n_chunks as u64,
+            embedding_model: embedding_model(&schema),
+            date: &date,
+        };
+        let (card_body, card_note) = card_file(hf_dataset::fetch_readme(&repo, &rev).await, &ctx);
+        if let Some(body) = &card_body {
+            let card_path = staging.path().join("README.md");
+            std::fs::write(&card_path, body)?;
+            ops.push(CommitOperation::add_file("README.md".to_string(), card_path));
+        }
+
         eprintln!("uploading {n_chunks} chunk(s) to {}…", target.label());
         let info = repo
             .create_commit()
@@ -288,7 +308,7 @@ pub async fn run_push(target: Store, project: Option<String>, force_reindex: boo
             .await
             .map_err(|e| anyhow::Error::new(e).context("create_commit failed"))?;
         return Ok(format!(
-            "{}: pushed {n_chunks} chunks (commit {})\n{}",
+            "{}: pushed {n_chunks} chunks (commit {})\n{card_note}{}",
             target.label(),
             info.commit_oid.as_deref().unwrap_or("?"),
             skipped.warning()
@@ -335,6 +355,37 @@ pub async fn run_push(target: Store, project: Option<String>, force_reindex: boo
     }
     out.push_str(&skipped.warning());
     Ok(out.into())
+}
+
+/// The store's pinned embedding model, from the schema metadata `index` stamps. A pre-metadata
+/// store has no id to show.
+fn embedding_model(schema: &arrow_schema::Schema) -> &str {
+    schema
+        .metadata()
+        .get("embedding_model")
+        .map(String::as_str)
+        .unwrap_or("unknown")
+}
+
+/// What a push does about the dataset card, from the remote README fetch (`Err` = unreadable):
+/// the content to commit as `README.md`, if any, and the report line. An unreadable README is
+/// indistinguishable from a hand-written card, so it's left alone rather than risk clobbering
+/// it — the next push retries.
+fn card_file(remote_readme: Result<Option<String>>, ctx: &CardCtx) -> (Option<String>, String) {
+    let existing = match remote_readme {
+        Ok(existing) => existing,
+        Err(e) => {
+            return (
+                None,
+                format!("  note: dataset card left untouched (couldn't read the current one: {e})\n"),
+            )
+        }
+    };
+    match card::plan(existing.as_deref(), ctx) {
+        CardAction::Create(text) => (Some(text), "  dataset card created\n".into()),
+        CardAction::Refresh(text) => (Some(text), "  dataset card refreshed\n".into()),
+        CardAction::LeaveAlone => (None, String::new()),
+    }
 }
 
 /// Rows held back from a push because their text still contained a secret.
@@ -467,6 +518,46 @@ mod tests {
         // path can't be built here; it's exercised by the gated round-trip.)
         assert!(!is_read_only(&anyhow::anyhow!("server said 403 Forbidden")));
         assert!(!is_read_only(&anyhow::anyhow!("no HF token")));
+    }
+
+    /// Card context for the [`card_file`] tests.
+    fn card_ctx(chunks: u64) -> CardCtx<'static> {
+        CardCtx {
+            repo: "acme/kb",
+            chunks,
+            embedding_model: "BAAI/bge-small-en-v1.5",
+            date: "2026-07-16",
+        }
+    }
+
+    #[test]
+    fn card_file_creates_when_the_remote_has_none() {
+        let (body, note) = card_file(Ok(None), &card_ctx(10));
+        assert!(body.expect("a card").contains("--store acme/kb"));
+        assert_eq!(note, "  dataset card created\n");
+    }
+
+    #[test]
+    fn card_file_refreshes_a_funes_card() {
+        let CardAction::Create(current) = card::plan(None, &card_ctx(10)) else {
+            panic!("expected Create");
+        };
+        let (body, note) = card_file(Ok(Some(current)), &card_ctx(999));
+        assert!(body.expect("a refresh").contains("| Chunks | 999 |"));
+        assert_eq!(note, "  dataset card refreshed\n");
+    }
+
+    #[test]
+    fn card_file_never_touches_a_hand_written_card() {
+        let (body, note) = card_file(Ok(Some("# my store\n".into())), &card_ctx(10));
+        assert!(body.is_none() && note.is_empty());
+    }
+
+    #[test]
+    fn card_file_skips_when_the_remote_readme_is_unreadable() {
+        let (body, note) = card_file(Err(anyhow::anyhow!("504")), &card_ctx(10));
+        assert!(body.is_none());
+        assert!(note.contains("left untouched"), "note: {note}");
     }
 
     use crate::trace::{Block, Turn};

--- a/src/push.rs
+++ b/src/push.rs
@@ -23,12 +23,13 @@ use crate::{chunk, dataset, scan};
 use anyhow::{bail, Context, Result};
 use arrow_array::{BooleanArray, RecordBatch, RecordBatchIterator, StringArray};
 use arrow_select::filter::filter_record_batch;
+use bytes::Bytes;
 use chrono::Utc;
 use hf_hub::repository::CommitOperation;
 use hf_hub::{HFClient, HFError, HFRepository, RepoTypeDataset};
 use lance::dataset::WriteParams;
 use lance::Dataset;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 
 /// Reindex the remote once this many appended rows are sitting unindexed (answered by a
@@ -248,6 +249,24 @@ pub async fn run_push(target: Store, project: Option<String>, force_reindex: boo
         });
     }
 
+    // The dataset card rides the data commit — created when the repo has none, refreshed when it
+    // carries the funes markers, a hand-written card left alone (see `card_file`). Root stores
+    // only: the root README describes the whole repo, which a prefixed store is only part of
+    // (and two stores sharing a repo would fight over one card's stats) — under a prefix it's
+    // the owner's. The chunk count is the post-push total.
+    let date = Utc::now().format("%Y-%m-%d").to_string();
+    let ctx = CardCtx {
+        repo: &repo_id,
+        chunks: (remote_ids.len() + n_chunks) as u64,
+        embedding_model: embedding_model(&schema),
+        date: &date,
+    };
+    let (card_body, card_note) = if prefix.is_empty() {
+        card_file(hf_dataset::fetch_readme(&repo, &rev).await, &ctx)
+    } else {
+        (None, String::new())
+    };
+
     // 5. First publish: build the whole dataset locally (data + indexes) and push it in one commit.
     if first_publish {
         let staging = tempfile::tempdir()?;
@@ -281,22 +300,6 @@ pub async fn run_push(target: Store, project: Option<String>, force_reindex: boo
             return Ok(format!("{}: nothing new to upload\n", target.label()).into());
         }
 
-        // The dataset card rides the same commit — created when the repo has none, a
-        // hand-written card left alone (see `card_file`). Root stores only: the root README
-        // describes the whole repo, which a prefixed store is only part of (and two stores
-        // sharing a repo would fight over one card's stats) — under a prefix it's the owner's.
-        let date = Utc::now().format("%Y-%m-%d").to_string();
-        let ctx = CardCtx {
-            repo: &repo_id,
-            chunks: n_chunks as u64,
-            embedding_model: embedding_model(&schema),
-            date: &date,
-        };
-        let (card_body, card_note) = if prefix.is_empty() {
-            card_file(hf_dataset::fetch_readme(&repo, &rev).await, &ctx)
-        } else {
-            (None, String::new())
-        };
         if let Some(body) = &card_body {
             let card_path = staging.path().join("README.md");
             std::fs::write(&card_path, body)?;
@@ -325,6 +328,10 @@ pub async fn run_push(target: Store, project: Option<String>, force_reindex: boo
     // 6. Append the data and commit it, retrying against a fresh head if a concurrent push moved it
     // (each attempt re-appends onto the new manifest — the data commit is small, so this is cheap).
     let message = format!("funes push: +{n_chunks} chunks");
+    // The card refresh rides the same guarded commit as the data.
+    let extra: BTreeMap<String, Bytes> = card_body
+        .map(|body| BTreeMap::from([("README.md".to_string(), Bytes::from(body))]))
+        .unwrap_or_default();
     eprintln!("uploading {n_chunks} chunk(s) to {}…", target.label());
     let mut attempts = 0u32;
     let (oid, unindexed) = loop {
@@ -336,6 +343,7 @@ pub async fn run_push(target: Store, project: Option<String>, force_reindex: boo
             message.clone(),
             batches.clone(),
             schema.clone(),
+            &extra,
         )
         .await?;
         match attempt {
@@ -349,6 +357,7 @@ pub async fn run_push(target: Store, project: Option<String>, force_reindex: boo
         }
     };
     let mut out = format!("{}: pushed {n_chunks} chunks (commit {oid})\n", target.label());
+    out.push_str(&card_note);
 
     // 7. Reindex as a separate commit: forced (retried until it lands) or, past the threshold,
     // best-effort (one shot, warn on a conflict — the next push retries).

--- a/tests/push_card.rs
+++ b/tests/push_card.rs
@@ -1,0 +1,180 @@
+//! Gated live e2e for the dataset card. The card is root-stores-only, so this test owns a whole
+//! throwaway repo (created and deleted here): a first publish must create the card, an append
+//! must refresh its stats in the same data commit, and once the README is hand-written funes
+//! must keep its hands off it.
+//!
+//! Skipped unless `HF_FUNES_TEST_TOKEN` is set (it provides `HF_TOKEN`) AND `trufflehog` is on
+//! PATH (push's pre-publish gate is fail-closed) — and skipped with a note if the token cannot
+//! create a scratch repo under the test org. Needs a bigger thread stack than the default. To
+//! run:
+//!
+//!   export HF_FUNES_TEST_TOKEN=<your HF token>
+//!   RUST_MIN_STACK=16777216 cargo test --test push_card -- --nocapture
+
+use std::io::Write;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use funes::hub::Store;
+use funes::push::Confirm;
+use hf_hub::repository::CommitOperation;
+use hf_hub::{HFClient, HFError, HFRepository, RepoTypeDataset};
+
+const OWNER: &str = "optimum-internal-testing";
+
+/// Write `projects/<proj>/sess.jsonl` with the given (uuid, text) user turns.
+fn write_session(source: &std::path::Path, turns: &[(&str, &str)]) {
+    let dir = source.join("projects").join("-cardtest-proj");
+    std::fs::create_dir_all(&dir).unwrap();
+    let mut f = std::fs::File::create(dir.join("sess.jsonl")).unwrap();
+    for (i, (uuid, text)) in turns.iter().enumerate() {
+        writeln!(
+            f,
+            r#"{{"type":"user","uuid":"{uuid}","timestamp":"2026-02-01T00:00:{i:02}Z","message":{{"role":"user","content":"{text}"}}}}"#
+        )
+        .unwrap();
+    }
+}
+
+fn tool_ok(bin: &str, arg: &str) -> bool {
+    Command::new(bin)
+        .arg(arg)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// The repo-root README, or None when the repo has none. Any other failure panics: a transport
+/// error must fail the test loudly, not masquerade as "no README".
+async fn root_readme(repo: &HFRepository<RepoTypeDataset>) -> Option<String> {
+    match repo.download_file_to_bytes().filename("README.md").send().await {
+        Ok(bytes) => Some(String::from_utf8_lossy(&bytes).into_owned()),
+        Err(HFError::EntryNotFound { .. }) => None,
+        Err(e) => panic!("querying the repo-root README: {e}"),
+    }
+}
+
+#[tokio::test]
+async fn card_created_refreshed_and_a_hand_card_respected() {
+    let token = std::env::var("HF_FUNES_TEST_TOKEN")
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    if token.is_empty() {
+        eprintln!("skip: HF_FUNES_TEST_TOKEN not set");
+        return;
+    }
+    if !tool_ok("trufflehog", "--version") {
+        eprintln!("skip: trufflehog not installed (push's secret gate is fail-closed)");
+        return;
+    }
+    std::env::set_var("HF_TOKEN", &token);
+    let client = HFClient::builder().token(token).build().unwrap();
+
+    // A throwaway ROOT store: unique repo name so concurrent/repeated runs don't collide.
+    let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
+    let name = format!("funes-test-card-{}-{nanos}", std::process::id());
+    if let Err(e) = funes::hub::create_dataset_repo(OWNER, &name).await {
+        eprintln!("skip: cannot create a scratch repo under {OWNER}: {e}");
+        return;
+    }
+    let repo = client.dataset(OWNER, name.clone());
+    let uri = format!("hf://datasets/{OWNER}/{name}");
+
+    // Synthetic local store with one turn.
+    let db_dir = tempfile::tempdir().unwrap();
+    let src = tempfile::tempdir().unwrap();
+    std::env::set_var("FUNES_HOME", db_dir.path());
+    write_session(src.path(), &[("s1", "CARDSMOKE the first turn")]);
+    funes::index::run_index(src.path(), false, None).await.unwrap();
+
+    // First publish → the card rides the initial commit.
+    let create = funes::push::run_push(Store::parse(&uri), None, false, Confirm::Yes).await;
+    let card_created = root_readme(&repo).await;
+
+    // Grow by one turn → the append must refresh the stats in the same data commit.
+    write_session(
+        src.path(),
+        &[("s1", "CARDSMOKE the first turn"), ("s2", "CARDSMOKE2 the second turn")],
+    );
+    funes::index::run_index(src.path(), false, None).await.unwrap();
+    let append = funes::push::run_push(Store::parse(&uri), None, false, Confirm::Yes).await;
+    let card_refreshed = root_readme(&repo).await;
+
+    // Hand-write the README: from here on funes must keep its hands off.
+    let hand = "# hand-written card\n";
+    let hand_dir = tempfile::tempdir().unwrap();
+    let hand_path = hand_dir.path().join("README.md");
+    std::fs::write(&hand_path, hand).unwrap();
+    repo.create_commit()
+        .operations(vec![CommitOperation::add_file("README.md".to_string(), hand_path)])
+        .commit_message("hand-edit the card".to_string())
+        .send()
+        .await
+        .expect("hand-editing the card");
+
+    write_session(
+        src.path(),
+        &[
+            ("s1", "CARDSMOKE the first turn"),
+            ("s2", "CARDSMOKE2 the second turn"),
+            ("s3", "CARDSMOKE3 the third turn"),
+        ],
+    );
+    funes::index::run_index(src.path(), false, None).await.unwrap();
+    let append_past_hand = funes::push::run_push(Store::parse(&uri), None, false, Confirm::Yes).await;
+    let card_after_hand = root_readme(&repo).await;
+
+    // Cleanup before asserting, so a failed assertion can't leave the scratch repo behind.
+    let _ = client
+        .delete_repository()
+        .repo_id(format!("{OWNER}/{name}"))
+        .repo_type(RepoTypeDataset)
+        .send()
+        .await;
+
+    let create = create.expect("create push").report;
+    assert!(
+        create.contains("dataset card created"),
+        "first publish should report the card: {create}"
+    );
+    let card_created = card_created.expect("first publish should create the card");
+    assert!(
+        card_created.contains("<!-- funes:stats -->"),
+        "the card should carry the stats markers: {card_created}"
+    );
+    assert!(
+        card_created.contains("| Chunks | 1 |"),
+        "the card should count the pushed chunk: {card_created}"
+    );
+    assert!(
+        card_created.contains(&format!("--store {OWNER}/{name}")),
+        "the recall example should name this store: {card_created}"
+    );
+
+    let append = append.expect("append push").report;
+    assert!(
+        append.contains("dataset card refreshed"),
+        "the append should report the refresh: {append}"
+    );
+    let card_refreshed = card_refreshed.expect("the refreshed card should still exist");
+    assert!(
+        card_refreshed.contains("| Chunks | 2 |"),
+        "the refresh should update the chunk count: {card_refreshed}"
+    );
+
+    let append_past_hand = append_past_hand.expect("append past a hand card").report;
+    assert!(
+        append_past_hand.contains("pushed 1 chunks"),
+        "the data push should proceed: {append_past_hand}"
+    );
+    assert!(
+        !append_past_hand.contains("dataset card"),
+        "a hand-written card must not be reported on: {append_past_hand}"
+    );
+    assert_eq!(
+        card_after_hand.as_deref(),
+        Some(hand),
+        "the hand-written card must survive an append untouched"
+    );
+}

--- a/tests/push_round_trip.rs
+++ b/tests/push_round_trip.rs
@@ -22,7 +22,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use funes::hub::Store;
 use funes::push::Confirm;
-use hf_hub::HFClient;
+use hf_hub::{HFClient, HFError, HFRepository, RepoTypeDataset};
 
 const OWNER: &str = "optimum-internal-testing";
 const NAME: &str = "funes-test";
@@ -47,6 +47,16 @@ fn tool_ok(bin: &str, arg: &str) -> bool {
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false)
+}
+
+/// The repo-root README, or None when the repo has none. Any other failure panics: a transport
+/// error must fail the test loudly, not masquerade as "no README".
+async fn root_readme(repo: &HFRepository<RepoTypeDataset>) -> Option<String> {
+    match repo.download_file_to_bytes().filename("README.md").send().await {
+        Ok(bytes) => Some(String::from_utf8_lossy(&bytes).into_owned()),
+        Err(HFError::EntryNotFound { .. }) => None,
+        Err(e) => panic!("querying the repo-root README: {e}"),
+    }
 }
 
 async fn recall_remote(uri: &str, query: &str) -> String {
@@ -91,6 +101,10 @@ async fn push_round_trip_create_append_recall() {
     std::env::set_var("HF_TOKEN", &token);
     let client = HFClient::builder().token(token).build().unwrap();
     let repo = client.dataset(OWNER, NAME);
+
+    // The store lives under a prefix, so no push here may ever touch the repo-root README (the
+    // dataset card is root-stores-only). Snapshot it now, compare after every push ran.
+    let readme_before = root_readme(&repo).await;
 
     // Unique scratch path so concurrent/repeated runs don't collide.
     let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
@@ -140,6 +154,7 @@ async fn push_round_trip_create_append_recall() {
     // the index as its own commit (capture_reindex + a separate commit), then recall it again.
     let reindex = funes::push::run_push(Store::parse(&uri), None, true, Confirm::Yes).await;
     let recall_reindexed = recall_remote(&uri, "SYNCSMOKE2 continuation").await;
+    let readme_after = root_readme(&repo).await;
     // The model id must travel with the store (stamped in the schema metadata, uploaded by push).
     let remote_model = match Store::parse(&uri).open().await {
         Ok(t) => t.schema().metadata.get("embedding_model").cloned(),
@@ -209,5 +224,9 @@ async fn push_round_trip_create_append_recall() {
         remote_model.as_deref(),
         Some(funes::index::MODEL),
         "the model id should travel with the store via push"
+    );
+    assert_eq!(
+        readme_before, readme_after,
+        "a prefixed push must never touch the repo-root README (the card is root-stores-only)"
     );
 }


### PR DESCRIPTION
A pushed store lands on the Hub as a bare repo — no card, no tags, nothing saying what it is. This makes every published store carry a self-describing **dataset card**, created and kept current by `funes push` itself.

## What changes

- **`card::plan` decides, push executes.** No README on the remote → write the full generated card: frontmatter (tags, size band), what a funes store is, a recall example naming the store, and a marker-delimited stats block (chunks, embedding model, last update). Markers present → rewrite only that block. **A hand-written card is never touched.**
- **Zero extra commits.** The card rides the commit that's already happening: one more operation in the first-publish commit, an extra file through `hf_dataset::append`'s guarded commit on later pushes — atomic with the data, re-attached on conflict retries.
- **Root stores only.** The root README describes the whole repo, and only a root store *is* the repo; a store under a prefix never touches it.
- **Fail-safe.** If the remote README can't be read it can't be classified, so the card is skipped with a note — never clobbered, and the push is unaffected.
- **Discovery.** The `funes` tag makes every shared store recognizable and [browsable](https://huggingface.co/datasets?other=funes) on the Hub; `agent-memory` names the category.

## Testing

- Unit: the ownership rules (create / refresh-markers-only / hands-off, malformed markers), size bands, and the push-side decision wiring.
- New gated live e2e (`push_card`, against a throwaway root repo): the card is created on first publish, its stats refresh on append, and a hand-written README survives further pushes byte-identical.
- The gated round-trip (prefixed store) now asserts the repo-root README is never touched.

Docs: the README's Hub section and `docs/automation.md` each gain the three-line version of the above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
