### PR TITLE
refactor(ui): drop fzf dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1226,6 +1226,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1411,7 +1417,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
 dependencies = [
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
+dependencies = [
+ "castaway",
+ "cfg-if 1.0.4",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
 ]
 
 [[package]]
@@ -1463,7 +1483,7 @@ checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "unicode-width",
+ "unicode-width 0.2.0",
  "windows-sys 0.61.2",
 ]
 
@@ -1685,6 +1705,31 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crunchy"
@@ -3045,9 +3090,11 @@ dependencies = [
  "lance-io",
  "lance-linalg",
  "multiversion",
+ "nucleo-matcher",
  "object_store",
  "openssl-sys",
  "parquet",
+ "ratatui",
  "rmcp",
  "safetensors",
  "serde",
@@ -3595,6 +3642,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -4154,9 +4203,18 @@ checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
  "console",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.0",
  "unit-prefix",
  "web-time",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -4167,6 +4225,19 @@ checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding",
  "generic-array",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling 0.23.0",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4999,6 +5070,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -5050,6 +5127,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
 dependencies = [
  "imgref",
+]
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -5204,6 +5290,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
@@ -5467,6 +5554,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nucleo-matcher"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf33f538733d1a5a3494b836ba913207f14d9d4a1d3cd67030c5061bdd2cac85"
+dependencies = [
+ "memchr",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -6784,6 +6881,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str 0.8.2",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools 0.13.0",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "rav1e"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7345,6 +7463,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -7352,7 +7483,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -7778,6 +7909,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8160,7 +8312,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.3",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -8319,7 +8471,7 @@ checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
 dependencies = [
  "ahash",
  "aho-corasick",
- "compact_str",
+ "compact_str 0.9.1",
  "dary_heap",
  "derive_builder",
  "esaxx-rs",
@@ -8659,10 +8811,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.2"
+name = "unicode-truncate"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode_categories"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-std", "syn
 futures = "0.3"
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
+ratatui = "0.29"                 # in-process recall browser (list + preview picker); re-exports crossterm 0.28
+nucleo-matcher = "0.3"           # fuzzy filtering the browser's hit/turn lists
 serde = { version = "1", features = ["derive"] }               # MCP request structs
 serde_json = { version = "1", features = ["preserve_order"] }  # parse JSONL; preserve tool_use key order
 sha1 = "0.10"                    # chunk id = sha1(...)[:16]

--- a/README.md
+++ b/README.md
@@ -192,8 +192,8 @@ Run recall in a terminal, though, and it notices — and switches to an interact
 funes recall "why must sparse attention mask future keys before top-k selection" --store dacorvo/funes-Glint-Research-Fable-5
 ```
 
-Browse the hits and expand any of them into its full surrounding turns.
-Install [fzf](https://github.com/junegunn/fzf) for a richer interface.
+Browse the hits, filter as you type, and press enter on any of them to read its full surrounding
+turns — a built-in browser, no extra tools to install.
 
 The full interface — output formats, flags, defaults — is specified in [AGENTS.md](AGENTS.md).
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,4 +45,5 @@ pub mod scan;
 pub mod scrub;
 pub mod source;
 pub mod trace;
+pub mod tui;
 pub mod update;

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,18 +85,6 @@ enum Cmd {
         #[command(flatten)]
         store: StoreOpts,
     },
-    /// Browse a session's turns in fzf — the hit picker's drill-down.
-    #[command(hide = true)]
-    Turns {
-        session_id: String,
-        /// The turn to mark in the list (the recall hit).
-        turn_uuid: String,
-        /// The matched chunk, highlighted in previews and pages.
-        #[arg(long)]
-        highlight: Option<String>,
-        #[command(flatten)]
-        store: StoreOpts,
-    },
     /// Build or update your local store from session transcripts.
     Index {
         /// A transcript tree or `.parquet` file, or a Hub trace repo `<org>/<repo>`. Omit — in a
@@ -317,13 +305,24 @@ async fn main() -> Result<()> {
                         return Ok(());
                     }
                     let (color, width) = human_io();
-                    print!("{note}");
-                    // fzf owns the whole terminal, so it needs a real one; a forced human format
-                    // without TTYs (or without fzf installed) keeps the line selector.
+                    // The in-process browser owns the whole terminal, so it needs real TTYs; a
+                    // forced human format without them (or the FUNES_NO_TUI opt-out) keeps the
+                    // plain line selector. It runs on its own thread — not a runtime worker — so it
+                    // can `block_on` a session load when drilling into a hit.
                     let interactive = std::io::stdin().is_terminal() && std::io::stdout().is_terminal();
-                    if interactive && use_fzf() {
-                        select_hits_fzf(&store, &query, &hits, color, width)
+                    if interactive && std::env::var_os("FUNES_NO_TUI").is_none() {
+                        let rt = tokio::runtime::Handle::current();
+                        std::thread::scope(|s| {
+                            match s
+                                .spawn(|| funes::tui::browser::run(store, note, query, &hits, color, width, rt))
+                                .join()
+                            {
+                                Ok(res) => res,
+                                Err(_) => Err(anyhow!("recall browser thread panicked")),
+                            }
+                        })
                     } else {
+                        print!("{note}");
                         select_hits(&store, &hits, color, width).await
                     }
                 }
@@ -358,12 +357,6 @@ async fn main() -> Result<()> {
             }
             Ok(())
         }
-        Cmd::Turns {
-            session_id,
-            turn_uuid,
-            highlight,
-            store,
-        } => select_turns_fzf(store.resolve(), session_id, turn_uuid, highlight).await,
         Cmd::Index {
             path,
             harness,
@@ -723,7 +716,7 @@ async fn select_hits(store: &hub::Store, hits: &[(Hit, f64)], color: bool, width
                                     "funes get {} {} --window {window} --store {}",
                                     h.session_id,
                                     h.turn_uuid,
-                                    sh_word(&store.label())
+                                    funes::tui::sh_word(&store.label())
                                 ),
                                 color
                             )
@@ -739,208 +732,6 @@ async fn select_hits(store: &hub::Store, hits: &[(Hit, f64)], color: bool, width
             }
         }
     }
-}
-
-/// fzf-driven hit selector, the human default when fzf is installed: the list pane holds one row
-/// per hit, the preview pane shows the matched chunk, enter drills into the session's turn
-/// browser and leaving it returns here — the walk-back; Esc quits. Each row carries hidden tab
-/// columns — session id and turn uuid for the drill-down, plus the matched chunk, which doubles
-/// as search text (a query matches content beyond the visible scent) and as the preview.
-fn select_hits_fzf(store: &hub::Store, query: &str, hits: &[(Hit, f64)], color: bool, width: usize) -> Result<()> {
-    let rows = render::recall_rows(hits, color, width, chrono::Utc::now());
-    let mut lines = String::new();
-    for ((h, _), row) in hits.iter().zip(&rows) {
-        // Field 4 is the matched chunk, whitespace-collapsed: fzf searches it (a query matches
-        // content beyond the visible scent) and the preview leads with it.
-        let blob: String = h
-            .text
-            .split_whitespace()
-            .collect::<Vec<_>>()
-            .join(" ")
-            .chars()
-            .take(2000)
-            .collect();
-        lines.push_str(&format!(
-            "{}\t{}\t{}\t{}\n",
-            row.replace('\t', " "),
-            h.session_id,
-            h.turn_uuid,
-            blob
-        ));
-    }
-    let exe = std::env::current_exe()?;
-    let copy = clipboard_pipe();
-    let hints = match copy {
-        Some(_) => "enter browses the session · ctrl-y copies its get command · esc quits",
-        None => "enter browses the session · esc quits",
-    };
-    let mut args = fzf_style_args(color, "recall ❯ ", &format!("{query} · {}\n{hints}", store.label()));
-    args.extend([
-        "--preview".to_string(),
-        // The matched chunk, nothing else — the turn browser behind enter owns the context.
-        // Rendering the turn here too would show the match's text twice in different shapes
-        // (or, for a tool hit, not at all: the turn view compresses tool blocks).
-        "echo {4} | fold -s -w $FZF_PREVIEW_COLUMNS".to_string(),
-        "--preview-window".to_string(),
-        "right:60%:wrap".to_string(),
-        "--bind".to_string(),
-        // fzf shell-escapes {4} (the matched chunk) itself.
-        format!(
-            "enter:execute:{} turns {{2}} {{3}} --store {} --highlight {{4}}",
-            sh_quote(&exe.display().to_string()),
-            sh_quote(&store.label())
-        ),
-    ]);
-    if let Some(pipe) = copy {
-        args.extend(["--bind".to_string(), copy_bind(store, pipe)]);
-    }
-    let mut fzf = std::process::Command::new("fzf")
-        .args(&args)
-        .stdin(std::process::Stdio::piped())
-        .spawn()?;
-    fzf.stdin.take().expect("stdin is piped").write_all(lines.as_bytes())?;
-    // Enter never terminates fzf (it drills into the turn browser and comes back); the picker
-    // ends on Esc or Ctrl-C, so any exit status just means "done browsing".
-    fzf.wait()?;
-    Ok(())
-}
-
-/// The turn browser behind enter in the hit picker: one fzf row per turn of the session, oldest
-/// first, the recall hit's turn marked `▶`; the highlighted turn shows whole in the preview pane
-/// — the matched chunk reverse-videoed within it — and enter toggles that pane full-screen for
-/// reading. Esc walks back to the hit picker.
-async fn select_turns_fzf(
-    store: hub::Store,
-    session_id: String,
-    center: String,
-    highlight: Option<String>,
-) -> Result<()> {
-    let s8 = &session_id[..session_id.len().min(8)];
-    let spinner = Spinner::start(&format!("loading session {s8}…"));
-    let (note, turns) = recall::get_turns(store.clone(), session_id.clone(), center.clone(), i64::MAX).await?;
-    drop(spinner);
-    if turns.is_empty() {
-        print!("{note}");
-        println!("turn {center} not found in session {session_id}");
-        return Ok(());
-    }
-    let (color, width) = human_io();
-    let rows = render::turn_rows(&turns, color, width);
-    // The session is fetched once, above; each turn's rendering is written to a file the preview
-    // and the pager read back — field 4 of the row — so neither touches the store again.
-    let dir = tempfile::tempdir()?;
-    let mut lines = String::new();
-    for (i, (t, row)) in turns.iter().zip(&rows).enumerate() {
-        let path = dir.path().join(i.to_string());
-        let body = render::get_human("", std::slice::from_ref(t), color, width, highlight.as_deref());
-        std::fs::write(&path, body)?;
-        let marker = if t.turn_uuid == center { "▶ " } else { "  " };
-        lines.push_str(&format!(
-            "{marker}{}\t{}\t{}\t{}\n",
-            row.replace('\t', " "),
-            session_id,
-            t.turn_uuid,
-            path.display()
-        ));
-    }
-    let copy = clipboard_pipe();
-    // Reading mode: enter grows the preview to most of the screen and back, and the arrows keep
-    // walking the turns while it's grown. An fzf without change-preview-window pages the turn
-    // through less instead.
-    let reader = fzf_version().is_some_and(|v| v >= (0, 30));
-    let enter_hint = if reader {
-        "enter toggles full-screen"
-    } else {
-        "enter opens the turn in less"
-    };
-    let hints = match copy {
-        Some(_) => format!("{enter_hint} · ctrl-y copies the get command · esc goes back"),
-        None => format!("{enter_hint} · esc goes back"),
-    };
-    let mut args = fzf_style_args(color, "turns ❯ ", &format!("session {s8} · {}\n{hints}", store.label()));
-    args.extend([
-        "--preview".to_string(),
-        "cat {4}".to_string(),
-        "--preview-window".to_string(),
-        "right:60%:wrap".to_string(),
-        "--bind".to_string(),
-        if reader {
-            "enter:change-preview-window(down,90%,wrap|right,60%,wrap)".to_string()
-        } else {
-            // fzf runs binds via $SHELL -c, and zsh doesn't word-split an unquoted
-            // `${PAGER:-less -R}` default — the command must be spelled out word by word.
-            // `-R` passes the highlight's ANSI marks through.
-            "enter:execute:cat {4} | less -R".to_string()
-        },
-    ]);
-    if let Some(pipe) = copy {
-        args.extend(["--bind".to_string(), copy_bind(&store, pipe)]);
-    }
-    let mut cmd = std::process::Command::new("fzf");
-    cmd.args(&args);
-    // Land on the hit's turn rather than the top of a possibly huge session. `pos` needs
-    // fzf 0.36; older ones still get the `▶` marker to search for.
-    if let Some(idx) = turns.iter().position(|t| t.turn_uuid == center) {
-        if fzf_version().is_some_and(|v| v >= (0, 36)) {
-            cmd.args(["--bind", &format!("load:pos({})", idx + 1)]);
-        }
-    }
-    let mut fzf = cmd.stdin(std::process::Stdio::piped()).spawn()?;
-    fzf.stdin.take().expect("stdin is piped").write_all(lines.as_bytes())?;
-    fzf.wait()?;
-    Ok(())
-}
-
-/// The presentation flags the fzf pickers share: rows are tab-delimited with only the first field
-/// visible, the header carries the context and key hints, and fzf's own chrome (prompt, pointer,
-/// match highlights) wears the funes accent, cyan — monochrome when `color` is off.
-fn fzf_style_args(color: bool, prompt: &str, header: &str) -> Vec<String> {
-    let mut args: Vec<String> = [
-        "--ansi",
-        "--layout=reverse",
-        "--no-sort",
-        "--info=inline",
-        "--pointer=❯",
-        "--delimiter",
-        "\t",
-        "--with-nth",
-        "1",
-    ]
-    .into_iter()
-    .map(str::to_string)
-    .collect();
-    args.push(format!("--prompt={prompt}"));
-    args.push(format!("--header={header}"));
-    args.push(if color {
-        "--color=hl:6,hl+:6,prompt:6,pointer:6,info:6,spinner:6,marker:6".to_string()
-    } else {
-        "--color=bw".to_string()
-    });
-    args
-}
-
-/// The ctrl-y bind for a picker whose rows carry session id and turn uuid in fields 2 and 3:
-/// copies the row's ready-to-run `funes get` command through `pipe`.
-fn copy_bind(store: &hub::Store, pipe: &str) -> String {
-    format!(
-        "ctrl-y:execute-silent(printf 'funes get %s %s --store %s' {{2}} {{3}} {} | {pipe})",
-        sh_word(&store.label())
-    )
-}
-
-/// The first clipboard writer on PATH, as a shell pipe target; None when the box has none.
-fn clipboard_pipe() -> Option<&'static str> {
-    const WRITERS: [(&str, &str); 4] = [
-        ("pbcopy", "pbcopy"),
-        ("wl-copy", "wl-copy"),
-        ("xclip", "xclip -selection clipboard"),
-        ("xsel", "xsel --input --clipboard"),
-    ];
-    let path = std::env::var_os("PATH")?;
-    WRITERS
-        .iter()
-        .find(|(bin, _)| std::env::split_paths(&path).any(|d| d.join(bin).is_file()))
-        .map(|(_, pipe)| *pipe)
 }
 
 /// A stderr spinner for the wait before results: braille frames plus a phase label, redrawn in
@@ -1004,38 +795,6 @@ impl Drop for Spinner {
     }
 }
 
-/// `s` single-quoted for a shell command line.
-fn sh_quote(s: &str) -> String {
-    format!("'{}'", s.replace('\'', "'\\''"))
-}
-
-/// `s` quoted only when a shell would mangle it bare — for commands shown to be copy-pasted,
-/// where quoting the common clean label is just noise.
-fn sh_word(s: &str) -> String {
-    let clean = |c: char| c.is_ascii_alphanumeric() || "/:.@_+=%,~-".contains(c);
-    if !s.is_empty() && s.chars().all(clean) {
-        s.to_string()
-    } else {
-        sh_quote(s)
-    }
-}
-
-/// The installed fzf's (major, minor), or None when it can't be read.
-fn fzf_version() -> Option<(u32, u32)> {
-    let out = std::process::Command::new("fzf").arg("--version").output().ok()?;
-    let s = String::from_utf8_lossy(&out.stdout);
-    let mut parts = s.split_whitespace().next()?.split('.');
-    Some((parts.next()?.parse().ok()?, parts.next()?.parse().ok()?))
-}
-
-/// True when fzf is on PATH and `FUNES_NO_FZF` is unset (presence opts out, like `NO_COLOR`).
-fn use_fzf() -> bool {
-    std::env::var_os("FUNES_NO_FZF").is_none()
-        && std::env::var_os("PATH")
-            .map(|p| std::env::split_paths(&p).any(|d| d.join("fzf").is_file()))
-            .unwrap_or(false)
-}
-
 /// One parsed selection.
 enum Selection {
     Quit,
@@ -1091,17 +850,7 @@ fn prompt_new_store(label: &str, chunks: usize) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{fzf_style_args, parse_confirm, parse_selection, Selection};
-
-    #[test]
-    fn fzf_style_args_wear_the_accent_only_in_color() {
-        let colored = fzf_style_args(true, "recall ❯ ", "q · store\nhints");
-        assert!(colored.contains(&"--prompt=recall ❯ ".to_string()));
-        assert!(colored.contains(&"--header=q · store\nhints".to_string()));
-        assert!(colored.iter().any(|a| a.starts_with("--color=hl:6")));
-        let plain = fzf_style_args(false, "p", "h");
-        assert!(plain.contains(&"--color=bw".to_string()));
-    }
+    use super::{parse_confirm, parse_selection, Selection};
 
     #[test]
     fn parse_confirm_honors_default_and_answers() {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,0 +1,655 @@
+//! An in-process list+preview picker: a filterable list on the left, a live preview on the right,
+//! a query line at the bottom. It is generic over a [`PickerModel`] the caller implements, so a
+//! screen supplies its own rows, preview, and custom key handling without the engine knowing
+//! anything about the domain. Recall drives two models (a hit picker that drills into a turn
+//! browser); other commands can drive their own.
+//!
+//! The engine owns all *view* state — the live query, the ranked survivor list, the cursor and its
+//! scroll, the preview scroll. The model owns only *domain* state. That split is what lets a
+//! model's [`PickerModel::on_key`] take `&mut self` and mutate itself (and any caller state it
+//! holds) each keypress with no aliasing, and stay open across those mutations.
+
+pub mod browser;
+
+use std::io::{Stdout, Write};
+
+use anyhow::Result;
+use nucleo_matcher::pattern::{CaseMatching, Normalization, Pattern};
+use nucleo_matcher::{Config, Matcher, Utf32Str};
+use ratatui::backend::CrosstermBackend;
+use ratatui::crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use ratatui::crossterm::execute;
+use ratatui::crossterm::terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen};
+use ratatui::layout::{Constraint, Layout};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span, Text};
+use ratatui::widgets::{Block, Borders, HighlightSpacing, List, ListItem, ListState, Paragraph, Wrap};
+use ratatui::{Frame, Terminal};
+
+/// The concrete terminal the picker draws to.
+pub type Term = Terminal<CrosstermBackend<Stdout>>;
+
+const PAGE: i32 = 10;
+const PREVIEW_STEP: i32 = 8;
+const DEFAULT_PREVIEW_PCT: u16 = 60;
+
+/// A screen the picker can drive. The engine calls these; a consumer implements them.
+#[allow(clippy::len_without_is_empty)]
+pub trait PickerModel {
+    /// Number of items before filtering.
+    fn len(&self) -> usize;
+    /// The text nucleo scores the live query against for item `i` — usually hidden content richer
+    /// than the visible row (so a query matches beyond what the scent shows).
+    fn filter_key(&self, i: usize) -> &str;
+    /// The list row for item `i`, fully styled (glyph, dim, text). The engine adds the cursor
+    /// pointer and selection highlight itself.
+    fn row(&self, i: usize) -> Line<'static>;
+    /// The preview pane for item `i`.
+    fn preview(&self, i: usize) -> Text<'static>;
+    /// The top line: context and key hints. Given the live query in case it wants to echo it.
+    fn header(&self, query: &str) -> Line<'static>;
+    /// A trailing hint shown dim on the query line.
+    fn hints(&self) -> String {
+        String::new()
+    }
+    /// Keys the engine did not consume (everything but query editing and list/preview navigation):
+    /// Enter, Esc, ←/→, Ctrl-y, … `sel` is the model index under the cursor (None on an empty
+    /// list). The returned [`Flow`] decides what happens next.
+    fn on_key(&mut self, key: KeyEvent, sel: Option<usize>, ctx: &mut Ctx) -> Flow;
+}
+
+/// What a model's [`PickerModel::on_key`] tells the engine to do next.
+pub enum Flow {
+    /// Stay open; redraw (the model may have mutated itself).
+    Continue,
+    /// Return `Accept(i)` from [`run`] — a select-one result for the caller.
+    Accept(usize),
+    /// Pop this screen: `run` returns `Back` to its caller (an outer picker, or the top).
+    Back,
+    /// Tear the whole picker down; propagates up through nested [`Ctx::drill`] calls.
+    Quit,
+}
+
+/// Handed to [`PickerModel::on_key`] so a model can drill into a nested screen, copy to the
+/// clipboard, or flash a transient frame — without ever touching engine view state.
+pub struct Ctx<'t> {
+    term: &'t mut Term,
+    clipboard: Option<&'static str>,
+}
+
+impl Ctx<'_> {
+    /// Run a nested picker on the same terminal (a drill-down). Returns when the nested model
+    /// yields `Back`/`Accept`/`Quit`; the caller should propagate a `Quit`.
+    pub fn drill<M: PickerModel>(&mut self, model: &mut M, opts: RunOpts) -> Result<Flow> {
+        run(&mut *self.term, model, opts, self.clipboard)
+    }
+
+    /// Copy `text` to the system clipboard via the discovered writer (pbcopy/wl-copy/xclip/xsel);
+    /// false when the box has none or the writer fails. Spawns the writer directly — no shell.
+    pub fn copy(&self, text: &str) -> bool {
+        let Some(pipe) = self.clipboard else { return false };
+        let mut parts = pipe.split_whitespace();
+        let Some(prog) = parts.next() else { return false };
+        let args: Vec<&str> = parts.collect();
+        match std::process::Command::new(prog)
+            .args(&args)
+            .stdin(std::process::Stdio::piped())
+            .spawn()
+        {
+            Ok(mut child) => {
+                if let Some(mut stdin) = child.stdin.take() {
+                    let _ = stdin.write_all(text.as_bytes());
+                }
+                child.wait().map(|s| s.success()).unwrap_or(false)
+            }
+            Err(_) => false,
+        }
+    }
+
+    /// Draw a one-off full-screen message (e.g. while a blocking load runs).
+    pub fn flash(&mut self, msg: &str) -> Result<()> {
+        self.term.draw(|f| {
+            f.render_widget(Paragraph::new(msg.to_string()).style(dim_style()), f.area());
+        })?;
+        Ok(())
+    }
+}
+
+/// Options for one [`run`] of a screen.
+pub struct RunOpts {
+    /// Initial cursor position (model index) — e.g. land on the hit's turn.
+    pub start: usize,
+    /// Initial query.
+    pub query: String,
+    /// Preview pane width, percent of the body.
+    pub preview_pct: u16,
+}
+
+impl Default for RunOpts {
+    fn default() -> Self {
+        Self {
+            start: 0,
+            query: String::new(),
+            preview_pct: DEFAULT_PREVIEW_PCT,
+        }
+    }
+}
+
+/// Enter raw mode + the alternate screen, run `model` to completion, and restore the terminal on
+/// the way out (including on panic).
+pub fn run_root<M: PickerModel>(model: &mut M, opts: RunOpts) -> Result<Flow> {
+    install_panic_hook();
+    let clipboard = clipboard_pipe();
+    let mut guard = TermGuard::enter()?;
+    run(&mut guard.term, model, opts, clipboard)
+}
+
+/// The engine loop over one screen. Consumes query editing and list/preview navigation itself;
+/// hands every other key to `model.on_key` and acts on the returned [`Flow`].
+pub fn run<M: PickerModel>(
+    term: &mut Term,
+    model: &mut M,
+    opts: RunOpts,
+    clipboard: Option<&'static str>,
+) -> Result<Flow> {
+    let mut view = View::new(model, &opts);
+    loop {
+        term.draw(|f| draw(f, &mut view, &*model))?;
+        let Event::Key(key) = event::read()? else {
+            continue; // resize/mouse/paste: just redraw
+        };
+        if key.kind != KeyEventKind::Press {
+            continue;
+        }
+        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+        let alt = key.modifiers.contains(KeyModifiers::ALT);
+        match key.code {
+            KeyCode::Char('c') if ctrl => return Ok(Flow::Quit),
+            KeyCode::Char('u') if ctrl => view.scroll_preview(-PREVIEW_STEP),
+            KeyCode::Char('d') if ctrl => view.scroll_preview(PREVIEW_STEP),
+            KeyCode::Char(c) if !ctrl && !alt => view.set_query_push(c, model),
+            KeyCode::Backspace => view.set_query_pop(model),
+            KeyCode::Up => view.move_cursor(-1),
+            KeyCode::Down => view.move_cursor(1),
+            KeyCode::PageUp => view.move_cursor(-PAGE),
+            KeyCode::PageDown => view.move_cursor(PAGE),
+            KeyCode::Home => view.move_cursor(i32::MIN),
+            KeyCode::End => view.move_cursor(i32::MAX),
+            _ => {
+                let sel = view.sel_model_idx();
+                let mut ctx = Ctx {
+                    term: &mut *term,
+                    clipboard,
+                };
+                match model.on_key(key, sel, &mut ctx) {
+                    Flow::Continue => {}
+                    other => return Ok(other),
+                }
+            }
+        }
+    }
+}
+
+/// Engine-owned view state for one screen.
+struct View {
+    query: String,
+    filtered: Vec<usize>, // model indices surviving the query, best-first
+    list: ListState,      // cursor (index into `filtered`) + scroll offset
+    preview_off: u16,
+    preview_pct: u16,
+    filter: Filter,
+}
+
+impl View {
+    fn new<M: PickerModel>(model: &M, opts: &RunOpts) -> Self {
+        let mut filter = Filter::new();
+        let filtered = rank(&mut filter, &opts.query, model);
+        let cursor = if opts.query.is_empty() {
+            opts.start.min(model.len().saturating_sub(1))
+        } else {
+            0
+        };
+        let mut list = ListState::default();
+        if !filtered.is_empty() {
+            list.select(Some(cursor.min(filtered.len() - 1)));
+        }
+        View {
+            query: opts.query.clone(),
+            filtered,
+            list,
+            preview_off: 0,
+            preview_pct: if opts.preview_pct == 0 {
+                DEFAULT_PREVIEW_PCT
+            } else {
+                opts.preview_pct
+            },
+            filter,
+        }
+    }
+
+    fn refilter<M: PickerModel>(&mut self, model: &M) {
+        self.filtered = rank(&mut self.filter, &self.query, model);
+        self.preview_off = 0;
+        self.list.select((!self.filtered.is_empty()).then_some(0));
+    }
+
+    fn set_query_push<M: PickerModel>(&mut self, c: char, model: &M) {
+        self.query.push(c);
+        self.refilter(model);
+    }
+
+    fn set_query_pop<M: PickerModel>(&mut self, model: &M) {
+        self.query.pop();
+        self.refilter(model);
+    }
+
+    fn move_cursor(&mut self, delta: i32) {
+        let n = self.filtered.len();
+        if n == 0 {
+            return;
+        }
+        let cur = self.list.selected().unwrap_or(0) as i32;
+        let next = cur.saturating_add(delta).clamp(0, n as i32 - 1) as usize;
+        if Some(next) != self.list.selected() {
+            self.preview_off = 0;
+        }
+        self.list.select(Some(next));
+    }
+
+    fn scroll_preview(&mut self, delta: i32) {
+        self.preview_off = (self.preview_off as i32 + delta).max(0) as u16;
+    }
+
+    fn sel_model_idx(&self) -> Option<usize> {
+        self.list.selected().and_then(|c| self.filtered.get(c).copied())
+    }
+}
+
+/// Rank a query over a model's filter keys into surviving model indices (best-first). An empty
+/// query passes every item in original order — the initial full list.
+fn rank<M: PickerModel>(filter: &mut Filter, query: &str, model: &M) -> Vec<usize> {
+    if query.is_empty() {
+        return (0..model.len()).collect();
+    }
+    filter.rank(query, (0..model.len()).map(|i| (i, model.filter_key(i))))
+}
+
+fn draw<M: PickerModel>(f: &mut Frame, view: &mut View, model: &M) {
+    let rows = Layout::vertical([Constraint::Length(1), Constraint::Min(1), Constraint::Length(1)]).split(f.area());
+    f.render_widget(Paragraph::new(model.header(&view.query)), rows[0]);
+
+    let body = Layout::horizontal([
+        Constraint::Percentage(100 - view.preview_pct),
+        Constraint::Percentage(view.preview_pct),
+    ])
+    .split(rows[1]);
+
+    let items: Vec<ListItem> = view.filtered.iter().map(|&i| ListItem::new(model.row(i))).collect();
+    let list = List::new(items)
+        .block(Block::default().borders(Borders::RIGHT))
+        .highlight_style(Style::default().add_modifier(Modifier::REVERSED | Modifier::BOLD))
+        .highlight_symbol("❯ ")
+        .highlight_spacing(HighlightSpacing::Always);
+    f.render_stateful_widget(list, body[0], &mut view.list);
+
+    let preview = view.sel_model_idx().map(|i| model.preview(i)).unwrap_or_default();
+    // Bound the scroll to the content so a short preview can't be scrolled off into empty space.
+    view.preview_off = view.preview_off.min(preview.lines.len().saturating_sub(1) as u16);
+    f.render_widget(
+        Paragraph::new(preview)
+            .wrap(Wrap { trim: false })
+            .scroll((view.preview_off, 0)),
+        body[1],
+    );
+
+    let meta = format!("  [{}/{}]  {}", view.filtered.len(), model.len(), model.hints());
+    let prompt = Line::from(vec![
+        Span::raw(format!("❯ {}", view.query)),
+        Span::styled(meta, dim_style()),
+    ]);
+    f.render_widget(Paragraph::new(prompt), rows[2]);
+    let cx = rows[2].x + 2 + view.query.chars().count() as u16;
+    f.set_cursor_position((cx.min(rows[2].x + rows[2].width.saturating_sub(1)), rows[2].y));
+}
+
+// --- terminal lifecycle ---
+
+/// RAII terminal: raw mode + alt screen on [`TermGuard::enter`], restored on `Drop` (survives a
+/// `?`-early-return and a panic unwind).
+struct TermGuard {
+    term: Term,
+}
+
+impl TermGuard {
+    fn enter() -> Result<Self> {
+        enable_raw_mode()?;
+        // Raw mode is now on but no guard owns the restore yet, so undo it by hand if entering the
+        // alt screen or building the terminal fails — otherwise an error here would leave the tty
+        // raw (the Drop restore and the panic hook only cover a live guard / an unwind).
+        let build = || -> Result<Term> {
+            execute!(std::io::stdout(), EnterAlternateScreen)?;
+            Ok(Terminal::new(CrosstermBackend::new(std::io::stdout()))?)
+        };
+        match build() {
+            Ok(term) => Ok(TermGuard { term }),
+            Err(e) => {
+                let _ = execute!(std::io::stdout(), LeaveAlternateScreen);
+                let _ = disable_raw_mode();
+                Err(e)
+            }
+        }
+    }
+}
+
+impl Drop for TermGuard {
+    fn drop(&mut self) {
+        let _ = disable_raw_mode();
+        let _ = execute!(self.term.backend_mut(), LeaveAlternateScreen);
+        let _ = self.term.show_cursor();
+    }
+}
+
+/// Restore the terminal before the default panic hook prints, so a panic mid-picker never leaves
+/// the tty in raw mode / the alternate screen.
+fn install_panic_hook() {
+    let prev = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let _ = disable_raw_mode();
+        let _ = execute!(std::io::stdout(), LeaveAlternateScreen);
+        prev(info);
+    }));
+}
+
+// --- nucleo filtering ---
+
+/// A reusable nucleo fuzzy matcher over bounded lists.
+struct Filter {
+    matcher: Matcher,
+    pattern: Pattern,
+    buf: Vec<char>,
+}
+
+impl Filter {
+    fn new() -> Self {
+        Filter {
+            matcher: Matcher::new(Config::DEFAULT),
+            pattern: Pattern::default(),
+            buf: Vec::new(),
+        }
+    }
+
+    /// Score `query` against each `(index, key)` and return the surviving indices, best score
+    /// first; ties keep the caller's order (the sort is stable).
+    fn rank<'a>(&mut self, query: &str, keys: impl Iterator<Item = (usize, &'a str)>) -> Vec<usize> {
+        self.pattern.reparse(query, CaseMatching::Smart, Normalization::Smart);
+        let (matcher, pattern, buf) = (&mut self.matcher, &self.pattern, &mut self.buf);
+        let mut scored: Vec<(usize, u32)> = keys
+            .filter_map(|(i, k)| pattern.score(Utf32Str::new(k, buf), matcher).map(|s| (i, s)))
+            .collect();
+        scored.sort_by_key(|&(_, score)| std::cmp::Reverse(score));
+        scored.into_iter().map(|(i, _)| i).collect()
+    }
+}
+
+// --- ANSI → ratatui ---
+
+fn dim_style() -> Style {
+    Style::default().add_modifier(Modifier::DIM)
+}
+
+fn sgr_style(dim: bool, reverse: bool) -> Style {
+    let mut s = Style::default();
+    if dim {
+        s = s.add_modifier(Modifier::DIM);
+    }
+    if reverse {
+        s = s.add_modifier(Modifier::REVERSED);
+    }
+    s
+}
+
+fn apply_sgr(params: &str, dim: &mut bool, reverse: &mut bool) {
+    if params.is_empty() {
+        // `ESC[m` is `ESC[0m`.
+        *dim = false;
+        *reverse = false;
+        return;
+    }
+    for p in params.split(';') {
+        match p.parse::<u16>() {
+            Ok(0) => {
+                *dim = false;
+                *reverse = false;
+            }
+            Ok(2) => *dim = true,
+            Ok(7) => *reverse = true,
+            Ok(22) => *dim = false,
+            Ok(27) => *reverse = false,
+            _ => {} // color/other SGR funes never emits — ignore, keep the text
+        }
+    }
+}
+
+/// Convert a string carrying render.rs's SGR escapes (only dim `2`, reverse `7`, and resets) into
+/// styled ratatui `Text`. Splits on newlines; unknown escapes are dropped, their text kept.
+pub fn ansi_to_text(s: &str) -> Text<'static> {
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    let mut spans: Vec<Span<'static>> = Vec::new();
+    let mut cur = String::new();
+    let (mut dim, mut reverse) = (false, false);
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '\x1b' if chars.peek() == Some(&'[') => {
+                chars.next(); // '['
+                let mut params = String::new();
+                for pc in chars.by_ref() {
+                    if pc == 'm' {
+                        break;
+                    }
+                    params.push(pc);
+                }
+                if !cur.is_empty() {
+                    spans.push(Span::styled(std::mem::take(&mut cur), sgr_style(dim, reverse)));
+                }
+                apply_sgr(&params, &mut dim, &mut reverse);
+            }
+            '\n' => {
+                if !cur.is_empty() {
+                    spans.push(Span::styled(std::mem::take(&mut cur), sgr_style(dim, reverse)));
+                }
+                lines.push(Line::from(std::mem::take(&mut spans)));
+            }
+            _ => cur.push(c),
+        }
+    }
+    if !cur.is_empty() {
+        spans.push(Span::styled(cur, sgr_style(dim, reverse)));
+    }
+    if !spans.is_empty() || lines.is_empty() {
+        lines.push(Line::from(spans));
+    }
+    Text::from(lines)
+}
+
+/// Single-line variant for list rows (one line each).
+pub fn ansi_line(s: &str) -> Line<'static> {
+    ansi_to_text(s).lines.into_iter().next().unwrap_or_default()
+}
+
+// --- shell / clipboard helpers (shared by the picker and the plain line selector) ---
+
+/// The `funes get` command a copy binding puts on the clipboard.
+pub fn copy_cmd(store_label: &str, session_id: &str, turn_uuid: &str) -> String {
+    format!("funes get {session_id} {turn_uuid} --store {}", sh_word(store_label))
+}
+
+/// `s` single-quoted for a shell command line.
+pub fn sh_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+/// `s` quoted only when a shell would mangle it bare — for commands shown to be copy-pasted, where
+/// quoting the common clean label is just noise.
+pub fn sh_word(s: &str) -> String {
+    let clean = |c: char| c.is_ascii_alphanumeric() || "/:.@_+=%,~-".contains(c);
+    if !s.is_empty() && s.chars().all(clean) {
+        s.to_string()
+    } else {
+        sh_quote(s)
+    }
+}
+
+/// The first clipboard writer on PATH, as a command string; None when the box has none.
+pub fn clipboard_pipe() -> Option<&'static str> {
+    const WRITERS: [(&str, &str); 4] = [
+        ("pbcopy", "pbcopy"),
+        ("wl-copy", "wl-copy"),
+        ("xclip", "xclip -selection clipboard"),
+        ("xsel", "xsel --input --clipboard"),
+    ];
+    let path = std::env::var_os("PATH")?;
+    WRITERS
+        .iter()
+        .find(|(bin, _)| std::env::split_paths(&path).any(|d| d.join(bin).is_file()))
+        .map(|(_, pipe)| *pipe)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::backend::TestBackend;
+
+    #[test]
+    fn ansi_converts_dim_and_reverse() {
+        let t = ansi_to_text("\x1b[2mmeta\x1b[0m tail");
+        let spans = &t.lines[0].spans;
+        assert_eq!(spans[0].content, "meta");
+        assert!(spans[0].style.add_modifier.contains(Modifier::DIM));
+        assert_eq!(spans[1].content, " tail");
+        assert!(!spans[1].style.add_modifier.contains(Modifier::DIM));
+
+        let r = ansi_line("a \x1b[7mhit\x1b[0m b");
+        assert!(r
+            .spans
+            .iter()
+            .any(|s| s.content == "hit" && s.style.add_modifier.contains(Modifier::REVERSED)));
+    }
+
+    #[test]
+    fn ansi_ignores_unknown_codes_keeps_text() {
+        // A 256-color SGR funes never emits: the code is dropped, the text survives unstyled.
+        let t = ansi_to_text("\x1b[38;5;6mcyan\x1b[0m");
+        let joined: String = t.lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(joined, "cyan");
+        assert!(t.lines[0].spans.iter().all(|s| s.style.add_modifier.is_empty()));
+    }
+
+    #[test]
+    fn ansi_splits_lines() {
+        let t = ansi_to_text("one\ntwo");
+        assert_eq!(t.lines.len(), 2);
+        assert_eq!(t.lines[0].spans[0].content, "one");
+        assert_eq!(t.lines[1].spans[0].content, "two");
+    }
+
+    #[test]
+    fn filter_empty_query_passes_all_in_order() {
+        let mut f = Filter::new();
+        let keys = ["alpha", "beta", "gamma"];
+        assert_eq!(f.rank("", keys.iter().copied().enumerate()), vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn filter_ranks_and_drops_non_matches() {
+        let mut f = Filter::new();
+        let keys = ["mask future keys", "top-k selection", "unrelated prose"];
+        let got = f.rank("mask", keys.iter().copied().enumerate());
+        assert_eq!(got, vec![0]);
+        // A query that matches nothing yields nothing.
+        assert!(f.rank("zzzzz", keys.iter().copied().enumerate()).is_empty());
+    }
+
+    #[test]
+    fn copy_cmd_quotes_awkward_labels() {
+        assert_eq!(copy_cmd("local", "sid", "tid"), "funes get sid tid --store local");
+        assert_eq!(
+            copy_cmd("hf://datasets/acme/kb", "s", "t"),
+            "funes get s t --store hf://datasets/acme/kb"
+        );
+        // A label with a space gets quoted.
+        assert_eq!(sh_word("a b"), "'a b'");
+    }
+
+    /// A minimal model for exercising the render path with `TestBackend`.
+    struct Mock {
+        rows: Vec<String>,
+    }
+    impl PickerModel for Mock {
+        fn len(&self) -> usize {
+            self.rows.len()
+        }
+        fn filter_key(&self, i: usize) -> &str {
+            &self.rows[i]
+        }
+        fn row(&self, i: usize) -> Line<'static> {
+            ansi_line(&self.rows[i])
+        }
+        fn preview(&self, i: usize) -> Text<'static> {
+            Text::raw(format!("preview of {}", self.rows[i]))
+        }
+        fn header(&self, _q: &str) -> Line<'static> {
+            Line::raw("HEADER")
+        }
+        fn on_key(&mut self, _k: KeyEvent, _s: Option<usize>, _c: &mut Ctx) -> Flow {
+            Flow::Continue
+        }
+    }
+
+    fn buf_text(term: &Terminal<TestBackend>) -> String {
+        term.backend().buffer().content.iter().map(|c| c.symbol()).collect()
+    }
+
+    #[test]
+    fn draws_header_rows_preview_and_prompt() {
+        let model = Mock {
+            rows: vec!["first row".into(), "second row".into()],
+        };
+        let mut term = Terminal::new(TestBackend::new(80, 12)).unwrap();
+        let mut view = View::new(&model, &RunOpts::default());
+        term.draw(|f| draw(f, &mut view, &model)).unwrap();
+        let text = buf_text(&term);
+        assert!(text.contains("HEADER"), "header missing: {text}");
+        assert!(text.contains("first row"), "row missing: {text}");
+        assert!(text.contains("preview of first row"), "preview missing: {text}");
+        assert!(text.contains("[2/2]"), "count missing: {text}");
+        assert!(text.contains('❯'), "pointer/prompt missing: {text}");
+    }
+
+    #[test]
+    fn typing_filters_the_list() {
+        let model = Mock {
+            rows: vec!["mask future keys".into(), "top-k selection".into()],
+        };
+        let mut view = View::new(&model, &RunOpts::default());
+        view.set_query_push('m', &model);
+        view.set_query_push('a', &model);
+        view.set_query_push('s', &model);
+        view.set_query_push('k', &model);
+        assert_eq!(view.filtered, vec![0]);
+        assert_eq!(view.sel_model_idx(), Some(0));
+    }
+
+    #[test]
+    fn initial_selection_lands_on_start() {
+        let model = Mock {
+            rows: (0..5).map(|i| format!("row {i}")).collect(),
+        };
+        let opts = RunOpts {
+            start: 3,
+            ..Default::default()
+        };
+        let view = View::new(&model, &opts);
+        assert_eq!(view.sel_model_idx(), Some(3));
+    }
+}

--- a/src/tui/browser.rs
+++ b/src/tui/browser.rs
@@ -1,0 +1,423 @@
+//! Recall's picker screens over the generic [`crate::tui`] engine: a hit picker whose Enter drills
+//! into a per-session turn browser, and Esc backs out. Both reuse [`crate::render`]'s human layout
+//! (the tested single source of truth) via the ANSI→ratatui converter — no span reimplementation.
+
+use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span, Text};
+use tokio::runtime::Handle;
+
+use crate::recall::{self, Hit, Turn};
+use crate::tui::{ansi_line, ansi_to_text, copy_cmd, run_root, Ctx, Flow, PickerModel, RunOpts};
+use crate::{hub, render};
+
+/// The interactive recall browser: a fuzzy-filterable list of hits with a live preview, Enter to
+/// browse a hit's session, Ctrl-y to copy its `get` command, Esc to quit. Runs on the caller's
+/// thread (a plain OS thread, not a runtime worker) so `rt.block_on` can load a session on drill.
+pub fn run(
+    store: hub::Store,
+    note: String,
+    query: String,
+    hits: &[(Hit, f64)],
+    color: bool,
+    width: usize,
+    rt: Handle,
+) -> anyhow::Result<()> {
+    // The list opens unfiltered in recall order — the recall query is shown in the header for
+    // context, NOT seeded as the live filter (that would fuzzy-AND every word against each chunk
+    // and hide the semantically-ranked hits until the user cleared it).
+    let mut picker = HitPicker::new(store, note, query, hits, color, width, rt);
+    run_root(&mut picker, RunOpts::default())?; // Back and Quit both mean "done browsing"
+    Ok(())
+}
+
+fn dim() -> Style {
+    Style::default().add_modifier(Modifier::DIM)
+}
+
+/// True when a clipboard writer is present — tailors the key hints.
+fn can_copy() -> bool {
+    crate::tui::clipboard_pipe().is_some()
+}
+
+struct HitPicker<'a> {
+    store: hub::Store,
+    label: String,
+    note: String,
+    query: String, // the recall query, shown in the header for context (not the live filter)
+    hits: &'a [(Hit, f64)],
+    rows: Vec<String>,  // render::recall_rows — one ANSI row per hit
+    blobs: Vec<String>, // whitespace-collapsed matched chunk: the search surface and the preview
+    color: bool,
+    width: usize,
+    copy: bool,
+    rt: Handle,
+}
+
+impl<'a> HitPicker<'a> {
+    fn new(
+        store: hub::Store,
+        note: String,
+        query: String,
+        hits: &'a [(Hit, f64)],
+        color: bool,
+        width: usize,
+        rt: Handle,
+    ) -> Self {
+        let rows = render::recall_rows(hits, color, width, chrono::Utc::now());
+        let blobs = hits
+            .iter()
+            .map(|(h, _)| {
+                h.text
+                    .split_whitespace()
+                    .collect::<Vec<_>>()
+                    .join(" ")
+                    .chars()
+                    .take(2000)
+                    .collect()
+            })
+            .collect();
+        HitPicker {
+            label: store.label(),
+            store,
+            note,
+            query,
+            hits,
+            rows,
+            blobs,
+            color,
+            width,
+            copy: can_copy(),
+            rt,
+        }
+    }
+}
+
+impl PickerModel for HitPicker<'_> {
+    fn len(&self) -> usize {
+        self.hits.len()
+    }
+
+    fn filter_key(&self, i: usize) -> &str {
+        &self.blobs[i]
+    }
+
+    fn row(&self, i: usize) -> Line<'static> {
+        ansi_line(&self.rows[i])
+    }
+
+    fn preview(&self, i: usize) -> Text<'static> {
+        // The matched chunk verbatim — the turn browser behind Enter owns the surrounding context.
+        ansi_to_text(&self.blobs[i])
+    }
+
+    fn header(&self, _query: &str) -> Line<'static> {
+        // `_query` is the live filter (the engine echoes it on the prompt line); the header shows
+        // the recall query so the user keeps sight of what these hits answer.
+        let mut spans = Vec::new();
+        let note = self.note.trim();
+        if !note.is_empty() {
+            spans.push(Span::styled(format!("{note}  "), dim()));
+        }
+        spans.push(Span::raw(format!("recall  {}", self.query)));
+        spans.push(Span::styled(format!("  ·  {}", self.label), dim()));
+        Line::from(spans)
+    }
+
+    fn hints(&self) -> String {
+        if self.copy {
+            "enter browses · ctrl-y copies · esc quits".into()
+        } else {
+            "enter browses · esc quits".into()
+        }
+    }
+
+    fn on_key(&mut self, key: KeyEvent, sel: Option<usize>, ctx: &mut Ctx) -> Flow {
+        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+        match key.code {
+            KeyCode::Enter => {
+                let Some(i) = sel else { return Flow::Continue };
+                let h = &self.hits[i].0;
+                let _ = ctx.flash("loading session…");
+                match self.rt.block_on(recall::get_turns(
+                    self.store.clone(),
+                    h.session_id.clone(),
+                    h.turn_uuid.clone(),
+                    i64::MAX,
+                )) {
+                    Ok((note, turns)) if !turns.is_empty() => {
+                        // Mark the matched chunk so it stands out of the surrounding turns.
+                        let mark: String = h.text.split_whitespace().collect::<Vec<_>>().join(" ");
+                        let mut browser = TurnBrowser::new(
+                            self.label.clone(),
+                            note,
+                            h.session_id.clone(),
+                            turns,
+                            h.turn_uuid.clone(),
+                            Some(mark),
+                            self.color,
+                            self.width,
+                            self.copy,
+                        );
+                        let start = browser.center;
+                        let opts = RunOpts {
+                            start,
+                            ..Default::default()
+                        };
+                        match ctx.drill(&mut browser, opts) {
+                            Ok(Flow::Quit) => Flow::Quit,
+                            _ => Flow::Continue, // Back (or a transient error) returns to the picker
+                        }
+                    }
+                    _ => Flow::Continue,
+                }
+            }
+            KeyCode::Char('y') if ctrl => {
+                if let Some(i) = sel {
+                    let h = &self.hits[i].0;
+                    ctx.copy(&copy_cmd(&self.label, &h.session_id, &h.turn_uuid));
+                }
+                Flow::Continue
+            }
+            KeyCode::Esc => Flow::Quit,
+            _ => Flow::Continue,
+        }
+    }
+}
+
+/// The turn browser behind Enter: the session's turns oldest-first, the recall hit's turn marked
+/// `▶` and landed on, the selected turn shown whole in the preview with the matched chunk
+/// reverse-videoed. Esc walks back to the hit picker.
+struct TurnBrowser {
+    label: String,
+    note: String,
+    session_id: String,
+    turns: Vec<Turn>,
+    rows: Vec<String>, // render::turn_rows — one ANSI row per turn (display)
+    keys: Vec<String>, // the same rows without SGR — the fuzzy-search surface
+    center: usize,     // index of the hit's turn (landing position + `▶` marker)
+    mark: Option<String>,
+    color: bool,
+    width: usize,
+    copy: bool,
+}
+
+impl TurnBrowser {
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        label: String,
+        note: String,
+        session_id: String,
+        turns: Vec<Turn>,
+        center_uuid: String,
+        mark: Option<String>,
+        color: bool,
+        width: usize,
+        copy: bool,
+    ) -> Self {
+        let rows = render::turn_rows(&turns, color, width);
+        // Search over the plain text (color=false emits no SGR), not the ANSI-laden display rows.
+        let keys = render::turn_rows(&turns, false, width);
+        let center = turns.iter().position(|t| t.turn_uuid == center_uuid).unwrap_or(0);
+        TurnBrowser {
+            label,
+            note,
+            session_id,
+            turns,
+            rows,
+            keys,
+            center,
+            mark,
+            color,
+            width,
+            copy,
+        }
+    }
+}
+
+impl PickerModel for TurnBrowser {
+    fn len(&self) -> usize {
+        self.turns.len()
+    }
+
+    fn filter_key(&self, i: usize) -> &str {
+        &self.keys[i]
+    }
+
+    fn row(&self, i: usize) -> Line<'static> {
+        let glyph = if i == self.center { "▶ " } else { "  " };
+        let mut line = ansi_line(&self.rows[i]);
+        line.spans.insert(0, Span::raw(glyph));
+        line
+    }
+
+    fn preview(&self, i: usize) -> Text<'static> {
+        let body = render::get_human(
+            "",
+            std::slice::from_ref(&self.turns[i]),
+            self.color,
+            self.width,
+            self.mark.as_deref(),
+        );
+        ansi_to_text(&body)
+    }
+
+    fn header(&self, _query: &str) -> Line<'static> {
+        let s8 = &self.session_id[..self.session_id.len().min(8)];
+        let mut spans = Vec::new();
+        let note = self.note.trim();
+        if !note.is_empty() {
+            spans.push(Span::styled(format!("{note}  "), dim()));
+        }
+        spans.push(Span::raw(format!("session {s8}")));
+        spans.push(Span::styled(format!("  ·  {}", self.label), dim()));
+        Line::from(spans)
+    }
+
+    fn hints(&self) -> String {
+        if self.copy {
+            "ctrl-y copies · esc goes back".into()
+        } else {
+            "esc goes back".into()
+        }
+    }
+
+    fn on_key(&mut self, key: KeyEvent, sel: Option<usize>, ctx: &mut Ctx) -> Flow {
+        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+        match key.code {
+            KeyCode::Esc => Flow::Back,
+            KeyCode::Char('y') if ctrl => {
+                if let Some(i) = sel {
+                    ctx.copy(&copy_cmd(&self.label, &self.session_id, &self.turns[i].turn_uuid));
+                }
+                Flow::Continue
+            }
+            _ => Flow::Continue,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A handle only to construct the models; the pure methods under test never touch it.
+    fn handle() -> Handle {
+        tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap()
+            .handle()
+            .clone()
+    }
+
+    fn hit(text: &str, sid: &str, tid: &str) -> Hit {
+        Hit {
+            text: text.into(),
+            session_id: sid.into(),
+            workdir: "-home-u-funes".into(),
+            turn_uuid: tid.into(),
+            seq: 1,
+            ts: "2026-06-19T01:29:59.000Z".into(),
+            block_type: "text".into(),
+            harness: "claude_code".into(),
+            neighbors: vec![],
+        }
+    }
+
+    fn turn(uuid: &str, role: &str, ts: &str, block: &str) -> Turn {
+        Turn {
+            seq: 1,
+            turn_uuid: uuid.into(),
+            ts: ts.into(),
+            role: role.into(),
+            blocks: vec![block.into()],
+        }
+    }
+
+    fn line_text(line: &Line<'static>) -> String {
+        line.spans.iter().map(|s| s.content.as_ref()).collect()
+    }
+
+    fn text_body(text: &Text<'static>) -> String {
+        text.lines
+            .iter()
+            .flat_map(|l| l.spans.iter())
+            .map(|s| s.content.as_ref())
+            .collect()
+    }
+
+    #[test]
+    fn hit_picker_searches_the_collapsed_chunk_and_names_the_store() {
+        let hits = vec![(hit("mask   future\n keys before top-k", "s1", "t1"), 0.9)];
+        let p = HitPicker::new(
+            hub::Store::local(),
+            String::new(),
+            "sparse attention".into(),
+            &hits,
+            false,
+            100,
+            handle(),
+        );
+        assert_eq!(p.len(), 1);
+        // The search surface is the whitespace-collapsed chunk, not the visible scent.
+        assert_eq!(p.filter_key(0), "mask future keys before top-k");
+        // The preview leads with that same chunk.
+        assert!(text_body(&p.preview(0)).contains("mask future keys"));
+        // The header shows the recall query and the store (the engine echoes the live filter
+        // separately, on the prompt line).
+        let header = line_text(&p.header(""));
+        assert!(header.contains("sparse attention"), "got {header:?}");
+        assert!(header.contains(&hub::Store::local().label()), "got {header:?}");
+    }
+
+    #[test]
+    fn turn_browser_marks_and_lands_on_the_hit_turn() {
+        let turns = vec![
+            turn("a", "user", "2026-06-19T01:29:00.000Z", "the question"),
+            turn("b", "assistant", "2026-06-19T01:30:00.000Z", "the answer we want"),
+        ];
+        let b = TurnBrowser::new(
+            "local".into(),
+            String::new(),
+            "0123456789abcdef".into(),
+            turns,
+            "b".into(),
+            Some("the answer we want".into()),
+            false,
+            100,
+            false,
+        );
+        // Lands on the hit's turn.
+        assert_eq!(b.center, 1);
+        // The hit turn is glyphed `▶`; the others are indented to align.
+        assert!(line_text(&b.row(1)).starts_with("▶ "));
+        assert!(line_text(&b.row(0)).starts_with("  "));
+        // The preview renders the selected turn's body.
+        assert!(text_body(&b.preview(1)).contains("the answer we want"));
+        // The header carries the 8-char session prefix.
+        assert!(line_text(&b.header("")).contains("01234567"));
+    }
+
+    #[test]
+    fn turn_browser_search_key_is_ansi_free() {
+        let turns = vec![turn("a", "assistant", "2026-06-19T01:29:00.000Z", "compute the mask")];
+        // Color on → the display rows carry SGR; the fuzzy-search key must not.
+        let b = TurnBrowser::new(
+            "local".into(),
+            String::new(),
+            "sid".into(),
+            turns,
+            "a".into(),
+            None,
+            true,
+            100,
+            false,
+        );
+        assert!(
+            !b.filter_key(0).contains('\u{1b}'),
+            "search key carries ANSI: {:?}",
+            b.filter_key(0)
+        );
+        assert!(b.filter_key(0).contains("compute the mask"));
+    }
+}


### PR DESCRIPTION
Reimplement the fzf-like behaviour of the interactive terminal user-inferface using ratatui and nucleo.