### PR TITLE
Better project facet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ fell back to; the built-in guide has no store to name and keeps a bare hint).
 | `--half-life` | 30 | recency decay in days (a hit this old keeps half its weight); 0 disables |
 | `--neighbors` | 1 | adjacent chunks (by seq) attached per hit; 0 disables |
 | `--type` | — | restrict to `text \| thinking \| tool_use \| tool_result` |
-| `--project` | — | restrict to a project (the directory segment under `projects`) |
+| `--project` | — | restrict to a project (the basename of the session's working directory, e.g. `funes`) |
 | `--harness` | — | restrict to `claude \| codex \| pi` (the stored facet `claude_code` also parses) |
 | `--store` | local store | the store to read — `<org>/<repo>`, an `hf://…` URI, a local path, or `local` |
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,12 @@ path = "benchmark/bench_index.rs"
 name = "bench_backends"
 path = "benchmark/bench_backends.rs"
 
+# One-off store migration for the cwd-derived project facet; delete with the file once every
+# store is migrated.
+[[example]]
+name = "migrate_project_facet"
+path = "scripts/migrate_project_facet.rs"
+
 [profile.release]
 opt-level = 3
 

--- a/scripts/migrate_project_facet.rs
+++ b/scripts/migrate_project_facet.rs
@@ -1,0 +1,136 @@
+//! One-off migration: recompute each stored row's `project` facet from its source transcript, in
+//! place — for a store built before the facet came from the session's recorded cwd. Uses the same
+//! per-harness derivation as the indexer, so a migrated store matches a freshly rebuilt one
+//! wherever the transcript still exists; a row whose transcript is gone keeps its stored facet
+//! (the store may be its only remaining record). Text and vectors are untouched — only the one
+//! column is rewritten. Local store only (`$FUNES_HOME` selects which).
+//!
+//!   cargo run --example migrate_project_facet
+//!
+//! Disposable: delete this file and its `[[example]]` entry once every store is migrated.
+
+use anyhow::{Context, Result};
+use arrow_array::{Array, RecordBatch, RecordBatchIterator, StringArray};
+use funes::{claude_traces, codex_traces, dataset, jsonl, lock, pi_traces};
+use lance::dataset::{Dataset, WriteMode, WriteParams};
+use std::collections::{BTreeMap, HashMap};
+use std::path::Path;
+use std::sync::Arc;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // The rewrite replaces the whole table, so hold the store lock to be the sole writer.
+    let _lock = lock::StoreLock::acquire()?;
+    let uri = dataset::table_uri(&dataset::local_store_dir());
+    let Ok(ds) = dataset::open(&uri, HashMap::new()).await else {
+        println!("no local store to migrate");
+        return Ok(());
+    };
+
+    eprintln!("loading the local store…");
+    let batches = dataset::scan_rows(&ds, &[], None, None).await?;
+    let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+    if total == 0 {
+        println!("store is empty");
+        return Ok(());
+    }
+
+    // One derivation per distinct source_path — a session's rows all share one transcript.
+    let mut derived: HashMap<String, Option<String>> = HashMap::new();
+    // (old, new) → row count, for the report.
+    let mut renames: BTreeMap<(String, String), usize> = BTreeMap::new();
+    let mut untouched = 0usize;
+    let mut changed = 0usize;
+
+    let mut out: Vec<RecordBatch> = Vec::new();
+    for b in &batches {
+        let projects = col_str(b, "project")?;
+        let sources = col_str(b, "source_path")?;
+        let harnesses = col_str(b, "harness")?;
+        let mut new_projects: Vec<Option<String>> = Vec::with_capacity(b.num_rows());
+        for i in 0..b.num_rows() {
+            let old = projects.value(i);
+            let (source, harness) = (sources.value(i), harnesses.value(i));
+            let new = derived
+                .entry(source.to_string())
+                .or_insert_with(|| derive_project(source, harness));
+            match new.as_deref() {
+                Some(p) if p != old => {
+                    *renames.entry((old.to_string(), p.to_string())).or_default() += 1;
+                    changed += 1;
+                    new_projects.push(Some(p.to_string()));
+                }
+                Some(_) => new_projects.push(Some(old.to_string())),
+                None => {
+                    untouched += 1;
+                    new_projects.push((!projects.is_null(i)).then(|| old.to_string()));
+                }
+            }
+        }
+        let proj_idx = b.schema().index_of("project")?;
+        let mut cols = b.columns().to_vec();
+        cols[proj_idx] = Arc::new(StringArray::from(new_projects));
+        out.push(RecordBatch::try_new(b.schema(), cols)?);
+    }
+
+    if changed == 0 {
+        println!("store is already migrated ({total} chunks)");
+        return Ok(());
+    }
+
+    // Rewrite in a single Overwrite commit — same rationale as scrub: two commits could be
+    // interrupted between them, and for a source-gone session that loss is permanent.
+    eprintln!("rewriting the store…");
+    let schema = out[0].schema();
+    let reader = RecordBatchIterator::new(out.into_iter().map(Ok), schema);
+    let mut ds = Dataset::write(
+        reader,
+        &uri,
+        Some(WriteParams {
+            mode: WriteMode::Overwrite,
+            ..Default::default()
+        }),
+    )
+    .await?;
+    dataset::build_indexes(&mut ds, |phase| eprintln!("building {phase}…")).await;
+
+    let mut msg = format!("migrated {changed} of {total} row(s):");
+    for ((old, new), n) in &renames {
+        msg.push_str(&format!("\n  {old} → {new}  ({n} row(s))"));
+    }
+    if untouched > 0 {
+        msg.push_str(&format!(
+            "\nleft {untouched} row(s) as-is (source transcript gone, or not a local JSONL transcript)"
+        ));
+    }
+    println!("{msg}");
+    Ok(())
+}
+
+/// The facet `source` derives to today, or `None` when it can't be re-derived — the caller leaves
+/// those rows alone. The extension gate matters: a parquet-sourced row's file-stem facet is
+/// already right, and the path fallback would clobber it with the parent dir. Mirrors the indexer:
+/// the recorded cwd's basename, else the path-derived fallback.
+fn derive_project(source: &str, harness: &str) -> Option<String> {
+    let p = Path::new(source);
+    if !p.extension().map(|x| x == "jsonl").unwrap_or(false) {
+        return None;
+    }
+    let records = jsonl::read_jsonl_records(p).ok()?;
+    let from_cwd = match harness {
+        "claude_code" => claude_traces::project_from_records(&records),
+        "codex" => codex_traces::project_from_records(&records),
+        "pi" => pi_traces::project_from_records(&records),
+        _ => return None,
+    };
+    Some(from_cwd.unwrap_or_else(|| claude_traces::project_of(p)))
+}
+
+/// A named Utf8 column of `b`, or an error naming what's missing.
+fn col_str<'a>(b: &'a RecordBatch, name: &str) -> Result<&'a StringArray> {
+    b.column_by_name(name)
+        .with_context(|| format!("store has no `{name}` column"))?
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .with_context(|| format!("`{name}` column is not utf8"))
+}

--- a/src/claude_traces.rs
+++ b/src/claude_traces.rs
@@ -7,7 +7,8 @@ use std::path::Path;
 use crate::jsonl;
 use crate::trace::{Block, Turn};
 
-/// The path segment right after a `projects` dir, else the parent dir name.
+/// Path-derived project fallback for a transcript that records no cwd: the segment right after a
+/// `projects` dir, else the parent dir name.
 pub fn project_of(p: &Path) -> String {
     let parts: Vec<&str> = p.iter().filter_map(|s| s.to_str()).collect();
     if let Some(i) = parts.iter().position(|&s| s == "projects") {
@@ -122,8 +123,15 @@ fn normalize_blocks(content: &Value) -> Vec<Block> {
     out
 }
 
-pub fn turns_from_jsonl_file(p: &Path, session_id: &str, project: &str) -> std::io::Result<Vec<Turn>> {
+pub fn turns_from_jsonl_file(p: &Path, session_id: &str, fallback_project: &str) -> std::io::Result<Vec<Turn>> {
     let records = jsonl::read_jsonl_records(p)?;
+    // The project facet is the basename of the session's recorded cwd (first usable one wins), so
+    // the same clone names the same project on every host; the path-derived fallback covers
+    // transcripts that never recorded one.
+    let project = records
+        .iter()
+        .find_map(|r| r.get("cwd").and_then(Value::as_str).and_then(jsonl::project_of_cwd))
+        .unwrap_or_else(|| fallback_project.to_string());
 
     let mut turns = Vec::new();
     let mut seq = 0i64; // index among RETAINED turns, file order
@@ -225,6 +233,30 @@ mod tests {
         assert_eq!(result.text, "file.txt");
         // name correlated from the tool_use with the same id.
         assert_eq!(result.tool_name.as_deref(), Some("Bash"));
+    }
+
+    #[test]
+    fn project_prefers_the_recorded_cwd_first_usable_wins() {
+        let f = write_jsonl(&[
+            r#"{"type":"user","uuid":"u1","cwd":"/Users/d/dev/funes","message":{"role":"user","content":"hi"}}"#,
+            r#"{"type":"assistant","uuid":"a1","cwd":"/Users/d/dev/elsewhere","message":{"role":"assistant","content":"yo"}}"#,
+        ]);
+        let turns = turns_from_jsonl_file(f.path(), "s", "fallback").unwrap();
+        assert!(turns.iter().all(|t| t.project == "funes"));
+    }
+
+    #[test]
+    fn cross_host_cwds_yield_the_same_project() {
+        // The same clone indexed from a Mac and a Linux home lands in one facet value.
+        let line = |cwd: &str| {
+            format!(r#"{{"type":"user","uuid":"u1","cwd":"{cwd}","message":{{"role":"user","content":"hi"}}}}"#)
+        };
+        let (mac_line, linux_line) = (line("/Users/dcorvoysier/dev/funes"), line("/home/ubuntu/funes"));
+        let mac = write_jsonl(&[mac_line.as_str()]);
+        let linux = write_jsonl(&[linux_line.as_str()]);
+        let p = |f: &tempfile::NamedTempFile| turns_from_jsonl_file(f.path(), "s", "fb").unwrap()[0].project.clone();
+        assert_eq!(p(&mac), "funes");
+        assert_eq!(p(&mac), p(&linux));
     }
 
     #[test]

--- a/src/claude_traces.rs
+++ b/src/claude_traces.rs
@@ -123,15 +123,19 @@ fn normalize_blocks(content: &Value) -> Vec<Block> {
     out
 }
 
-pub fn turns_from_jsonl_file(p: &Path, session_id: &str, fallback_project: &str) -> std::io::Result<Vec<Turn>> {
-    let records = jsonl::read_jsonl_records(p)?;
-    // The project facet is the basename of the session's recorded cwd (first usable one wins), so
-    // the same clone names the same project on every host; the path-derived fallback covers
-    // transcripts that never recorded one.
-    let project = records
+/// The project a session's records name: the basename of the first usable `cwd` (Claude Code
+/// stamps one on every entry). `None` when no record carries one.
+pub fn project_from_records(records: &[Value]) -> Option<String> {
+    records
         .iter()
         .find_map(|r| r.get("cwd").and_then(Value::as_str).and_then(jsonl::project_of_cwd))
-        .unwrap_or_else(|| fallback_project.to_string());
+}
+
+pub fn turns_from_jsonl_file(p: &Path, session_id: &str, fallback_project: &str) -> std::io::Result<Vec<Turn>> {
+    let records = jsonl::read_jsonl_records(p)?;
+    // The project facet is the basename of the session's recorded cwd, so the same clone names the
+    // same project on every host; the path-derived fallback covers transcripts without one.
+    let project = project_from_records(&records).unwrap_or_else(|| fallback_project.to_string());
 
     let mut turns = Vec::new();
     let mut seq = 0i64; // index among RETAINED turns, file order

--- a/src/codex_traces.rs
+++ b/src/codex_traces.rs
@@ -18,9 +18,7 @@ pub fn turns_from_jsonl_file(p: &Path, fallback_project: &str) -> std::io::Resul
     let session_id = session_meta_str(&records, "id").unwrap_or_else(|| jsonl::session_id_of(p));
     // The project facet is the basename of the session's recorded cwd, so the same clone names the
     // same project on every host; the path-derived fallback covers transcripts without one.
-    let project = session_meta_str(&records, "cwd")
-        .and_then(|cwd| jsonl::project_of_cwd(&cwd))
-        .unwrap_or_else(|| fallback_project.to_string());
+    let project = project_from_records(&records).unwrap_or_else(|| fallback_project.to_string());
 
     let mut turns = Vec::new();
     let mut seq = 0i64; // index among RETAINED turns, file order
@@ -69,6 +67,12 @@ pub fn turns_from_jsonl_file(p: &Path, fallback_project: &str) -> std::io::Resul
 
     jsonl::backfill_tool_names(&mut turns);
     Ok(turns)
+}
+
+/// The project a rollout's records name: the basename of the `session_meta` payload's `cwd`.
+/// `None` when no record carries one.
+pub fn project_from_records(records: &[Value]) -> Option<String> {
+    session_meta_str(records, "cwd").and_then(|cwd| jsonl::project_of_cwd(&cwd))
 }
 
 /// A string field of the first `session_meta` line's payload, if present.

--- a/src/codex_traces.rs
+++ b/src/codex_traces.rs
@@ -11,11 +11,16 @@ use std::path::Path;
 use crate::jsonl;
 use crate::trace::{Block, Turn};
 
-pub fn turns_from_jsonl_file(p: &Path, project: &str) -> std::io::Result<Vec<Turn>> {
+pub fn turns_from_jsonl_file(p: &Path, fallback_project: &str) -> std::io::Result<Vec<Turn>> {
     let records = jsonl::read_jsonl_records(p)?;
     // Rollout filenames (`rollout-<ts>-<uuid>.jsonl`) aren't a clean session id; take it from the
     // `session_meta` line in this same pass, else fall back to the file stem.
-    let session_id = session_meta_id(&records).unwrap_or_else(|| jsonl::session_id_of(p));
+    let session_id = session_meta_str(&records, "id").unwrap_or_else(|| jsonl::session_id_of(p));
+    // The project facet is the basename of the session's recorded cwd, so the same clone names the
+    // same project on every host; the path-derived fallback covers transcripts without one.
+    let project = session_meta_str(&records, "cwd")
+        .and_then(|cwd| jsonl::project_of_cwd(&cwd))
+        .unwrap_or_else(|| fallback_project.to_string());
 
     let mut turns = Vec::new();
     let mut seq = 0i64; // index among RETAINED turns, file order
@@ -66,11 +71,13 @@ pub fn turns_from_jsonl_file(p: &Path, project: &str) -> std::io::Result<Vec<Tur
     Ok(turns)
 }
 
-/// The session id from the `session_meta` line's `payload.id`, if present.
-fn session_meta_id(records: &[Value]) -> Option<String> {
+/// A string field of the first `session_meta` line's payload, if present.
+fn session_meta_str(records: &[Value], key: &str) -> Option<String> {
     records.iter().find_map(|rec| {
         if rec.get("type").and_then(Value::as_str) == Some("session_meta") {
-            rec.pointer("/payload/id").and_then(Value::as_str).map(str::to_string)
+            rec.pointer(&format!("/payload/{key}"))
+                .and_then(Value::as_str)
+                .map(str::to_string)
         } else {
             None
         }
@@ -245,6 +252,25 @@ mod tests {
         assert_eq!(result.blocks[0].text, "file.txt");
         // name correlated from the function_call with the same call_id.
         assert_eq!(result.blocks[0].tool_name.as_deref(), Some("exec_command"));
+    }
+
+    #[test]
+    fn project_comes_from_the_session_meta_cwd_with_path_fallback() {
+        let msg = r#"{"type":"response_item","timestamp":"t","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]}}"#;
+        let mac = write_jsonl(&[
+            r#"{"type":"session_meta","timestamp":"t0","payload":{"id":"s","cwd":"/Users/d/dev/funes"}}"#,
+            msg,
+        ]);
+        let linux = write_jsonl(&[
+            r#"{"type":"session_meta","timestamp":"t0","payload":{"id":"s","cwd":"/home/u/funes"}}"#,
+            msg,
+        ]);
+        // The same clone names the same project on both hosts.
+        assert_eq!(turns_from_jsonl_file(mac.path(), "fb").unwrap()[0].project, "funes");
+        assert_eq!(turns_from_jsonl_file(linux.path(), "fb").unwrap()[0].project, "funes");
+        // No recorded cwd → the path-derived fallback.
+        let bare = write_jsonl(&[msg]);
+        assert_eq!(turns_from_jsonl_file(bare.path(), "fb").unwrap()[0].project, "fb");
     }
 
     #[test]

--- a/src/hf_traces.rs
+++ b/src/hf_traces.rs
@@ -5,8 +5,12 @@
 //! `Glint-Research/Fable-5-traces`): each row is one session whose `messages` column is a list of
 //! JSON-encoded OpenAI-style chat messages — `{role, content, reasoning_content?, tool_calls?}`.
 //! `reasoning_content` becomes a thinking block, `content` a text block, and each `tool_calls`
-//! entry a tool_use block, matching funes' block vocabulary.
+//! entry a tool_use block, matching funes' block vocabulary. Per-row columns carry the facets:
+//! `harness`, and the project as the basename of the `metadata` JSON's `cwd` key (where the
+//! normalizer surfaces the session's working directory) — the same derivation as the JSONL
+//! parsers.
 
+use crate::jsonl;
 use crate::trace::{Block, Turn};
 
 use anyhow::{anyhow, Context, Result};
@@ -20,7 +24,7 @@ use std::path::Path;
 /// sessions (one row each), skipping rows whose messages yield no indexable block. Each `Turn`
 /// carries its own `session_id`, so the index pipeline groups them without a per-session wrapper —
 /// mirroring `claude_traces::turns_from_jsonl_file`, which also returns `Vec<Turn>`.
-pub fn turns_from_parquet(path: &Path, project: &str, limit: Option<usize>) -> Result<Vec<Turn>> {
+pub fn turns_from_parquet(path: &Path, fallback_project: &str, limit: Option<usize>) -> Result<Vec<Turn>> {
     let file = File::open(path).with_context(|| format!("open parquet {}", path.display()))?;
     let reader = ParquetRecordBatchReaderBuilder::try_new(file)?.build()?;
     let cap = limit.unwrap_or(usize::MAX);
@@ -54,9 +58,15 @@ pub fn turns_from_parquet(path: &Path, project: &str, limit: Option<usize>) -> R
             let source = str_at(&batch, "file_path", i).unwrap_or_else(|| path.display().to_string());
             // Per-row: a dataset can mix harnesses; a dataset without the column reads as "".
             let harness = str_at(&batch, "harness", i).unwrap_or_default();
+            // Per-row facet: the basename of the session's recorded cwd (`metadata.cwd`, where
+            // the normalizer surfaces it), else the dataset-level fallback (its file stem).
+            let project = metadata_cwd(&batch, i)
+                .as_deref()
+                .and_then(jsonl::project_of_cwd)
+                .unwrap_or_else(|| fallback_project.to_string());
 
             let msgs = parse_message_list(&messages.value(i))?;
-            let turns = turns_from_messages(&msgs, &sid, project, &ts, &source, &harness);
+            let turns = turns_from_messages(&msgs, &sid, &project, &ts, &source, &harness);
             if !turns.is_empty() {
                 out.extend(turns);
                 sessions += 1;
@@ -64,6 +74,14 @@ pub fn turns_from_parquet(path: &Path, project: &str, limit: Option<usize>) -> R
         }
     }
     Ok(out)
+}
+
+/// The `cwd` recorded in a row's `metadata` JSON column — where the Hub's agent-traces normalizer
+/// surfaces the session's working directory.
+fn metadata_cwd(batch: &RecordBatch, i: usize) -> Option<String> {
+    let md = str_at(batch, "metadata", i)?;
+    let v: Value = serde_json::from_str(&md).ok()?;
+    v.get("cwd").and_then(Value::as_str).map(str::to_string)
 }
 
 /// A `Utf8`/`LargeUtf8` column's non-null value at row `i`. HF auto-conversion can emit either
@@ -302,6 +320,49 @@ mod tests {
             "s2 rows are claude_code"
         );
         assert!(!harness_for("s1").is_empty() && !harness_for("s2").is_empty());
+    }
+
+    #[test]
+    fn project_is_the_metadata_cwd_basename_with_the_stem_fallback() {
+        let msg = r#"{"role":"user","content":"hi"}"#;
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("session_id", DataType::Utf8, false),
+            Field::new(
+                "messages",
+                DataType::List(Arc::new(Field::new("item", DataType::Utf8, true))),
+                false,
+            ),
+            Field::new("metadata", DataType::Utf8, true),
+        ]));
+        let mut sid = StringBuilder::new();
+        let mut msgs = ListBuilder::new(StringBuilder::new());
+        let mut md = StringBuilder::new();
+        for (s, m) in [
+            ("s1", Some(r#"{"cwd":"/Users/g/Desktop/huggingface.js"}"#)),
+            ("s2", Some(r#"{"cwd":null}"#)),
+            ("s3", None),
+        ] {
+            sid.append_value(s);
+            msgs.values().append_value(msg);
+            msgs.append(true);
+            md.append_option(m);
+        }
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(sid.finish()), Arc::new(msgs.finish()), Arc::new(md.finish())],
+        )
+        .unwrap();
+        let f = tempfile::Builder::new().suffix(".parquet").tempfile().unwrap();
+        let mut w = ArrowWriter::try_new(f.reopen().unwrap(), schema, None).unwrap();
+        w.write(&batch).unwrap();
+        w.close().unwrap();
+
+        let turns = turns_from_parquet(f.path(), "stem", None).unwrap();
+        let project_for =
+            |sess: &str| -> String { turns.iter().find(|t| t.session_id == sess).unwrap().project.clone() };
+        assert_eq!(project_for("s1"), "huggingface.js", "metadata.cwd basename");
+        assert_eq!(project_for("s2"), "stem", "null cwd → the dataset fallback");
+        assert_eq!(project_for("s3"), "stem", "no metadata → the dataset fallback");
     }
 
     #[test]

--- a/src/jsonl.rs
+++ b/src/jsonl.rs
@@ -29,6 +29,16 @@ pub fn session_id_of(p: &Path) -> String {
     p.file_stem().and_then(|s| s.to_str()).unwrap_or("").to_string()
 }
 
+/// The project facet for a session's recorded working directory: the cwd's basename, so clones of
+/// the same repo agree across hosts and teammates (`/Users/d/dev/funes` and `/home/u/funes` are
+/// both `funes`). The cwd was written by whatever machine ran the session, so both separator
+/// styles are split rather than trusting the local platform's path semantics. `None` when there
+/// is no final component (an empty or root cwd).
+pub fn project_of_cwd(cwd: &str) -> Option<String> {
+    let name = cwd.trim_end_matches(['/', '\\']).rsplit(['/', '\\']).next()?;
+    (!name.is_empty()).then(|| name.to_string())
+}
+
 /// Parse a `*.jsonl` file into one [`Value`] per non-blank, parseable line. A read failure
 /// propagates as `Err` so the indexer skips the file *without recording state* — swallowing it
 /// would silently mark an unreadable file fully indexed. A line that doesn't parse is dropped (a
@@ -102,6 +112,22 @@ mod tests {
     #[test]
     fn session_id_is_file_stem() {
         assert_eq!(session_id_of(Path::new("/x/y/71626b12.jsonl")), "71626b12");
+    }
+
+    #[test]
+    fn project_of_cwd_is_the_basename_on_any_host() {
+        // The same clone dir name yields the same facet whichever machine recorded the cwd.
+        assert_eq!(project_of_cwd("/Users/dcorvoysier/dev/funes").as_deref(), Some("funes"));
+        assert_eq!(project_of_cwd("/home/ubuntu/funes").as_deref(), Some("funes"));
+        assert_eq!(project_of_cwd(r"C:\Users\d\dev\funes").as_deref(), Some("funes"));
+        assert_eq!(project_of_cwd("/home/ubuntu/funes/").as_deref(), Some("funes"));
+    }
+
+    #[test]
+    fn project_of_cwd_rejects_empty_and_root_cwds() {
+        assert_eq!(project_of_cwd(""), None);
+        assert_eq!(project_of_cwd("/"), None);
+        assert_eq!(project_of_cwd("///"), None);
     }
 
     #[test]

--- a/src/jsonl.rs
+++ b/src/jsonl.rs
@@ -33,10 +33,11 @@ pub fn session_id_of(p: &Path) -> String {
 /// the same repo agree across hosts and teammates (`/Users/d/dev/funes` and `/home/u/funes` are
 /// both `funes`). The cwd was written by whatever machine ran the session, so both separator
 /// styles are split rather than trusting the local platform's path semantics. `None` when there
-/// is no final component (an empty or root cwd).
+/// is no final component (an empty or root cwd — a Windows drive root like `C:\` counts, its
+/// basename being the bare drive designator).
 pub fn project_of_cwd(cwd: &str) -> Option<String> {
     let name = cwd.trim_end_matches(['/', '\\']).rsplit(['/', '\\']).next()?;
-    (!name.is_empty()).then(|| name.to_string())
+    (!name.is_empty() && !name.ends_with(':')).then(|| name.to_string())
 }
 
 /// Parse a `*.jsonl` file into one [`Value`] per non-blank, parseable line. A read failure
@@ -128,6 +129,8 @@ mod tests {
         assert_eq!(project_of_cwd(""), None);
         assert_eq!(project_of_cwd("/"), None);
         assert_eq!(project_of_cwd("///"), None);
+        assert_eq!(project_of_cwd(r"C:\"), None);
+        assert_eq!(project_of_cwd("C:/"), None);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,7 @@ enum Cmd {
         /// Restrict to a block type: text | thinking | tool_use | tool_result.
         #[arg(long = "type", value_name = "BLOCK_TYPE")]
         block_type: Option<String>,
-        /// Restrict to a project (the path segment under `projects`).
+        /// Restrict to a project (the basename of the session's working directory).
         #[arg(long)]
         project: Option<String>,
         /// Restrict to a harness: claude | codex | pi.
@@ -134,7 +134,7 @@ enum Cmd {
     Push {
         /// Store to publish to: `<org>/<repo>` or a full `hf://…` URI.
         store: String,
-        /// Publish only this project's chunks (the path segment under `projects`) — a projection,
+        /// Publish only this project's chunks (the basename of the session's working directory) — a projection,
         /// so a multi-project machine can seed a per-project store without leaking siblings.
         #[arg(long)]
         project: Option<String>,

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -19,7 +19,7 @@ pub struct RecallRequest {
     pub k: Option<usize>,
     #[schemars(description = "Restrict to a block type: text | thinking | tool_use | tool_result")]
     pub block_type: Option<String>,
-    #[schemars(description = "Restrict to a project (the directory segment under `projects`)")]
+    #[schemars(description = "Restrict to a project (the basename of the session's working directory, e.g. `funes`)")]
     pub project: Option<String>,
     #[schemars(description = "Restrict to a harness: claude | codex | pi")]
     pub harness: Option<String>,

--- a/src/pi_traces.rs
+++ b/src/pi_traces.rs
@@ -10,20 +10,23 @@ use std::path::Path;
 use crate::jsonl;
 use crate::trace::{Block, Turn};
 
+/// The project a session's records name: the basename of the `session` line's `cwd`. `None` when
+/// no record carries one.
+pub fn project_from_records(records: &[Value]) -> Option<String> {
+    records.iter().find_map(|r| {
+        if r.get("type").and_then(Value::as_str) == Some("session") {
+            r.get("cwd").and_then(Value::as_str).and_then(jsonl::project_of_cwd)
+        } else {
+            None
+        }
+    })
+}
+
 pub fn turns_from_jsonl_file(p: &Path, session_id: &str, fallback_project: &str) -> std::io::Result<Vec<Turn>> {
     let records = jsonl::read_jsonl_records(p)?;
-    // The project facet is the basename of the cwd on the `session` line, so the same clone names
-    // the same project on every host; the path-derived fallback covers transcripts without one.
-    let project = records
-        .iter()
-        .find_map(|r| {
-            if r.get("type").and_then(Value::as_str) == Some("session") {
-                r.get("cwd").and_then(Value::as_str).and_then(jsonl::project_of_cwd)
-            } else {
-                None
-            }
-        })
-        .unwrap_or_else(|| fallback_project.to_string());
+    // The project facet is the basename of the session's recorded cwd, so the same clone names the
+    // same project on every host; the path-derived fallback covers transcripts without one.
+    let project = project_from_records(&records).unwrap_or_else(|| fallback_project.to_string());
 
     let mut turns = Vec::new();
     let mut seq = 0i64; // index among RETAINED turns, file order

--- a/src/pi_traces.rs
+++ b/src/pi_traces.rs
@@ -10,8 +10,20 @@ use std::path::Path;
 use crate::jsonl;
 use crate::trace::{Block, Turn};
 
-pub fn turns_from_jsonl_file(p: &Path, session_id: &str, project: &str) -> std::io::Result<Vec<Turn>> {
+pub fn turns_from_jsonl_file(p: &Path, session_id: &str, fallback_project: &str) -> std::io::Result<Vec<Turn>> {
     let records = jsonl::read_jsonl_records(p)?;
+    // The project facet is the basename of the cwd on the `session` line, so the same clone names
+    // the same project on every host; the path-derived fallback covers transcripts without one.
+    let project = records
+        .iter()
+        .find_map(|r| {
+            if r.get("type").and_then(Value::as_str) == Some("session") {
+                r.get("cwd").and_then(Value::as_str).and_then(jsonl::project_of_cwd)
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| fallback_project.to_string());
 
     let mut turns = Vec::new();
     let mut seq = 0i64; // index among RETAINED turns, file order
@@ -253,6 +265,31 @@ mod tests {
         // name is inline, id from toolCallId.
         assert_eq!(r.blocks[0].tool_name.as_deref(), Some("bash"));
         assert_eq!(r.blocks[0].tool_use_id.as_deref(), Some("call_1"));
+    }
+
+    #[test]
+    fn project_comes_from_the_session_line_cwd_with_path_fallback() {
+        let msg = r#"{"type":"message","id":"u1","timestamp":1,"message":{"role":"user","content":[{"type":"text","text":"hi"}]}}"#;
+        let mac = write_jsonl(&[
+            r#"{"type":"session","id":"s","timestamp":1,"cwd":"/Users/d/dev/funes","version":"1"}"#,
+            msg,
+        ]);
+        let linux = write_jsonl(&[
+            r#"{"type":"session","id":"s","timestamp":1,"cwd":"/home/u/funes","version":"1"}"#,
+            msg,
+        ]);
+        // The same clone names the same project on both hosts.
+        assert_eq!(
+            turns_from_jsonl_file(mac.path(), "s", "fb").unwrap()[0].project,
+            "funes"
+        );
+        assert_eq!(
+            turns_from_jsonl_file(linux.path(), "s", "fb").unwrap()[0].project,
+            "funes"
+        );
+        // No recorded cwd → the path-derived fallback.
+        let bare = write_jsonl(&[msg]);
+        assert_eq!(turns_from_jsonl_file(bare.path(), "s", "fb").unwrap()[0].project, "fb");
     }
 
     #[test]

--- a/src/source.rs
+++ b/src/source.rs
@@ -172,9 +172,9 @@ impl TraceSource for ParquetDataset {
 
     fn read(&self, unit: &Unit) -> Result<Vec<Turn>> {
         let p = Path::new(&unit.key);
-        // The project facet for a parquet dataset is its file stem.
-        let project = p.file_stem().and_then(|s| s.to_str()).unwrap_or("parquet").to_string();
-        hf_traces::turns_from_parquet(p, &project, self.limit)
+        // Fallback project for rows without a recorded cwd: the dataset's file stem.
+        let fallback = p.file_stem().and_then(|s| s.to_str()).unwrap_or("parquet").to_string();
+        hf_traces::turns_from_parquet(p, &fallback, self.limit)
     }
 
     fn fatal_on_read_error(&self) -> bool {
@@ -189,7 +189,8 @@ struct RemoteShard {
     key: String,
     /// The shard downloaded whole into hf-hub's cache.
     local: PathBuf,
-    /// Project facet = the shard's file stem (parity with [`ParquetDataset`]).
+    /// Fallback project for rows without a recorded cwd: the shard's file stem (parity with
+    /// [`ParquetDataset`]).
     project: String,
 }
 

--- a/src/source.rs
+++ b/src/source.rs
@@ -137,11 +137,13 @@ impl TraceSource for JsonlTree {
 
     fn read(&self, unit: &Unit) -> Result<Vec<Turn>> {
         let p = Path::new(&unit.key);
-        let project = claude_traces::project_of(p);
+        // Each parser derives the project facet from the session's recorded cwd; the path-derived
+        // value is only the fallback for transcripts that never recorded one.
+        let fallback = claude_traces::project_of(p);
         let turns = match self.harness {
-            Harness::Claude => claude_traces::turns_from_jsonl_file(p, &jsonl::session_id_of(p), &project)?,
-            Harness::Codex => codex_traces::turns_from_jsonl_file(p, &project)?,
-            Harness::Pi => pi_traces::turns_from_jsonl_file(p, &jsonl::session_id_of(p), &project)?,
+            Harness::Claude => claude_traces::turns_from_jsonl_file(p, &jsonl::session_id_of(p), &fallback)?,
+            Harness::Codex => codex_traces::turns_from_jsonl_file(p, &fallback)?,
+            Harness::Pi => pi_traces::turns_from_jsonl_file(p, &jsonl::session_id_of(p), &fallback)?,
         };
         Ok(turns)
     }


### PR DESCRIPTION
The `project` facet was derived from where a transcript sits on disk, which made it host-dependent (`-home-ubuntu-funes` vs `-Users-dcorvoysier-dev-funes` for the same clone) and outright wrong for codex/pi, whose date-tree layouts have no `projects` segment — their fallback stamped a date directory as the project.

The facet is now **the basename of the working directory the session recorded**, read from the transcript only — nothing probed at index time, so ingest stays deterministic. The same clone names the same project on every host and for every teammate, by the natural convention of the clone's directory name.

| source | where the cwd comes from |
| --- | --- |
| Claude Code | first usable `cwd` across entries |
| codex | `session_meta.payload.cwd` |
| pi | the `session` line's `cwd` |
| converted trace datasets (parquet) | `metadata.cwd`, where the Hub's agent-traces normalizer surfaces it |

The old path derivation survives only as the fallback for transcripts that never recorded a cwd; parquet rows without one keep the file/shard stem. Indexing `julien-c/pi-sessions` now yields facets like `huggingface.js` and `pi-mono` instead of the shard stem.

**Rejected: git-remote identity (org/repo).** Resolving a remote needs the live filesystem at index time — the same transcript would index differently depending on machine state, the directory is gone for old sessions and never existed for Hub traces, and forks/multiple remotes fracture team identity anyway. Accepted tradeoff: basename collisions (`~/work/api` vs `~/personal/api`) merge in the facet — it's a filter, over-inclusion is tolerable.

**Migrating existing stores.** `cargo run --example migrate_project_facet` recomputes the facet in place from each row's source transcript — only the `project` column is rewritten (no re-embedding), and rows whose transcript is gone keep their stored facet, which a rebuild-from-transcripts would silently drop. It's a disposable one-off, not funes surface: delete the file and its `[[example]]` entry once every store is migrated. Note that remotes keep old values (push id-dedupe never re-ships), and hooks keep writing old-style facets until the released binary includes this change — run the migration once more after updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)