### PR TITLE
Progressive indexing for faster and leaner indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,14 @@ To build it yourself instead, see [Building from source](#building-from-source).
 **1. Index — one store for every agent on the machine.**
 
 ```bash
-funes index      # sweeps ~/.claude/projects, ~/.codex/sessions, ~/.pi/agent/sessions into one store
+funes index      # a fast, text-first pass over ~/.claude/projects, ~/.codex/sessions, ~/.pi/agent/sessions
 ```
 
-Run with no arguments and `funes` indexes every supported agent's sessions it finds, into one store.
-It's incremental — only new turns are embedded — so it's cheap to re-run as you work — a store runs ~2.3 KB/chunk and grows ~6 MB on a heavy day ([storage growth](docs/storage.md)). Point it at a
-path to index one place, or scope to a single agent with `--harness codex`.
+Run with no arguments and `funes` does a fast, text-first pass over every supported agent's sessions
+it finds, into one store, offering to finish the rest. It's incremental — only new turns are embedded
+— so re-running (and the per-turn hooks) fill in the deeper content a bounded step at a time — a store
+runs ~2.3 KB/chunk and grows ~6 MB on a heavy day ([storage growth](docs/storage.md)). Point it at a
+path to index one place in full, or scope to a single agent with `--harness codex`.
 
 `funes` can index sessions from: Claude, Codex, Pi
 
@@ -79,8 +81,9 @@ funes add claude acme/kb         # …backed by a shared store you own (sync acr
 ```
 
 Your agent gets `recall` and `get` as tools, plus instructions on when to use them. For **Claude
-and Codex**, `funes add` also wires the automation: it builds your first index if you skipped step 1,
-installs a hook that indexes every turn, and — when you name a shared store — publishes at each
+and Codex**, `funes add` also wires the automation: it builds your first index — a fast, text-first
+pass (about a minute, after asking), with deeper content backfilling as you work — installs a hook
+that indexes every turn, and — when you name a shared store — publishes at each
 session boundary (and does the first push for you). Nothing is left to run by hand; see
 [docs/automation.md](docs/automation.md).
 

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -11,7 +11,8 @@ it behaves; you rarely need to touch any of it by hand.
 
 - **Per-turn indexing.** A `Stop` hook runs `funes index` after every turn, so your local store
   tracks the session as it grows — a session killed mid-flight is already indexed up to its last
-  completed turn.
+  completed turn. Each run is time-boxed (text first, ~60s), so a large backlog fills in a bounded
+  step per turn instead of one long sweep.
 - **Publishing at session boundaries.** Bind a shared store — `funes add claude <org>/<repo>` — and
   `SessionStart`/`SessionEnd` hooks run `funes push` to publish there. Without a store, indexing is
   local-only and nothing is published.
@@ -19,8 +20,10 @@ it behaves; you rarely need to touch any of it by hand.
 It also performs the one-time bootstrap the hooks are forbidden to do unattended, so nothing is left
 to run by hand after it:
 
-- **Builds your first index** (from that agent's sessions) if you don't have one yet. A first build
-  can take a while, so the hooks never trigger it — `funes add` does, interactively.
+- **Builds your first index** (from that agent's sessions) if you don't have one yet — a fast,
+  text-first pass that gets recall working in about a minute, after asking. Deeper content and older
+  sessions backfill on later turns. The hooks never trigger a first index; `funes add` does, once you
+  accept.
 - **Does the first push** to a freshly-bound store. The push hook can't: a first publish to a store
   your local store shares no chunks with is refused off a terminal (the wrong-store guard, below),
   so it must be interactive — `funes add` handles it.

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -17,13 +17,13 @@ it behaves; you rarely need to touch any of it by hand.
   `SessionStart`/`SessionEnd` hooks run `funes push` to publish there. Without a store, indexing is
   local-only and nothing is published.
 
-It also performs the one-time bootstrap the hooks are forbidden to do unattended, so nothing is left
-to run by hand after it:
+It also performs the one-time bootstrap steps, so nothing is left to run by hand after it:
 
 - **Builds your first index** (from that agent's sessions) if you don't have one yet — a fast,
   text-first pass that gets recall working in about a minute, after asking. Deeper content and older
-  sessions backfill on later turns. The hooks never trigger a first index; `funes add` does, once you
-  accept.
+  sessions backfill on later turns. The hooks alone would also fill a cold store, one bounded step
+  per turn; `funes add` builds the most valuable part upfront so recall works from your first
+  session.
 - **Does the first push** to a freshly-bound store. The push hook can't: a first publish to a store
   your local store shares no chunks with is refused off a terminal (the wrong-store guard, below),
   so it must be interactive — `funes add` handles it.

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -3,6 +3,7 @@
 
 use crate::trace::Turn;
 use arrow_array::{Array, Int64Array, RecordBatch, StringArray};
+use serde::{Deserialize, Serialize};
 use sha1::{Digest, Sha1};
 use std::collections::HashMap;
 
@@ -14,7 +15,7 @@ pub const OVERLAP: usize = 150;
 /// Indexing tiers, cheapest-and-highest-value first: L1 `text` (onboarding), L2 `tool_use`, L3
 /// `tool_result` (bulky, lowest value). A block's tier decides *when* it's indexed. `thinking` and
 /// any unknown block type fold into L1 so nothing is ever dropped by tiering.
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Serialize, Deserialize)]
 pub enum Tier {
     Text,
     ToolUse,

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -256,16 +256,20 @@ pub(crate) fn resplit(template: &Chunk, text: &str) -> Vec<Chunk> {
         .collect()
 }
 
+/// Whether a pass over `tiers` (with `include_thinking`) indexes a block of this type: its tier is
+/// requested and it isn't a dropped thinking block. Shared with redaction, so the blocks scanned for
+/// secrets are exactly the blocks stored.
+pub fn block_selected(block_type: &str, tiers: &[Tier], include_thinking: bool) -> bool {
+    tiers.contains(&Tier::of_block(block_type)) && (block_type != "thinking" || include_thinking)
+}
+
 pub fn chunks_from_turns(turns: &[Turn], tiers: &[Tier], include_thinking: bool) -> Vec<Chunk> {
     let mut out = Vec::new();
     for turn in turns {
         for (bi, block) in turn.blocks.iter().enumerate() {
             // block_idx counts every block, so skipping one here (tier or thinking) never
             // renumbers the rest.
-            if !tiers.contains(&Tier::of_block(&block.block_type)) {
-                continue;
-            }
-            if block.block_type == "thinking" && !include_thinking {
+            if !block_selected(&block.block_type, tiers, include_thinking) {
                 continue;
             }
             let rendered = render(&block.block_type, &block.text, &block.tool_name);

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -34,6 +34,15 @@ impl Tier {
             _ => Tier::Text,
         }
     }
+
+    /// Human label for progress output.
+    pub fn label(self) -> &'static str {
+        match self {
+            Tier::Text => "text",
+            Tier::ToolUse => "tool_use",
+            Tier::ToolResult => "tool_result",
+        }
+    }
 }
 
 #[derive(Clone)]

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -11,6 +11,30 @@ const MAX_CHARS: usize = 1200;
 /// (`recall::stitch`) never needs to match a longer overlap than this.
 pub const OVERLAP: usize = 150;
 
+/// Indexing tiers, cheapest-and-highest-value first: L1 `text` (onboarding), L2 `tool_use`, L3
+/// `tool_result` (bulky, lowest value). A block's tier decides *when* it's indexed. `thinking` and
+/// any unknown block type fold into L1 so nothing is ever dropped by tiering.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub enum Tier {
+    Text,
+    ToolUse,
+    ToolResult,
+}
+
+impl Tier {
+    /// Every tier, in index order — the block-type set a full index emits.
+    pub const ALL: [Tier; 3] = [Tier::Text, Tier::ToolUse, Tier::ToolResult];
+
+    /// The tier a block type belongs to; unknown types fold into L1.
+    pub fn of_block(block_type: &str) -> Tier {
+        match block_type {
+            "tool_use" => Tier::ToolUse,
+            "tool_result" => Tier::ToolResult,
+            _ => Tier::Text,
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct Chunk {
     pub id: String,
@@ -231,11 +255,15 @@ pub(crate) fn resplit(template: &Chunk, text: &str) -> Vec<Chunk> {
         .collect()
 }
 
-pub fn chunks_from_turns(turns: &[Turn], include_thinking: bool) -> Vec<Chunk> {
+pub fn chunks_from_turns(turns: &[Turn], tiers: &[Tier], include_thinking: bool) -> Vec<Chunk> {
     let mut out = Vec::new();
     for turn in turns {
         for (bi, block) in turn.blocks.iter().enumerate() {
-            // block_idx counts every block; dropping a thinking block does not renumber it.
+            // block_idx counts every block, so skipping one here (tier or thinking) never
+            // renumbers the rest.
+            if !tiers.contains(&Tier::of_block(&block.block_type)) {
+                continue;
+            }
             if block.block_type == "thinking" && !include_thinking {
                 continue;
             }
@@ -394,7 +422,7 @@ mod tests {
         // would produce for that text — so a scrub's delete-by-id + append stays coordinate-stable.
         let long: String = (0..600).map(|i| format!("word{i} ")).collect();
         let t = turn(vec![block("text", &long, None)]);
-        let fresh = chunks_from_turns(std::slice::from_ref(&t), true);
+        let fresh = chunks_from_turns(std::slice::from_ref(&t), &Tier::ALL, true);
         let template = fresh[0].clone();
         let rendered = render("text", &long, &None);
         let re = resplit(&template, &rendered);
@@ -415,13 +443,71 @@ mod tests {
             block("thinking", "secret", None),
             block("text", "third", None),
         ]);
-        let with = chunks_from_turns(std::slice::from_ref(&t), true);
+        let with = chunks_from_turns(std::slice::from_ref(&t), &Tier::ALL, true);
         assert_eq!(with.len(), 3);
         assert_eq!(with.iter().map(|c| c.block_idx).collect::<Vec<_>>(), vec![0, 1, 2]);
 
-        let without = chunks_from_turns(std::slice::from_ref(&t), false);
+        let without = chunks_from_turns(std::slice::from_ref(&t), &Tier::ALL, false);
         assert_eq!(without.len(), 2);
         assert_eq!(without.iter().map(|c| c.block_idx).collect::<Vec<_>>(), vec![0, 2]);
         assert!(without.iter().all(|c| c.block_type != "thinking"));
+    }
+
+    #[test]
+    fn tier_of_block_maps_and_orders() {
+        assert_eq!(Tier::of_block("text"), Tier::Text);
+        assert_eq!(Tier::of_block("thinking"), Tier::Text);
+        assert_eq!(Tier::of_block("tool_use"), Tier::ToolUse);
+        assert_eq!(Tier::of_block("tool_result"), Tier::ToolResult);
+        assert_eq!(Tier::of_block("mystery"), Tier::Text); // unknown folds into L1, never dropped
+        assert!(Tier::Text < Tier::ToolUse && Tier::ToolUse < Tier::ToolResult);
+    }
+
+    #[test]
+    fn tiers_filter_selects_only_requested_block_types() {
+        let t = turn(vec![
+            block("text", "decision", None),
+            block("tool_use", r#"{"cmd":1}"#, Some("Bash")),
+            block("tool_result", "output", Some("Bash")),
+        ]);
+        let kinds = |cs: &[Chunk]| cs.iter().map(|c| c.block_type.clone()).collect::<Vec<_>>();
+        assert_eq!(
+            kinds(&chunks_from_turns(std::slice::from_ref(&t), &[Tier::Text], true)),
+            vec!["text"]
+        );
+        assert_eq!(
+            kinds(&chunks_from_turns(std::slice::from_ref(&t), &[Tier::ToolUse], true)),
+            vec!["tool_use"]
+        );
+        assert_eq!(
+            kinds(&chunks_from_turns(std::slice::from_ref(&t), &[Tier::ToolResult], true)),
+            vec!["tool_result"]
+        );
+        assert_eq!(
+            kinds(&chunks_from_turns(std::slice::from_ref(&t), &Tier::ALL, true)),
+            vec!["text", "tool_use", "tool_result"]
+        );
+    }
+
+    #[test]
+    fn chunk_ids_are_tier_pass_independent() {
+        // The core invariant behind tier backfill: a block's id/coordinate is the same whether a
+        // pass emits every tier or only that block's tier — so a later L3 pass dedups exactly
+        // against what a full index would have written, with no gaps or renumbering.
+        let t = turn(vec![
+            block("text", "decision", None),
+            block("tool_use", r#"{"cmd":1}"#, Some("Bash")),
+            block("tool_result", "output", Some("Bash")),
+        ]);
+        let all = chunks_from_turns(std::slice::from_ref(&t), &Tier::ALL, true);
+        let only_result = chunks_from_turns(std::slice::from_ref(&t), &[Tier::ToolResult], true);
+        let from_all: Vec<&Chunk> = all.iter().filter(|c| c.block_type == "tool_result").collect();
+        assert_eq!(only_result.len(), from_all.len());
+        assert!(!only_result.is_empty());
+        for (a, b) in only_result.iter().zip(from_all) {
+            assert_eq!(a.id, b.id, "tool_result id must match across tier passes");
+            assert_eq!(a.block_idx, b.block_idx);
+            assert_eq!(a.split_idx, b.split_idx);
+        }
     }
 }

--- a/src/curate.rs
+++ b/src/curate.rs
@@ -19,7 +19,7 @@
 //! already shipped — the remote is append-only; curation prevents, it does not undo.
 
 use crate::hub::{self, Store};
-use crate::{dataset, hf_dataset, index};
+use crate::{dataset, hf_dataset, index, jsonl};
 use anyhow::{bail, Context, Result};
 use arrow_array::{Int64Array, RecordBatch, RecordBatchIterator, StringArray};
 use arrow_schema::Schema;
@@ -299,18 +299,12 @@ pub(crate) async fn ids_by_session(ds: &Dataset) -> Result<HashMap<String, Vec<S
     Ok(by_session)
 }
 
-/// A Claude Code sub-agent session: Claude writes each to its own `agent-<hash>.jsonl`, and funes
-/// keys sessions by transcript file stem.
-pub fn is_subagent(session_id: &str) -> bool {
-    session_id.starts_with("agent-")
-}
-
 /// The local sessions curation may offer — [`ids_by_session`] minus sub-agents. Project memories
 /// and the review both draw from this; a personal memory's `all_ids` push is unaffected (it keeps
 /// everything).
 pub(crate) async fn candidate_sessions(local: &Dataset) -> Result<HashMap<String, Vec<String>>> {
     let mut by_session = ids_by_session(local).await?;
-    by_session.retain(|session, _| !is_subagent(session));
+    by_session.retain(|session, _| !jsonl::is_subagent(session));
     Ok(by_session)
 }
 
@@ -1074,15 +1068,5 @@ exclude ddd # later";
             HashSet::from(["mine".to_string(), "fork".to_string()]),
             "only sessions whose repo names the project are scoped in — others aren't its pending"
         );
-    }
-
-    #[test]
-    fn is_subagent_matches_the_agent_prefix() {
-        assert!(is_subagent("agent-a90670a3067db59ca"));
-        assert!(
-            !is_subagent("72e856b6-9214-47ed-ab2d-0a1905093f45"),
-            "a uuid is a top-level session"
-        );
-        assert!(!is_subagent("agentic-refactor"), "the prefix is `agent-`, not `agent`");
     }
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -205,60 +205,207 @@ fn unit_current(entry: Option<&UnitState>, sig: &str, target: Tier) -> bool {
     entry.is_some_and(|e| e.sig == sig && e.level >= target)
 }
 
-/// The run-wide indexing state: the local store uri, the dataset (created on the first write), the
-/// embedder, and the optional redaction scanner. Bundling it lets each unit be indexed by a method
-/// instead of threading the same handles through every call.
-struct Indexer<'a> {
-    uri: &'a str,
+/// A set-up indexer: it holds the store lock, embedder, dataset, redaction scanner, and incremental
+/// state, so a caller can index units in whatever batches it likes — one at a time to check the
+/// clock between them, or all at once — without reloading the model. Build the indexes once at the
+/// end with [`Indexer::finalize`].
+struct Indexer {
+    uri: String,
     ds: Option<Dataset>,
+    /// [`stored_ids`] at open plus everything appended this run — the dedup baseline for new chunks.
+    existing: HashSet<String>,
     embedder: Box<dyn Embedder>,
-    scanner: Option<&'a dyn scan::SecretScanner>,
+    scanner: Option<scan::Trufflehog>,
     include_thinking: bool,
     /// cwd → resolved `repo` value, so each distinct checkout runs `git` once across the run.
     repo_cache: HashMap<String, String>,
+    state: HashMap<String, UnitState>,
+    state_path: PathBuf,
+    /// The store didn't exist when this run opened it — the first index.
+    first_index: bool,
+    _lock: lock::StoreLock,
+    /// The sources and their units, enumerated once at open so the change-stamps are a stable
+    /// snapshot; a caller drives them by index via [`Indexer::index_unit`].
+    sources: Vec<Box<dyn source::TraceSource>>,
+    units: Vec<(usize, source::Unit)>,
+    n_sessions: u64,
+    n_skipped: u64,
+    n_chunks: u64,
 }
 
-impl Indexer<'_> {
-    /// Index one unit's turns: redact, chunk, keep only chunks whose id isn't already stored, and
-    /// embed those in a single append. Returns `(sessions read, new chunks added)`. `key` names the
-    /// unit in logs (and is the label when the unit has no sessions).
+impl Indexer {
+    /// Acquire the store lock, open (or plan to create) the dataset, load incremental state, bring
+    /// up the embedder and secret scanner, and enumerate `sources`' units.
+    async fn open(sources: Vec<Box<dyn source::TraceSource>>, no_thinking: bool) -> Result<Indexer> {
+        let dir = dataset::funes_dir();
+        std::fs::create_dir_all(&dir)?;
+        // Held for the whole run so the stored-id read and the appends see one stable version.
+        let _lock = lock::StoreLock::acquire()?;
+
+        let uri = dataset::table_uri(&dataset::local_store_dir());
+        let ds = dataset::open(&uri, HashMap::new()).await.ok();
+
+        // Model-pin: refuse to add to a store built with a different embedding model. The id rides
+        // in the dataset's schema metadata; a pre-metadata store (no id) is tolerated and guarded
+        // only by the dimension check until it is reindexed.
+        if let Some(ds) = &ds {
+            let schema = arrow_schema::Schema::from(ds.schema());
+            if let Some(em) = schema.metadata().get("embedding_model") {
+                if em != MODEL {
+                    return Err(anyhow!("index built with model {em:?}, refusing to mix with {MODEL:?}"));
+                }
+            }
+        }
+
+        let first_index = ds.is_none();
+
+        // Incremental state: path -> {size:mtime stamp, tier}; an unreadable or old-schema file → empty.
+        let state_path = dir.join("state.json");
+        let state = std::fs::read_to_string(&state_path)
+            .ok()
+            .and_then(|s| serde_json::from_str(&s).ok())
+            .unwrap_or_default();
+
+        let embedder: Box<dyn Embedder> = inference::embedder()?;
+        // Best-effort secret redaction: if the scanner isn't installed, indexing continues
+        // unredacted — the push gate still scans, fail-closed, before any upload, so a secret can't
+        // reach the Hub.
+        let scanner = match scan::Trufflehog::find() {
+            Ok(s) => Some(s),
+            Err(e) => {
+                eprintln!("note: secret redaction disabled — {e}");
+                None
+            }
+        };
+
+        let existing = match &ds {
+            Some(d) => stored_ids(d).await?,
+            None => HashSet::new(),
+        };
+
+        // Each source orders its own units (recency-desc, subagents last); tag each with its source.
+        let mut units = Vec::new();
+        for (i, src) in sources.iter().enumerate() {
+            for unit in src.units()? {
+                units.push((i, unit));
+            }
+        }
+
+        Ok(Indexer {
+            uri,
+            ds,
+            existing,
+            embedder,
+            scanner,
+            include_thinking: !no_thinking,
+            repo_cache: HashMap::new(),
+            state,
+            state_path,
+            first_index,
+            _lock,
+            sources,
+            units,
+            n_sessions: 0,
+            n_skipped: 0,
+            n_chunks: 0,
+        })
+    }
+
+    /// Number of units this run will consider.
+    fn unit_count(&self) -> usize {
+        self.units.len()
+    }
+
+    /// Index unit `i` at `tiers` — the one primitive a caller loops over, choosing the tiers and
+    /// when to stop. Skips a unit already indexed to the top of `tiers`; a signature-less (bulk)
+    /// unit is never skipped — it is re-read every run, and its chunk-id dedup makes that a no-op.
+    /// Otherwise reads the unit, redacts, chunks those tiers, keeps only chunks whose id isn't
+    /// already stored, embeds them in a single append, and stamps the unit's state. Returns the
+    /// new-chunk count (0 when skipped, unreadable, or already indexed).
+    ///
+    /// `progress` is the caller's label for the per-unit output line — the caller owns the counter
+    /// because only it knows its iteration order and count.
     ///
     /// Add-only-new: a grown session is the same memory — embed and add only its new turns, never
     /// re-embedding or deleting what's unchanged. (A rewritten turn lands under new ids.) A unit's
-    /// turns are written in one append, so a bulk source (many sessions in one unit) stays a
-    /// single Lance fragment rather than one per session.
-    async fn index_unit(&mut self, progress: &str, key: &str, mut turns: Vec<trace::Turn>) -> Result<(u64, u64)> {
-        let (sessions, label) = unit_summary(&turns, key);
+    /// turns are written in one append, so a bulk source (many sessions in one unit) stays a single
+    /// Lance fragment rather than one per session.
+    async fn index_unit(&mut self, i: usize, tiers: &[Tier], progress: &str) -> Result<u64> {
+        let target = *tiers.iter().max().expect("a pass covers at least one tier");
+        let (src_i, key, sig) = {
+            let (si, unit) = &self.units[i];
+            (*si, unit.key.clone(), unit.signature.clone())
+        };
 
-        if let Some(scanner) = self.scanner {
-            redact_turns(&mut turns, scanner, &chunk::Tier::ALL, self.include_thinking)?;
+        if let Some(sig) = &sig {
+            if unit_current(self.state.get(&key), sig, target) {
+                self.n_skipped += 1;
+                return Ok(0);
+            }
         }
-        let mut chunks = chunk::chunks_from_turns(&turns, &chunk::Tier::ALL, self.include_thinking);
-        let repo = self.repo_for(key);
+
+        // Best-effort sources retry a failed read next run (no state recorded); a fatal source
+        // aborts rather than silently dropping data.
+        let mut turns = {
+            let src = &self.sources[src_i];
+            match src.read(&self.units[i].1) {
+                Ok(t) => t,
+                Err(e) if !src.fatal_on_read_error() => {
+                    eprintln!("{progress} {key} — read failed, skipping: {e}");
+                    return Ok(0);
+                }
+                Err(e) => return Err(e),
+            }
+        };
+
+        let (sessions, label) = unit_summary(&turns, &key);
+        let first_time = !self.state.contains_key(&key);
+        if let Some(scanner) = &self.scanner {
+            redact_turns(&mut turns, scanner, tiers, self.include_thinking)?;
+        }
+        let mut chunks = chunk::chunks_from_turns(&turns, tiers, self.include_thinking);
+        let repo = self.repo_for(&key);
         if !repo.is_empty() {
             for c in &mut chunks {
                 c.repo.clone_from(&repo);
             }
         }
         let total_chunks = chunks.len();
-        if total_chunks == 0 {
+        let added = if total_chunks == 0 {
             eprintln!("{progress} {label} — no indexable content");
-            return Ok((sessions, 0));
-        }
-
-        let existing = match &self.ds {
-            Some(d) => stored_ids(d).await?,
-            None => HashSet::new(),
+            0
+        } else {
+            let new_chunks: Vec<chunk::Chunk> = chunks.into_iter().filter(|c| !self.existing.contains(&c.id)).collect();
+            if new_chunks.is_empty() {
+                eprintln!("{progress} {label} — {total_chunks} chunks, all already indexed");
+                0
+            } else {
+                eprintln!("{progress} {label} — {} new of {total_chunks} chunks", new_chunks.len());
+                let n = self.embed_and_write(&new_chunks).await?;
+                self.existing.extend(new_chunks.into_iter().map(|c| c.id));
+                n
+            }
         };
-        let new_chunks: Vec<chunk::Chunk> = chunks.into_iter().filter(|c| !existing.contains(&c.id)).collect();
-        if new_chunks.is_empty() {
-            eprintln!("{progress} {label} — {total_chunks} chunks, all already indexed");
-            return Ok((sessions, 0));
-        }
 
-        eprintln!("{progress} {label} — {} new of {total_chunks} chunks", new_chunks.len());
-        let added = self.embed_and_write(&new_chunks).await?;
-        Ok((sessions, added))
+        // Record state only for signed units, even when they produced no chunks ("remembered when
+        // empty"), and persist after each so an interrupted run is resumable.
+        if let Some(sig) = &sig {
+            self.state.insert(
+                key.clone(),
+                UnitState {
+                    sig: sig.clone(),
+                    level: target,
+                },
+            );
+            std::fs::write(&self.state_path, serde_json::to_string_pretty(&self.state)?)?;
+        }
+        // Count a unit's sessions once — the first time it's indexed; later tier passes only add
+        // chunks to sessions already counted.
+        if first_time {
+            self.n_sessions += sessions;
+        }
+        self.n_chunks += added;
+        Ok(added)
     }
 
     /// The session's repo(s) for the unit at `key`, resolved from its transcript's cwd and cached
@@ -292,16 +439,42 @@ impl Indexer<'_> {
 
         let batch = build_batch(new_chunks, &vectors)?;
         let reader = RecordBatchIterator::new(vec![Ok(batch)], schema());
-        let uri = self.uri;
+        let uri = self.uri.clone();
         match &mut self.ds {
             Some(d) => {
                 d.append(reader, None).await?;
             }
             None => {
-                self.ds = Some(Dataset::write(reader, uri, Some(WriteParams::default())).await?);
+                self.ds = Some(Dataset::write(reader, &uri, Some(WriteParams::default())).await?);
             }
         }
         Ok(n as u64)
+    }
+
+    /// Build the FTS + IVF_PQ indexes (best-effort), reap superseded versions, and print the run
+    /// summary. Consumes the indexer, releasing the store lock. The vector index bounds how much a
+    /// query reads — what makes recall over a remote (hf://) tier lazy rather than a full scan; lance
+    /// enforces its own training minimum (256 rows) and skips below it, falling back to brute force.
+    async fn finalize(mut self) -> Result<()> {
+        if let Some(d) = &mut self.ds {
+            dataset::build_indexes(d, |phase| eprintln!("building {phase}…")).await;
+
+            // Reap superseded versions — best-effort; on failure the reap waits for next run.
+            match d.cleanup_old_versions(chrono::Duration::minutes(10), None, None).await {
+                Ok(stats) if stats.bytes_removed > 0 => eprintln!(
+                    "reclaimed {:.1} MB from {} old version(s)",
+                    stats.bytes_removed as f64 / 1e6,
+                    stats.old_versions
+                ),
+                Ok(_) => {}
+                Err(e) => eprintln!("note: version cleanup skipped — {e}"),
+            }
+        }
+        println!(
+            "indexed sessions={} skipped={} chunks={}",
+            self.n_sessions, self.n_skipped, self.n_chunks
+        );
+        Ok(())
     }
 }
 
@@ -333,179 +506,73 @@ pub async fn run_index_remote(uri: &str, no_thinking: bool) -> Result<()> {
     index_sources(vec![src], no_thinking, true).await
 }
 
-/// Index a set of already-opened sources into the local store, sharing one embedder, `state.json`,
-/// and dataset handle across them (state keyed by absolute path / `hf://…` shard, so incremental
-/// works cross-source). The wrappers above open the sources; this drives the
-/// units→skip→read→embed→write loop and builds the indexes once.
+/// Index a set of already-opened sources fully — every tier of every unit, one read each — sharing
+/// one embedder, `state.json`, and dataset handle across them (state keyed by absolute path /
+/// `hf://…` shard, so incremental works cross-source). On a first interactive index it estimates
+/// the run after the first session and asks before the long haul.
 async fn index_sources(sources: Vec<Box<dyn source::TraceSource>>, no_thinking: bool, yes: bool) -> Result<()> {
-    let include_thinking = !no_thinking;
-    let dir = dataset::funes_dir();
-    std::fs::create_dir_all(&dir)?;
-
-    // Held for the whole run so the stored-id read and the appends below see one stable version.
-    let _lock = lock::StoreLock::acquire()?;
-
-    let uri = dataset::table_uri(&dataset::local_store_dir());
-    let ds = dataset::open(&uri, HashMap::new()).await.ok();
-
-    // Model-pin: refuse to add to a store built with a different embedding model. The id rides
-    // in the dataset's schema metadata; a pre-metadata store (no id) is tolerated and guarded only
-    // by the dimension check until it is reindexed.
-    if let Some(ds) = &ds {
-        let schema = arrow_schema::Schema::from(ds.schema());
-        if let Some(em) = schema.metadata().get("embedding_model") {
-            if em != MODEL {
-                return Err(anyhow!("index built with model {em:?}, refusing to mix with {MODEL:?}"));
-            }
-        }
-    }
-
-    let first_index = ds.is_none();
     let interactive = std::io::stdin().is_terminal();
 
     // A first index can take a long time; never let an automated run (no TTY — a hook, cron) trigger
     // it. Fail closed like push's new-store guard: require a manual `funes index` first, or --yes to
     // force. Exit 0 so a session-end hook isn't treated as failed.
-    if first_index && !yes && !interactive {
-        eprintln!(
-            "funes: no index yet — run `funes index` in a terminal first to build the initial index \
-             (one-time; it can take a while), or pass --yes to force it here. Skipping."
-        );
-        return Ok(());
+    if !yes && !interactive {
+        let uri = dataset::table_uri(&dataset::local_store_dir());
+        if dataset::open(&uri, HashMap::new()).await.is_err() {
+            eprintln!(
+                "funes: no index yet — run `funes index` in a terminal first to build the initial index \
+                 (one-time; it can take a while), or pass --yes to force it here. Skipping."
+            );
+            return Ok(());
+        }
     }
 
-    // Incremental state: path -> {size:mtime stamp, tier}; an unreadable or old-schema file → empty.
-    let state_path = dir.join("state.json");
-    let mut state: HashMap<String, UnitState> = std::fs::read_to_string(&state_path)
-        .ok()
-        .and_then(|s| serde_json::from_str(&s).ok())
-        .unwrap_or_default();
-    // This run indexes every tier, so a unit counts as current only once it has reached the highest.
+    let mut indexer = Indexer::open(sources, no_thinking).await?;
+    let total = indexer.unit_count();
+
+    // Per-source tally. This run indexes every tier, so a unit counts as cached only once it has
+    // reached the highest.
     let target = *Tier::ALL.iter().max().expect("Tier::ALL is non-empty");
-
-    let embedder: Box<dyn Embedder> = inference::embedder()?;
-    // Best-effort secret redaction: if the scanner isn't installed, indexing continues unredacted —
-    // the push gate still scans, fail-closed, before any upload, so a secret can't reach the Hub.
-    let scanner = match scan::Trufflehog::find() {
-        Ok(s) => Some(s),
-        Err(e) => {
-            eprintln!("note: secret redaction disabled — {e}");
-            None
+    for (si, src) in indexer.sources.iter().enumerate() {
+        let units = indexer.units.iter().filter(|(i, _)| *i == si);
+        let (mut n, mut cached) = (0usize, 0usize);
+        for (_, u) in units {
+            n += 1;
+            if u.signature
+                .as_ref()
+                .is_some_and(|s| unit_current(indexer.state.get(&u.key), s, target))
+            {
+                cached += 1;
+            }
         }
-    };
-    let scanner = scanner.as_ref().map(|s| s as &dyn scan::SecretScanner);
+        eprintln!("{} — {} to index, {cached} cached", src.describe(), n - cached);
+    }
 
-    let mut indexer = Indexer {
-        uri: &uri,
-        ds,
-        embedder,
-        scanner,
-        include_thinking,
-        repo_cache: HashMap::new(),
-    };
     // First interactive index: after the first session lands, estimate the whole run from its time
     // and — if it looks long — ask whether to continue or bail and re-run with --limit.
-    let mut probe_pending = first_index && !yes && interactive;
-    // Only that estimate needs the grand total up front (a cheap stat-only pass); an incremental run
-    // skips it and enumerates each source lazily in the loop, holding nothing for the whole run.
-    let total_units: usize = if probe_pending {
-        sources.iter().map(|s| s.units().map(|u| u.len()).unwrap_or(0)).sum()
-    } else {
-        0
-    };
+    let mut probe_pending = indexer.first_index && !yes && interactive;
 
-    let (mut n_sessions, mut n_skipped, mut n_chunks) = (0u64, 0u64, 0u64);
-    'sources: for src in &sources {
-        let units = src.units()?;
-        let total = units.len();
-        let cached = units
-            .iter()
-            .filter(|u| {
-                u.signature
-                    .as_ref()
-                    .is_some_and(|s| unit_current(state.get(&u.key), s, target))
-            })
-            .count();
-        eprintln!("{} — {} to index, {cached} cached", src.describe(), total - cached);
+    for i in 0..total {
+        // Time from before the read so a first-index estimate covers parse + I/O, not just embedding.
+        let t_unit = Instant::now();
+        let progress = format!("[{}/{}]", i + 1, total);
+        let added = indexer.index_unit(i, &Tier::ALL, &progress).await?;
 
-        for (idx, unit) in units.iter().enumerate() {
-            // Skip a unit only if it carries a signature that still matches what's recorded; a
-            // signature-less (bulk) unit has none, so it's never skipped here — always re-read (its
-            // chunk-id dedup makes a re-run a no-op).
-            if let Some(sig) = &unit.signature {
-                if unit_current(state.get(&unit.key), sig, target) {
-                    n_skipped += 1;
-                    continue;
-                }
-            }
-            let progress = format!("[{}/{}]", idx + 1, total);
-            // Time from before the read so a first-index estimate covers parse + I/O, not just embedding.
-            let t_unit = Instant::now();
-            let turns = match src.read(unit) {
-                Ok(t) => t,
-                // Best-effort sources retry a failed read next run (no state recorded); a fatal
-                // source aborts rather than silently dropping data.
-                Err(e) if !src.fatal_on_read_error() => {
-                    eprintln!("{progress} {} — read failed, skipping: {e}", unit.key);
-                    continue;
-                }
-                Err(e) => return Err(e),
-            };
-            let (sessions, added) = indexer.index_unit(&progress, &unit.key, turns).await?;
-            n_sessions += sessions;
-            n_chunks += added;
-
-            // Record state only for signed units, even when they produced no chunks ("remembered
-            // when empty"), and persist after each so an interrupted run is resumable.
-            // Signature-less (bulk) units are never recorded: a re-run re-reads and dedups to a no-op.
-            if let Some(sig) = &unit.signature {
-                state.insert(
-                    unit.key.clone(),
-                    UnitState {
-                        sig: sig.clone(),
-                        level: target,
-                    },
+        // Estimate off the first session that actually embedded, and ask before a long haul.
+        if probe_pending && added > 0 {
+            probe_pending = false;
+            let est = t_unit.elapsed().mul_f64(total as f64);
+            if est >= Duration::from_secs(FIRST_INDEX_PROMPT_SECS) && !confirm_full_index(total, est) {
+                eprintln!(
+                    "stopped after 1 session (kept — the index is resumable). Re-run \
+                     `funes index --limit M` for the most recent M, or `funes index` to do all."
                 );
-                std::fs::write(&state_path, serde_json::to_string_pretty(&state)?)?;
-            }
-
-            // Estimate off the first session that actually embedded, and ask before a long haul.
-            if probe_pending && added > 0 {
-                probe_pending = false;
-                let est = t_unit.elapsed().mul_f64(total_units as f64);
-                if est >= Duration::from_secs(FIRST_INDEX_PROMPT_SECS) && !confirm_full_index(total_units, est) {
-                    eprintln!(
-                        "stopped after 1 session (kept — the index is resumable). Re-run \
-                         `funes index --limit M` for the most recent M, or `funes index` to do all."
-                    );
-                    break 'sources;
-                }
+                break;
             }
         }
     }
 
-    // Build the FTS + IVF_PQ indexes (best-effort). The vector index bounds how much a query reads,
-    // which is what makes recall over a remote (hf://) tier lazy instead of a full-column scan; lance
-    // enforces its own training minimum (256 rows for default IVF_PQ) and skips below it, so recall
-    // falls back to brute-force vector search.
-    if let Some(d) = &mut indexer.ds {
-        dataset::build_indexes(d, |phase| eprintln!("building {phase}…")).await;
-
-        // Reap superseded versions — best-effort; on failure the reap waits for next run.
-        match d.cleanup_old_versions(chrono::Duration::minutes(10), None, None).await {
-            Ok(stats) if stats.bytes_removed > 0 => eprintln!(
-                "reclaimed {:.1} MB from {} old version(s)",
-                stats.bytes_removed as f64 / 1e6,
-                stats.old_versions
-            ),
-            Ok(_) => {}
-            Err(e) => eprintln!("note: version cleanup skipped — {e}"),
-        }
-    }
-
-    println!("indexed sessions={n_sessions} skipped={n_skipped} chunks={n_chunks}");
-
-    Ok(())
+    indexer.finalize().await
 }
 
 /// Build/update the local index from a single source root, auto-detecting its harness — a thin

--- a/src/index.rs
+++ b/src/index.rs
@@ -223,6 +223,9 @@ struct Indexer {
     state_path: PathBuf,
     /// The store didn't exist when this run opened it — the first index.
     first_index: bool,
+    /// A human is watching (stdin is a terminal) — probed once here, so every prompt-or-proceed
+    /// choice in a run agrees.
+    interactive: bool,
     _lock: lock::StoreLock,
     /// The sources and their units, enumerated once at open so the change-stamps are a stable
     /// snapshot; a caller drives them by index via [`Indexer::index_unit`].
@@ -302,6 +305,7 @@ impl Indexer {
             state,
             state_path,
             first_index,
+            interactive: std::io::stdin().is_terminal(),
             _lock,
             sources,
             units,
@@ -316,6 +320,21 @@ impl Indexer {
         self.units.len()
     }
 
+    /// Units still owing work at `tier` — a pure state + signature check, no session read, so a
+    /// caller can plan and estimate a run before touching anything. A signature-less (bulk) unit
+    /// always counts as pending, as [`Indexer::index_unit`] never skips it.
+    fn pending(&self, tier: Tier) -> Vec<usize> {
+        (0..self.units.len())
+            .filter(|&i| {
+                let unit = &self.units[i].1;
+                match &unit.signature {
+                    Some(sig) => !unit_current(self.state.get(&unit.key), sig, tier),
+                    None => true,
+                }
+            })
+            .collect()
+    }
+
     /// Index unit `i` at `tiers` — the one primitive a caller loops over, choosing the tiers and
     /// when to stop. Skips a unit already indexed to the top of `tiers`; a signature-less (bulk)
     /// unit is never skipped — it is re-read every run, and its chunk-id dedup makes that a no-op.
@@ -323,8 +342,8 @@ impl Indexer {
     /// already stored, embeds them in a single append, and stamps the unit's state. Returns the
     /// new-chunk count (0 when skipped, unreadable, or already indexed).
     ///
-    /// `progress` is the caller's label for the per-unit output line — the caller owns the counter
-    /// because only it knows its iteration order and count.
+    /// `progress` is the caller's label for the per-unit output line (e.g. `"text [1/3]"`) — the
+    /// caller owns the counter because only it knows the iteration (which tier, how many owed).
     ///
     /// Add-only-new: a grown session is the same memory — embed and add only its new turns, never
     /// re-embedding or deleting what's unchanged. (A rewritten turn lands under new ids.) A unit's
@@ -506,6 +525,98 @@ pub async fn run_index_remote(uri: &str, no_thinking: bool) -> Result<()> {
     index_sources(vec![src], no_thinking, true).await
 }
 
+/// The wall-clock budget a budgeted run gives itself: it stops at the first whole-session boundary
+/// past this. Deeper tiers and older sessions backfill on later runs.
+const INDEX_BUDGET_SECS: u64 = 60;
+
+/// What a budgeted run does when the budget expires with passes still owed.
+#[derive(Clone, Copy)]
+enum Finish {
+    /// Offer to finish the rest now (interactive only; otherwise stop at the session boundary —
+    /// later runs catch up).
+    Ask,
+    /// Finish everything without asking (`--yes`).
+    All,
+}
+
+/// Build/update the local index from harness session roots, budgeted and tier-major: text across
+/// every session first, then tool_use, then tool_result, stopping at the first whole-session
+/// boundary past the budget. The no-path `funes index` — the per-turn hook advances the backfill
+/// one bounded step per run; an interactive run offers to finish the rest; `yes` finishes it
+/// without asking.
+pub async fn run_index_budgeted(
+    roots: &[(PathBuf, Option<Harness>)],
+    no_thinking: bool,
+    max_sessions: Option<usize>,
+    yes: bool,
+) -> Result<()> {
+    let sources = roots
+        .iter()
+        .map(|(path, harness)| source::open_with_harness(path, max_sessions, *harness))
+        .collect();
+    let finish = if yes { Finish::All } else { Finish::Ask };
+    run_budgeted(sources, no_thinking, &Tier::ALL, finish).await
+}
+
+/// Drive `sources` tier-major — every owed unit at `tiers[0]`, then `tiers[1]`, … — checking the
+/// budget after each whole-session pass; `finish` says what to do when it expires with work left.
+/// The owed passes are computed upfront from state alone (no reading), so the plan and the ETA
+/// reflect what this run actually owes.
+async fn run_budgeted(
+    sources: Vec<Box<dyn source::TraceSource>>,
+    no_thinking: bool,
+    tiers: &[Tier],
+    finish: Finish,
+) -> Result<()> {
+    let mut idx = Indexer::open(sources, no_thinking).await?;
+
+    let owed: Vec<(Tier, Vec<usize>)> = tiers
+        .iter()
+        .map(|&t| (t, idx.pending(t)))
+        .filter(|(_, units)| !units.is_empty())
+        .collect();
+    if owed.is_empty() {
+        return idx.finalize().await;
+    }
+    let report = owed
+        .iter()
+        .map(|(t, u)| format!("{}: {}", t.label(), u.len()))
+        .collect::<Vec<_>>()
+        .join(", ");
+    eprintln!("to index — {report}");
+
+    let start = Instant::now();
+    let budget = Duration::from_secs(INDEX_BUDGET_SECS);
+    let passes: usize = owed.iter().map(|(_, u)| u.len()).sum();
+    let mut done = 0usize;
+    let mut capped = true;
+    'tiers: for (tier, units) in &owed {
+        for (j, &i) in units.iter().enumerate() {
+            let progress = format!("{} [{}/{}]", tier.label(), j + 1, units.len());
+            idx.index_unit(i, &[*tier], &progress).await?;
+            done += 1;
+            if capped && start.elapsed() >= budget {
+                let go_on = match finish {
+                    Finish::All => true,
+                    Finish::Ask if idx.interactive => {
+                        confirm_continue(estimate_remaining(start.elapsed(), done, passes))
+                    }
+                    _ => false,
+                };
+                if !go_on {
+                    eprintln!(
+                        "{} pass(es) left — per-turn indexing (or a `funes index` rerun) picks them up",
+                        passes - done
+                    );
+                    break 'tiers;
+                }
+                capped = false; // finish the rest now
+            }
+        }
+    }
+    idx.finalize().await
+}
+
 /// Index a set of already-opened sources fully — every tier of every unit, one read each — sharing
 /// one embedder, `state.json`, and dataset handle across them (state keyed by absolute path /
 /// `hf://…` shard, so incremental works cross-source). On a first interactive index it estimates
@@ -585,20 +696,54 @@ pub async fn run_index(path: &Path, no_thinking: bool, max_sessions: Option<usiz
 /// A first interactive index estimated at ≥ this many seconds prompts before continuing.
 const FIRST_INDEX_PROMPT_SECS: u64 = 120;
 
+/// Ask `prompt` on stderr and read one stdin line. Enter takes the default; anything but `y`/`yes`
+/// is a no, and EOF or a read error declines — never start long work off a wedged stdin.
+fn confirm(prompt: &str, default_yes: bool) -> bool {
+    eprint!("{prompt} ");
+    let _ = std::io::stderr().flush();
+    let mut answer = String::new();
+    match std::io::stdin().read_line(&mut answer) {
+        Ok(n) if n > 0 => match answer.trim().to_ascii_lowercase().as_str() {
+            "" => default_yes,
+            "y" | "yes" => true,
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
 /// Prompt before a long first index (interactive only): continue all, or bail and re-run with a
 /// `--limit`. Returns whether to proceed.
 fn confirm_full_index(total: usize, est: Duration) -> bool {
-    eprint!(
-        "indexing all {total} sessions is estimated at ~{} (rough, from one session). Continue? [y/N]  \
-         (or re-run with `--limit M` for the most recent M) ",
-        fmt_eta(est)
-    );
-    let _ = std::io::stderr().flush();
-    let mut answer = String::new();
-    if std::io::stdin().read_line(&mut answer).is_err() {
-        return false;
+    confirm(
+        &format!(
+            "indexing all {total} sessions is estimated at ~{} (rough, from one session). Continue? [y/N]  \
+             (or re-run with `--limit M` for the most recent M)",
+            fmt_eta(est)
+        ),
+        false,
+    )
+}
+
+/// After a budgeted pass leaves work unfinished, ask whether to finish the rest now; default yes.
+/// `remaining` is a rough estimate of the time left.
+fn confirm_continue(remaining: Duration) -> bool {
+    confirm(
+        &format!(
+            "more to index (~{} left, rough). Finish it now? [Y/n]  (or let per-turn indexing catch up)",
+            fmt_eta(remaining)
+        ),
+        true,
+    )
+}
+
+/// Extrapolate the time left from the average cost of the passes done so far — cached and cheap
+/// passes count, so the estimate tracks the run's real mix rather than its slowest pass.
+fn estimate_remaining(elapsed: Duration, processed: usize, total: usize) -> Duration {
+    if processed == 0 || processed >= total {
+        return Duration::ZERO;
     }
-    matches!(answer.trim().to_ascii_lowercase().as_str(), "y" | "yes")
+    elapsed / processed as u32 * (total - processed) as u32
 }
 
 /// Rough human ETA: "45s", "12 min", "2.3 h".
@@ -639,6 +784,18 @@ mod tests {
         assert!(unit_current(Some(&full), "10:20", Tier::ToolResult));
         // No record → not current.
         assert!(!unit_current(None, "10:20", Tier::Text));
+    }
+
+    #[test]
+    fn estimate_remaining_extrapolates_average_pass_cost() {
+        // 10 of 40 passes done in 20s → 2s/pass, 30 left → 60s.
+        assert_eq!(
+            estimate_remaining(Duration::from_secs(20), 10, 40),
+            Duration::from_secs(60)
+        );
+        // Nothing processed yet, or already done → no estimate.
+        assert_eq!(estimate_remaining(Duration::from_secs(5), 0, 40), Duration::ZERO);
+        assert_eq!(estimate_remaining(Duration::from_secs(5), 40, 40), Duration::ZERO);
     }
 
     #[test]

--- a/src/index.rs
+++ b/src/index.rs
@@ -532,8 +532,9 @@ const INDEX_BUDGET_SECS: u64 = 60;
 /// What a budgeted run does when the budget expires with passes still owed.
 #[derive(Clone, Copy)]
 enum Finish {
-    /// Offer to finish the rest now (interactive only; otherwise stop at the session boundary —
-    /// later runs catch up).
+    /// Stop at the session boundary — later runs catch up.
+    Stop,
+    /// Offer to finish the rest now (interactive only; otherwise stop).
     Ask,
     /// Finish everything without asking (`--yes`).
     All,
@@ -556,6 +557,15 @@ pub async fn run_index_budgeted(
         .collect();
     let finish = if yes { Finish::All } else { Finish::Ask };
     run_budgeted(sources, no_thinking, &Tier::ALL, finish).await
+}
+
+/// The `funes add` first index: `root`'s sessions, text tier only, newest first, one whole session
+/// at a time, stopping at the first boundary past the budget — recall works in about a minute.
+/// Deeper tiers and older sessions backfill on later (budgeted) runs. Never prompts: the caller
+/// already asked, and the per-turn drip owns the rest.
+pub async fn run_index_seed(root: &Path, harness: Harness) -> Result<()> {
+    let sources = vec![source::open_with_harness(root, None, Some(harness))];
+    run_budgeted(sources, false, &[Tier::Text], Finish::Stop).await
 }
 
 /// Drive `sources` tier-major — every owed unit at `tiers[0]`, then `tiers[1]`, … — checking the

--- a/src/index.rs
+++ b/src/index.rs
@@ -612,31 +612,26 @@ pub async fn run_index_budgeted(
         .map(|(path, harness)| source::open_with_harness(path, max_sessions, *harness))
         .collect();
     let finish = if yes { Finish::All } else { Finish::Ask };
-    run_budgeted(sources, no_thinking, &Tier::ALL, finish).await
+    run_budgeted(sources, no_thinking, finish).await
 }
 
-/// The `funes add` first index: `root`'s sessions, text tier only, newest first, one whole session
-/// at a time, stopping at the first boundary past the budget — recall works in about a minute.
-/// Deeper tiers and older sessions backfill on later (budgeted) runs. Never prompts: the caller
-/// already asked, and the per-turn drip owns the rest.
+/// The `funes add` first index: the budgeted drain with no finish prompt — the add flow already
+/// asked, and the per-turn drip owns whatever the budget defers. Tier-major order spends the
+/// budget on text (decisions, rationale) first, so recall works in about a minute; a small history
+/// simply finishes whole.
 pub async fn run_index_seed(root: &Path, harness: Harness) -> Result<()> {
     let sources = vec![source::open_with_harness(root, None, Some(harness))];
-    run_budgeted(sources, false, &[Tier::Text], Finish::Stop).await
+    run_budgeted(sources, false, Finish::Stop).await
 }
 
-/// Drive `sources` tier-major — every owed unit at `tiers[0]`, then `tiers[1]`, … — checking the
-/// budget after each whole-session pass; `finish` says what to do when it expires with work left.
-/// The owed passes are computed upfront from state alone (no reading), so the plan and the ETA
-/// reflect what this run actually owes.
-async fn run_budgeted(
-    sources: Vec<Box<dyn source::TraceSource>>,
-    no_thinking: bool,
-    tiers: &[Tier],
-    finish: Finish,
-) -> Result<()> {
+/// Drive `sources` tier-major — every owed unit at text, then at tool_use, then at tool_result —
+/// checking the budget after each whole-session pass; `finish` says what to do when it expires
+/// with work left. The owed passes are computed upfront from state alone (no reading), so the plan
+/// and the ETA reflect what this run actually owes.
+async fn run_budgeted(sources: Vec<Box<dyn source::TraceSource>>, no_thinking: bool, finish: Finish) -> Result<()> {
     let mut idx = Indexer::open(sources, no_thinking).await?;
 
-    let owed: Vec<(Tier, Vec<usize>)> = tiers
+    let owed: Vec<(Tier, Vec<usize>)> = Tier::ALL
         .iter()
         .map(|&t| (t, idx.pending(t)))
         .filter(|(_, units)| !units.is_empty())

--- a/src/index.rs
+++ b/src/index.rs
@@ -214,7 +214,7 @@ impl Indexer<'_> {
         if let Some(scanner) = self.scanner {
             redact_turns(&mut turns, scanner)?;
         }
-        let mut chunks = chunk::chunks_from_turns(&turns, self.include_thinking);
+        let mut chunks = chunk::chunks_from_turns(&turns, &chunk::Tier::ALL, self.include_thinking);
         let repo = self.repo_for(key);
         if !repo.is_empty() {
             for c in &mut chunks {

--- a/src/index.rs
+++ b/src/index.rs
@@ -248,6 +248,9 @@ struct Indexer {
     /// A human is watching (stdin is a terminal) — probed once here, so every prompt-or-proceed
     /// choice in a run agrees.
     interactive: bool,
+    /// The caller stopped early with passes still owed, so the summary must not claim the store is
+    /// up to date.
+    work_remaining: bool,
     _lock: lock::StoreLock,
     /// The sources and their units, enumerated once at open so the change-stamps are a stable
     /// snapshot; a caller drives them by index via [`Indexer::index_unit`].
@@ -335,6 +338,7 @@ impl Indexer {
             state_path,
             first_index,
             interactive,
+            work_remaining: false,
             _lock,
             sources,
             units,
@@ -504,25 +508,46 @@ impl Indexer {
     /// query reads — what makes recall over a remote (hf://) tier lazy rather than a full scan; lance
     /// enforces its own training minimum (256 rows) and skips below it, falling back to brute force.
     async fn finalize(mut self) -> Result<()> {
-        if let Some(d) = &mut self.ds {
-            dataset::build_indexes(d, |phase| eprintln!("building {phase}…")).await;
+        // Nothing written → the store is unchanged since it opened; skip the rebuild and its
+        // version churn.
+        if self.n_chunks > 0 {
+            if let Some(d) = &mut self.ds {
+                dataset::build_indexes(d, |phase| eprintln!("building {phase}…")).await;
 
-            // Reap superseded versions — best-effort; on failure the reap waits for next run.
-            match d.cleanup_old_versions(chrono::Duration::minutes(10), None, None).await {
-                Ok(stats) if stats.bytes_removed > 0 => eprintln!(
-                    "reclaimed {:.1} MB from {} old version(s)",
-                    stats.bytes_removed as f64 / 1e6,
-                    stats.old_versions
-                ),
-                Ok(_) => {}
-                Err(e) => eprintln!("note: version cleanup skipped — {e}"),
+                // Reap superseded versions — best-effort; on failure the reap waits for next run.
+                match d.cleanup_old_versions(chrono::Duration::minutes(10), None, None).await {
+                    Ok(stats) if stats.bytes_removed > 0 => eprintln!(
+                        "reclaimed {:.1} MB from {} old version(s)",
+                        stats.bytes_removed as f64 / 1e6,
+                        stats.old_versions
+                    ),
+                    Ok(_) => {}
+                    Err(e) => eprintln!("note: version cleanup skipped — {e}"),
+                }
             }
         }
         println!(
-            "indexed sessions={} skipped={} chunks={}",
-            self.n_sessions, self.n_skipped, self.n_chunks
+            "{}",
+            run_summary(
+                self.interactive && !self.work_remaining,
+                self.n_sessions,
+                self.n_skipped,
+                self.n_chunks,
+                self.units.len(),
+            )
         );
         Ok(())
+    }
+}
+
+/// The run summary line. An interactive rerun that added nothing — and left nothing owed — gets a
+/// friendly "up to date" instead of a zero-count tally; an automated run (no reader) or any run
+/// that indexed or still owes something gets the tally.
+fn run_summary(done: bool, sessions: u64, skipped: u64, chunks: u64, units: usize) -> String {
+    if done && chunks == 0 {
+        format!("up to date ({units} sessions, all tiers)")
+    } else {
+        format!("indexed sessions={sessions} skipped={skipped} chunks={chunks}")
     }
 }
 
@@ -647,6 +672,7 @@ async fn run_budgeted(
                         "{} pass(es) left — per-turn indexing (or a `funes index` rerun) picks them up",
                         passes - done
                     );
+                    idx.work_remaining = true;
                     break 'tiers;
                 }
                 capped = false; // finish the rest now
@@ -702,6 +728,7 @@ async fn index_sources(sources: Vec<Box<dyn source::TraceSource>>, no_thinking: 
                     "stopped after 1 session (kept — the index is resumable). Re-run \
                      `funes index --limit M` for the most recent M, or `funes index` to do all."
                 );
+                indexer.work_remaining = true;
                 break;
             }
         }
@@ -808,6 +835,22 @@ mod tests {
         assert!(unit_current(Some(&full), "10:20", Tier::ToolResult));
         // No record → not current.
         assert!(!unit_current(None, "10:20", Tier::Text));
+    }
+
+    #[test]
+    fn run_summary_says_up_to_date_only_on_a_done_no_op() {
+        // Interactive rerun that added nothing and owes nothing → the friendly no-op.
+        assert_eq!(run_summary(true, 0, 30, 0, 30), "up to date (30 sessions, all tiers)");
+        // A run that indexed something → the tally, not "up to date".
+        assert_eq!(
+            run_summary(true, 2, 28, 57, 30),
+            "indexed sessions=2 skipped=28 chunks=57"
+        );
+        // Stopped early (or no reader at all) → the tally, even with nothing added: work is owed.
+        assert_eq!(
+            run_summary(false, 0, 30, 0, 30),
+            "indexed sessions=0 skipped=30 chunks=0"
+        );
     }
 
     #[test]

--- a/src/index.rs
+++ b/src/index.rs
@@ -132,38 +132,40 @@ async fn stored_ids(ds: &Dataset) -> Result<HashSet<String>> {
 
 /// Redact secrets from a session's turns *before* chunking — so a long key that chunking would
 /// split across pieces is whole when scanned, and never reaches the embedding, the local store, or
-/// (via push) the Hub. Best-effort: removes a secret whose value byte-matches the stored text (the
-/// common case, real newlines); anything that resists is caught downstream by the fail-closed push
-/// gate. Reports to stderr what it removed.
-fn redact_turns(turns: &mut [trace::Turn], scanner: &dyn scan::SecretScanner) -> Result<()> {
-    let texts: Vec<String> = turns
-        .iter()
-        .flat_map(|t| t.blocks.iter().map(|b| b.text.clone()))
-        .collect();
-    if texts.is_empty() {
-        return Ok(());
-    }
-    let refs: Vec<&str> = texts.iter().map(String::as_str).collect();
-    let per_block = scan::scan_blocks(&refs, scanner)?;
-
-    let mut removed: Vec<String> = Vec::new();
-    let redacted: Vec<String> = texts
-        .iter()
-        .zip(&per_block)
-        .map(|(text, findings)| {
-            let r = scan::excise(text, findings);
+/// (via push) the Hub. Scans exactly the blocks the pass will store ([`chunk::block_selected`]), so
+/// deferred tiers aren't scanned now and a tier-major backfill doesn't re-scan each session per
+/// tier. Best-effort: removes a secret whose value byte-matches the stored text (the common case,
+/// real newlines); anything that resists is caught downstream by the fail-closed push gate.
+/// Reports to stderr what it removed.
+fn redact_turns(
+    turns: &mut [trace::Turn],
+    scanner: &dyn scan::SecretScanner,
+    tiers: &[Tier],
+    include_thinking: bool,
+) -> Result<()> {
+    let removed: Vec<String> = {
+        let mut blocks: Vec<&mut trace::Block> = turns
+            .iter_mut()
+            .flat_map(|t| t.blocks.iter_mut())
+            .filter(|b| chunk::block_selected(&b.block_type, tiers, include_thinking))
+            .collect();
+        if blocks.is_empty() {
+            return Ok(());
+        }
+        let per_block = {
+            let texts: Vec<&str> = blocks.iter().map(|b| b.text.as_str()).collect();
+            scan::scan_blocks(&texts, scanner)?
+        };
+        let mut removed = Vec::new();
+        for (b, findings) in blocks.iter_mut().zip(&per_block) {
+            let r = scan::excise(&b.text, findings);
             removed.extend(r.removed_detectors);
-            r.text
-        })
-        .collect();
+            b.text = r.text;
+        }
+        removed
+    };
     if removed.is_empty() {
         return Ok(());
-    }
-    let mut it = redacted.into_iter();
-    for t in turns.iter_mut() {
-        for b in t.blocks.iter_mut() {
-            b.text = it.next().expect("one redacted text per block");
-        }
     }
     let sid = turns.first().map(|t| t.session_id.as_str()).unwrap_or("?");
     eprintln!(
@@ -229,7 +231,7 @@ impl Indexer<'_> {
         let (sessions, label) = unit_summary(&turns, key);
 
         if let Some(scanner) = self.scanner {
-            redact_turns(&mut turns, scanner)?;
+            redact_turns(&mut turns, scanner, &chunk::Tier::ALL, self.include_thinking)?;
         }
         let mut chunks = chunk::chunks_from_turns(&turns, &chunk::Tier::ALL, self.include_thinking);
         let repo = self.repo_for(key);
@@ -655,10 +657,56 @@ mod tests {
             source_path: String::new(),
             harness: "claude_code".into(),
         }];
-        redact_turns(&mut turns, &scanner).unwrap();
+        redact_turns(&mut turns, &scanner, &chunk::Tier::ALL, true).unwrap();
         assert_eq!(
             turns[0].blocks[0].text,
             "key=[REDACTED:PrivateKey] hash=[REDACTED:VirusTotal]"
+        );
+    }
+
+    #[test]
+    fn redact_only_scans_the_pass_tier_blocks() {
+        struct Fake;
+        impl scan::SecretScanner for Fake {
+            fn scan(&self, _blob: &str) -> Result<Vec<scan::Finding>> {
+                Ok(vec![scan::Finding {
+                    detector: "PrivateKey".into(),
+                    raw: "SECRET".into(),
+                    line: None,
+                    decoder: "PLAIN".into(),
+                }])
+            }
+        }
+        let block = |bt: &str, text: &str| trace::Block {
+            block_type: bt.into(),
+            text: text.into(),
+            tool_name: None,
+            tool_use_id: None,
+        };
+        let mut turns = vec![trace::Turn {
+            session_id: "sess".into(),
+            workdir: "proj".into(),
+            turn_uuid: "turn".into(),
+            parent_uuid: None,
+            seq: 0,
+            ts: String::new(),
+            role: "user".into(),
+            blocks: vec![
+                block("text", "note SECRET here"),
+                block("tool_result", "output SECRET dump"),
+            ],
+            source_path: String::new(),
+            harness: "claude_code".into(),
+        }];
+        // A text-only pass redacts the text block but leaves the tool_result it won't store untouched.
+        redact_turns(&mut turns, &Fake, &[chunk::Tier::Text], true).unwrap();
+        assert!(
+            turns[0].blocks[0].text.contains("[REDACTED:PrivateKey]"),
+            "text block redacted"
+        );
+        assert_eq!(
+            turns[0].blocks[1].text, "output SECRET dump",
+            "unindexed tool_result untouched"
         );
     }
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -251,6 +251,9 @@ struct Indexer {
     /// The caller stopped early with passes still owed, so the summary must not claim the store is
     /// up to date.
     work_remaining: bool,
+    /// Units (by index) already counted in `n_sessions` this run, so a tier-major caller's repeat
+    /// passes over one unit don't recount its sessions.
+    counted: HashSet<usize>,
     _lock: lock::StoreLock,
     /// The sources and their units, enumerated once at open so the change-stamps are a stable
     /// snapshot; a caller drives them by index via [`Indexer::index_unit`].
@@ -339,6 +342,7 @@ impl Indexer {
             first_index,
             interactive,
             work_remaining: false,
+            counted: HashSet::new(),
             _lock,
             sources,
             units,
@@ -411,7 +415,6 @@ impl Indexer {
         };
 
         let (sessions, label) = unit_summary(&turns, &key);
-        let first_time = !self.state.contains_key(&key);
         if let Some(scanner) = &self.scanner {
             redact_turns(&mut turns, scanner, tiers, self.include_thinking)?;
         }
@@ -451,9 +454,8 @@ impl Indexer {
             );
             std::fs::write(&self.state_path, serde_json::to_string_pretty(&self.state)?)?;
         }
-        // Count a unit's sessions once — the first time it's indexed; later tier passes only add
-        // chunks to sessions already counted.
-        if first_time {
+        // Count a unit's sessions once per run — later tier passes over it only add chunks.
+        if self.counted.insert(i) {
             self.n_sessions += sessions;
         }
         self.n_chunks += added;

--- a/src/index.rs
+++ b/src/index.rs
@@ -27,6 +27,28 @@ pub const MODEL: &str = "BAAI/bge-small-en-v1.5";
 pub const DIM: i32 = 384;
 const EMBED_BATCH: usize = 256;
 
+/// Take the store lock. An interactive caller (a human at `funes index`/`funes add`) waits out a
+/// brief contention — up to 3 retries, 5s apart — since a store operation rarely runs long; an
+/// automated run (a hook) bails at once and re-sweeps next turn.
+async fn acquire_lock(interactive: bool) -> Result<lock::StoreLock> {
+    let retries = if interactive { 3 } else { 0 };
+    for attempt in 0..=retries {
+        if let Some(l) = lock::StoreLock::try_acquire()? {
+            return Ok(l);
+        }
+        if attempt < retries {
+            eprintln!(
+                "funes: another store operation is in progress; retrying in 5s… ({}/{retries})",
+                attempt + 1
+            );
+            tokio::time::sleep(Duration::from_secs(5)).await;
+        }
+    }
+    Err(anyhow!(
+        "another funes store operation is in progress; retry in a moment"
+    ))
+}
+
 /// The table schema (column order is load-bearing for Lance).
 pub(crate) fn schema() -> Arc<Schema> {
     let utf8 = |name: &str| Field::new(name, DataType::Utf8, true);
@@ -242,8 +264,9 @@ impl Indexer {
     async fn open(sources: Vec<Box<dyn source::TraceSource>>, no_thinking: bool) -> Result<Indexer> {
         let dir = dataset::funes_dir();
         std::fs::create_dir_all(&dir)?;
+        let interactive = std::io::stdin().is_terminal();
         // Held for the whole run so the stored-id read and the appends see one stable version.
-        let _lock = lock::StoreLock::acquire()?;
+        let _lock = acquire_lock(interactive).await?;
 
         let uri = dataset::table_uri(&dataset::local_store_dir());
         let ds = dataset::open(&uri, HashMap::new()).await.ok();
@@ -305,7 +328,7 @@ impl Indexer {
             state,
             state_path,
             first_index,
-            interactive: std::io::stdin().is_terminal(),
+            interactive,
             _lock,
             sources,
             units,

--- a/src/index.rs
+++ b/src/index.rs
@@ -285,12 +285,18 @@ impl Indexer {
 
         let first_index = ds.is_none();
 
-        // Incremental state: path -> {size:mtime stamp, tier}; an unreadable or old-schema file → empty.
+        // Incremental state: path -> {size:mtime stamp, tier}; an unreadable or old-schema file →
+        // empty. A first index (store missing) owes everything, whatever an old state.json says — a
+        // stale one would silently skip every unit against the empty store.
         let state_path = dir.join("state.json");
-        let state = std::fs::read_to_string(&state_path)
-            .ok()
-            .and_then(|s| serde_json::from_str(&s).ok())
-            .unwrap_or_default();
+        let state = if first_index {
+            HashMap::new()
+        } else {
+            std::fs::read_to_string(&state_path)
+                .ok()
+                .and_then(|s| serde_json::from_str(&s).ok())
+                .unwrap_or_default()
+        };
 
         let embedder: Box<dyn Embedder> = inference::embedder()?;
         // Best-effort secret redaction: if the scanner isn't installed, indexing continues
@@ -524,7 +530,7 @@ impl Indexer {
 /// where `None` auto-detects. All roots share one store, embedder, and `state.json` (keyed by
 /// absolute file path, so cross-root incremental works). Writes only locally — publishing is the
 /// separate `push`. `max_sessions` caps sessions *per root* to the most recent N (`None` = all).
-/// `yes` skips the first-index confirmation and the automated-first-index guard (`--yes`).
+/// `yes` skips the first-index confirmation (`--yes`).
 pub async fn run_index_roots(
     roots: &[(PathBuf, Option<Harness>)],
     no_thinking: bool,
@@ -544,7 +550,7 @@ pub async fn run_index_roots(
 pub async fn run_index_remote(uri: &str, no_thinking: bool) -> Result<()> {
     let (owner, name, _prefix) = hub::parse_hf(uri)?;
     let src = source::open_remote(&owner, &name, None).await?;
-    // A Hub import is an explicit, deliberate command — bypass the first-index confirmation/guard.
+    // A Hub import is an explicit, deliberate command — skip the first-index confirmation.
     index_sources(vec![src], no_thinking, true).await
 }
 
@@ -656,21 +662,6 @@ async fn run_budgeted(
 /// the run after the first session and asks before the long haul.
 async fn index_sources(sources: Vec<Box<dyn source::TraceSource>>, no_thinking: bool, yes: bool) -> Result<()> {
     let interactive = std::io::stdin().is_terminal();
-
-    // A first index can take a long time; never let an automated run (no TTY — a hook, cron) trigger
-    // it. Fail closed like push's new-store guard: require a manual `funes index` first, or --yes to
-    // force. Exit 0 so a session-end hook isn't treated as failed.
-    if !yes && !interactive {
-        let uri = dataset::table_uri(&dataset::local_store_dir());
-        if dataset::open(&uri, HashMap::new()).await.is_err() {
-            eprintln!(
-                "funes: no index yet — run `funes index` in a terminal first to build the initial index \
-                 (one-time; it can take a while), or pass --yes to force it here. Skipping."
-            );
-            return Ok(());
-        }
-    }
-
     let mut indexer = Indexer::open(sources, no_thinking).await?;
     let total = indexer.unit_count();
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -2,18 +2,21 @@
 //! local Lance dataset. One generic loop drives every source — a JSONL tree today, new formats by
 //! implementing the trait — indexing each of its units in a single append.
 //!
-//! Incremental on two levels: skip a unit whose signature is unchanged (size:mtime in state.json),
-//! and within a re-read unit add only chunks whose id is new — a grown session (the same memory)
-//! contributes just its new turns, nothing is re-embedded or deleted.
+//! Incremental on two levels: skip a unit whose stamp (size:mtime) is unchanged *and* which
+//! state.json records as already indexed to the run's target tier; and within a re-read unit add
+//! only chunks whose id is new — a grown session (the same memory) contributes just its new turns,
+//! nothing is re-embedded or deleted.
 
+use crate::chunk::{self, Tier};
 use crate::harness::Harness;
 use crate::inference::{self, Embedder};
-use crate::{chunk, dataset, hub, lock, repo, scan, source, trace};
+use crate::{dataset, hub, lock, repo, scan, source, trace};
 use anyhow::{anyhow, Result};
 use arrow_array::types::Float32Type;
 use arrow_array::{Array, FixedSizeListArray, Int64Array, RecordBatch, RecordBatchIterator, StringArray};
 use arrow_schema::{DataType, Field, Schema};
 use lance::dataset::{Dataset, WriteParams};
+use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::io::{IsTerminal, Write as _};
 use std::path::{Path, PathBuf};
@@ -186,6 +189,20 @@ fn unit_summary(turns: &[trace::Turn], key: &str) -> (u64, String) {
     (sids.len() as u64, label)
 }
 
+/// What `state.json` records per unit: the change-stamp last seen and the highest [`Tier`] it has
+/// been indexed to.
+#[derive(Serialize, Deserialize, Clone)]
+struct UnitState {
+    sig: String,
+    level: Tier,
+}
+
+/// Whether a recorded unit is current for a run targeting `target`: its stamp still matches and it
+/// has already reached at least that tier. A lower recorded tier still needs a pass.
+fn unit_current(entry: Option<&UnitState>, sig: &str, target: Tier) -> bool {
+    entry.is_some_and(|e| e.sig == sig && e.level >= target)
+}
+
 /// The run-wide indexing state: the local store uri, the dataset (created on the first write), the
 /// embedder, and the optional redaction scanner. Bundling it lets each unit be indexed by a method
 /// instead of threading the same handles through every call.
@@ -355,12 +372,14 @@ async fn index_sources(sources: Vec<Box<dyn source::TraceSource>>, no_thinking: 
         return Ok(());
     }
 
-    // Incremental state: path -> "size:mtime".
+    // Incremental state: path -> {size:mtime stamp, tier}; an unreadable or old-schema file → empty.
     let state_path = dir.join("state.json");
-    let mut state: HashMap<String, String> = std::fs::read_to_string(&state_path)
+    let mut state: HashMap<String, UnitState> = std::fs::read_to_string(&state_path)
         .ok()
         .and_then(|s| serde_json::from_str(&s).ok())
         .unwrap_or_default();
+    // This run indexes every tier, so a unit counts as current only once it has reached the highest.
+    let target = *Tier::ALL.iter().max().expect("Tier::ALL is non-empty");
 
     let embedder: Box<dyn Embedder> = inference::embedder()?;
     // Best-effort secret redaction: if the scanner isn't installed, indexing continues unredacted —
@@ -399,7 +418,11 @@ async fn index_sources(sources: Vec<Box<dyn source::TraceSource>>, no_thinking: 
         let total = units.len();
         let cached = units
             .iter()
-            .filter(|u| u.signature.as_ref().is_some_and(|s| state.get(&u.key) == Some(s)))
+            .filter(|u| {
+                u.signature
+                    .as_ref()
+                    .is_some_and(|s| unit_current(state.get(&u.key), s, target))
+            })
             .count();
         eprintln!("{} — {} to index, {cached} cached", src.describe(), total - cached);
 
@@ -408,7 +431,7 @@ async fn index_sources(sources: Vec<Box<dyn source::TraceSource>>, no_thinking: 
             // signature-less (bulk) unit has none, so it's never skipped here — always re-read (its
             // chunk-id dedup makes a re-run a no-op).
             if let Some(sig) = &unit.signature {
-                if state.get(&unit.key) == Some(sig) {
+                if unit_current(state.get(&unit.key), sig, target) {
                     n_skipped += 1;
                     continue;
                 }
@@ -434,7 +457,13 @@ async fn index_sources(sources: Vec<Box<dyn source::TraceSource>>, no_thinking: 
             // when empty"), and persist after each so an interrupted run is resumable.
             // Signature-less (bulk) units are never recorded: a re-run re-reads and dedups to a no-op.
             if let Some(sig) = &unit.signature {
-                state.insert(unit.key.clone(), sig.clone());
+                state.insert(
+                    unit.key.clone(),
+                    UnitState {
+                        sig: sig.clone(),
+                        level: target,
+                    },
+                );
                 std::fs::write(&state_path, serde_json::to_string_pretty(&state)?)?;
             }
 
@@ -518,6 +547,30 @@ fn fmt_eta(d: Duration) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn unit_current_needs_matching_sig_and_reached_target_tier() {
+        let l1 = UnitState {
+            sig: "10:20".into(),
+            level: Tier::Text,
+        };
+        // Signature mismatch is never current, whatever the tier.
+        assert!(!unit_current(Some(&l1), "99:99", Tier::Text));
+        // Sig matches and the recorded tier meets the target → current.
+        assert!(unit_current(Some(&l1), "10:20", Tier::Text));
+        // Sig matches but a higher tier is targeted → NOT current; L2/L3 still owe a pass.
+        assert!(!unit_current(Some(&l1), "10:20", Tier::ToolUse));
+        assert!(!unit_current(Some(&l1), "10:20", Tier::ToolResult));
+        // A fully-indexed unit satisfies every target.
+        let full = UnitState {
+            sig: "10:20".into(),
+            level: Tier::ToolResult,
+        };
+        assert!(unit_current(Some(&full), "10:20", Tier::Text));
+        assert!(unit_current(Some(&full), "10:20", Tier::ToolResult));
+        // No record → not current.
+        assert!(!unit_current(None, "10:20", Tier::Text));
+    }
 
     #[test]
     fn fmt_eta_uses_the_right_unit_at_each_boundary() {

--- a/src/jsonl.rs
+++ b/src/jsonl.rs
@@ -29,6 +29,11 @@ pub fn session_id_of(p: &Path) -> String {
     p.file_stem().and_then(|s| s.to_str()).unwrap_or("").to_string()
 }
 
+/// A Claude Code sub-agent session id: each sub-agent's transcript is named `agent-<hash>.jsonl`.
+pub fn is_subagent(session_id: &str) -> bool {
+    session_id.starts_with("agent-")
+}
+
 /// The workdir facet for a session's recorded working directory: the whole cwd munged the way
 /// Claude Code names its workdir dirs — every non-alphanumeric character becomes `-` — so the
 /// facet is unique per directory per host (no basename collisions) and matches the `projects`
@@ -116,6 +121,16 @@ mod tests {
     #[test]
     fn session_id_is_file_stem() {
         assert_eq!(session_id_of(Path::new("/x/y/71626b12.jsonl")), "71626b12");
+    }
+
+    #[test]
+    fn is_subagent_matches_the_agent_prefix() {
+        assert!(is_subagent("agent-a90670a3067db59ca"));
+        assert!(
+            !is_subagent("72e856b6-9214-47ed-ab2d-0a1905093f45"),
+            "a uuid is a top-level session"
+        );
+        assert!(!is_subagent("agentic-refactor"), "the prefix is `agent-`, not `agent`");
     }
 
     #[test]

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -6,7 +6,7 @@
 
 use std::fs::{File, TryLockError};
 
-use anyhow::{bail, Context, Result};
+use anyhow::{anyhow, Context, Result};
 
 use crate::dataset;
 
@@ -28,15 +28,20 @@ fn open_lockfile() -> Result<File> {
 }
 
 impl StoreLock {
-    /// Take the lock, or fail if another store operation holds it. Never blocks.
-    pub fn acquire() -> Result<Self> {
+    /// Try to take the lock without blocking: `Some` if acquired, `None` if another operation holds
+    /// it. A caller that wants to wait retries this itself.
+    pub fn try_acquire() -> Result<Option<Self>> {
         let f = open_lockfile()?;
         match f.try_lock() {
-            Ok(()) => Ok(Self(f)),
-            Err(TryLockError::WouldBlock) => {
-                bail!("another funes store operation is in progress; retry once it finishes")
-            }
+            Ok(()) => Ok(Some(Self(f))),
+            Err(TryLockError::WouldBlock) => Ok(None),
             Err(TryLockError::Error(e)) => Err(e).context("locking the store"),
         }
+    }
+
+    /// Take the lock, or fail if another store operation holds it. Never blocks.
+    pub fn acquire() -> Result<Self> {
+        Self::try_acquire()?
+            .ok_or_else(|| anyhow!("another funes store operation is in progress; retry once it finishes"))
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -755,15 +755,16 @@ async fn offer_hub_store() -> Result<Option<Resolved>> {
     }
 }
 
-/// Prompt for yes/no on stderr and read a line from stdin. Empty input takes `default_yes`.
+/// Prompt for yes/no on stderr and read a line from stdin. Empty input takes `default_yes`; EOF or
+/// a read error declines, so an unattended run never proceeds.
 fn confirm(prompt: &str, default_yes: bool) -> bool {
     eprint!("{prompt}");
     let _ = std::io::stderr().flush();
     let mut answer = String::new();
-    if std::io::stdin().read_line(&mut answer).is_err() {
-        return false;
+    match std::io::stdin().read_line(&mut answer) {
+        Ok(n) if n > 0 => parse_confirm(&answer, default_yes),
+        _ => false,
     }
-    parse_confirm(&answer, default_yes)
 }
 
 /// Pure core of [`confirm`]: empty → the default; `y`/`yes` → yes; anything else → no (conservative,
@@ -779,7 +780,8 @@ fn parse_confirm(input: &str, default_yes: bool) -> bool {
 /// `funes add claude|codex [store]` for the agents with a full local pipeline: bootstrap the
 /// one-time steps the hooks can't do unattended, around the per-agent `install` (hooks + MCP).
 ///
-/// 1. build the first index if the local store is missing (so recall/push have content);
+/// 1. ask, then build the first index if the local store is missing (so recall/push have content);
+///    declining aborts the add — nothing is installed;
 /// 2. `install` — register hooks + MCP (bakes the store);
 /// 3. first push if a store is bound — clears the overlap guard so the push hook works thereafter.
 async fn bootstrap_add(
@@ -787,11 +789,17 @@ async fn bootstrap_add(
     resolved: Option<Resolved>,
     install: impl FnOnce(Option<String>) -> Result<()>,
 ) -> Result<()> {
-    ensure_local_index(harness).await;
+    if !ensure_local_index(harness).await {
+        eprintln!(
+            "funes: skipped — nothing installed. Run `funes add {}` again when you're ready.",
+            harness.cli_name()
+        );
+        return Ok(());
+    }
     install(resolved.as_ref().map(|r| r.store.clone()))?;
-    // First push only when there's actually a local index to publish. Without one (a declined or
-    // non-interactive first build, or no sessions yet) there's nothing to push, and running it
-    // would just error on the absent store.
+    // First push only when there's actually a local index to publish. Without one (a failed first
+    // build, or no sessions yet) there's nothing to push, and running it would just error on the
+    // absent store.
     if let Some(Resolved { store, created }) = resolved {
         if hub::Store::local().open().await.is_ok() {
             first_push(&store, created).await?;
@@ -802,18 +810,14 @@ async fn bootstrap_add(
     Ok(())
 }
 
-/// Build the first index from `harness`'s sessions when the local store is missing, so `add` leaves
-/// recall working without a separate step. Best-effort: a decline, an empty/absent session dir, or
-/// a build error leaves a note and lets `add` finish — the hooks are still installed, and the user
-/// can run `funes index` later. A non-interactive run never triggers the (potentially long) first
-/// build; it just points at `funes index`.
-async fn ensure_local_index(harness: Harness) {
+/// Build the first index from `harness`'s sessions when the local store is missing — asking first,
+/// since it's about a minute of work. Returns whether `add` should proceed: declining (or EOF — a
+/// no-TTY run reads none) returns `false`, so the caller installs nothing. An empty/absent session
+/// dir or a build error is a note, not a decline: the hooks still go in and `funes index` builds
+/// it later.
+async fn ensure_local_index(harness: Harness) -> bool {
     if hub::Store::local().open().await.is_ok() {
-        return; // already have a local index
-    }
-    if !std::io::stdin().is_terminal() {
-        eprintln!("funes: no local index yet — run `funes index` in a terminal to build it (the hooks index each turn after that).");
-        return;
+        return true; // already have a local index
     }
     let Some(root) = funes::harness::known_harness_roots()
         .into_iter()
@@ -823,17 +827,24 @@ async fn ensure_local_index(harness: Harness) {
             "funes: no {} sessions found yet — the hooks are installed; run `funes index` once you've used it.",
             harness.cli_name()
         );
-        return;
+        return true;
     };
-    eprintln!(
-        "funes: no local index yet — building it from your {} sessions…",
-        harness.cli_name()
-    );
-    if let Err(e) = index::run_index_roots(&[(root.0, Some(harness))], false, None, false).await {
+    if !confirm(
+        &format!(
+            "funes will index your recent {} sessions so recall works (about a minute). Proceed? [Y/n] ",
+            harness.cli_name()
+        ),
+        true,
+    ) {
+        return false;
+    }
+    eprintln!("funes: indexing your recent {} sessions…", harness.cli_name());
+    if let Err(e) = index::run_index_seed(&root.0, harness).await {
         eprintln!(
             "funes: initial index didn't complete ({e:#}) — the hooks are installed; run `funes index` to build it."
         );
     }
+    true
 }
 
 /// The one-time first publish `add` performs when a store is bound (the push hook can't, off a

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,15 +157,24 @@ enum Cmd {
         store: Option<String>,
     },
     /// Add funes to a coding agent.
-    #[command(subcommand_value_name = "AGENT", subcommand_help_heading = "Agents")]
+    ///
+    /// Installs the `recall`/`get` tools for any agent — and, for claude and codex, automatic
+    /// per-turn indexing. Name a store the agent recalls from — and, for claude and codex,
+    /// publishes to — an `<org>/<repo>` shorthand or an `hf://…` URI; omit it to stay local
+    /// (the default).
+    #[command(
+        subcommand_value_name = "AGENT",
+        subcommand_help_heading = "Agents",
+        override_usage = "funes add <AGENT> [STORE]"
+    )]
     Add {
         #[command(subcommand)]
         agent: AddAgent,
     },
 }
 
-/// The store an agent recalls from, baked into its MCP registration. `<org>/<repo>`, an `hf://…`
-/// URI, or `local` (the default). Doc string is shared across the agents via `#[arg]`'s help.
+// Flattened into every agent so they share one optional `[STORE]` positional; the user-facing help
+// comes from the field doc below.
 #[derive(Args)]
 struct AddStore {
     /// Store this agent recalls from — `<org>/<repo>`, an `hf://…` URI, or `local` (default).
@@ -174,17 +183,14 @@ struct AddStore {
 
 #[derive(Subcommand)]
 enum AddAgent {
-    /// claude: register funes as an MCP server with Claude Code (native MCP client, user scope).
     Claude {
         #[command(flatten)]
         store: AddStore,
     },
-    /// codex: register funes as an MCP server with Codex (native MCP client, user scope).
     Codex {
         #[command(flatten)]
         store: AddStore,
     },
-    /// pi: install funes as a pi extension user-wide (pi has no MCP client of its own).
     Pi {
         #[command(flatten)]
         store: AddStore,
@@ -192,12 +198,10 @@ enum AddAgent {
         #[arg(long)]
         force: bool,
     },
-    /// hermes: register funes as an MCP server (hermes has a native MCP client).
     Hermes {
         #[command(flatten)]
         store: AddStore,
     },
-    /// opencode: register funes as an MCP server (user scope).
     Opencode {
         #[command(flatten)]
         store: AddStore,

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,8 +101,9 @@ enum Cmd {
         /// Index only the most recent N sessions per source. Omit to index all.
         #[arg(long)]
         limit: Option<usize>,
-        /// Skip the first-index size confirmation, and allow a first index from a non-interactive
-        /// run (a hook/cron) — which is otherwise refused so the long initial build stays manual.
+        /// Don't ask: a budgeted (no-path) run finishes all remaining work instead of offering it;
+        /// an explicit path skips the first-index size confirmation, and a first index is allowed
+        /// from a non-interactive run (otherwise refused so the long initial build stays manual).
         #[arg(long)]
         yes: bool,
     },
@@ -384,6 +385,10 @@ async fn main() -> Result<()> {
             yes,
         } => {
             let harness = harness.map(|h| Harness::parse(&h)).transpose()?;
+            // A harness-dirs refresh (no explicit path — the per-turn hook and the terminal "keep
+            // me fresh" case) is budgeted and text-first; an explicit path or Hub repo is indexed
+            // in full.
+            let budgeted = path.is_none();
             let roots: Vec<(PathBuf, Option<Harness>)> = match path {
                 // An existing local path wins over reading the same string as a repo ref.
                 Some(p) if PathBuf::from(&p).exists() => vec![(PathBuf::from(p), harness)],
@@ -427,7 +432,11 @@ async fn main() -> Result<()> {
                     "no local sessions found — looked in ~/.claude/projects, ~/.codex/sessions, ~/.pi/agent/sessions"
                 ));
             }
-            index::run_index_roots(&roots, no_thinking, limit, yes).await
+            if budgeted {
+                index::run_index_budgeted(&roots, no_thinking, limit, yes).await
+            } else {
+                index::run_index_roots(&roots, no_thinking, limit, yes).await
+            }
         }
         Cmd::Status { store } => {
             print!("{}", recall::status(hub::Store::resolve(store)).await?);

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,8 +102,7 @@ enum Cmd {
         #[arg(long)]
         limit: Option<usize>,
         /// Don't ask: a budgeted (no-path) run finishes all remaining work instead of offering it;
-        /// an explicit path skips the first-index size confirmation, and a first index is allowed
-        /// from a non-interactive run (otherwise refused so the long initial build stays manual).
+        /// an explicit path skips the first-index size confirmation.
         #[arg(long)]
         yes: bool,
     },

--- a/src/push.rs
+++ b/src/push.rs
@@ -631,7 +631,7 @@ mod tests {
 
     /// Build a to-push batch the way the store stores it: chunk the turns, stamp zero vectors.
     fn batch(turns: &[Turn]) -> (RecordBatch, Vec<chunk::Chunk>) {
-        let chunks = chunk::chunks_from_turns(turns, true);
+        let chunks = chunk::chunks_from_turns(turns, &chunk::Tier::ALL, true);
         let vectors = vec![vec![0.0f32; index::DIM as usize]; chunks.len()];
         (index::build_batch(&chunks, &vectors).unwrap(), chunks)
     }

--- a/src/source.rs
+++ b/src/source.rs
@@ -28,6 +28,7 @@ use std::time::UNIX_EPOCH;
 pub struct Unit {
     pub key: String,
     pub signature: Option<String>,
+    pub is_subagent: bool,
 }
 
 /// A source of agent-session transcripts. `units()` is cheap (enumerate + stat, no parsing);
@@ -118,21 +119,25 @@ impl TraceSource for JsonlTree {
 
     fn units(&self) -> Result<Vec<Unit>> {
         let mut files = jsonl::iter_jsonl_files(&self.root);
+        // Newest-first by mtime; `--limit` then keeps the recent N. (Default filename order is
+        // ≈ random for UUID-named sessions.)
+        files.sort_by_cached_key(|p| {
+            std::cmp::Reverse(std::fs::metadata(p).and_then(|m| m.modified()).unwrap_or(UNIX_EPOCH))
+        });
         if let Some(n) = self.limit {
-            // Keep the most recent `n` by mtime: recall values recency, and the default order is by
-            // filename (≈ random for UUID-named sessions), so a plain truncate would drop recent work.
-            files.sort_by_cached_key(|p| {
-                std::cmp::Reverse(std::fs::metadata(p).and_then(|m| m.modified()).unwrap_or(UNIX_EPOCH))
-            });
             files.truncate(n);
         }
-        Ok(files
+        let mut units: Vec<Unit> = files
             .into_iter()
             .map(|p| Unit {
+                is_subagent: jsonl::is_subagent(&jsonl::session_id_of(&p)),
                 signature: file_sig(&p),
                 key: p.to_string_lossy().into_owned(),
             })
-            .collect())
+            .collect();
+        // Subagents last (stable sort preserves recency within each group).
+        units.sort_by_key(|u| u.is_subagent);
+        Ok(units)
     }
 
     fn read(&self, unit: &Unit) -> Result<Vec<Turn>> {
@@ -167,6 +172,7 @@ impl TraceSource for ParquetDataset {
         Ok(vec![Unit {
             key: self.path.to_string_lossy().into_owned(),
             signature: None,
+            is_subagent: false,
         }])
     }
 
@@ -254,6 +260,7 @@ impl TraceSource for RemoteParquetDataset {
             .map(|s| Unit {
                 key: s.key.clone(),
                 signature: Some(self.revision.clone()),
+                is_subagent: false,
             })
             .collect())
     }
@@ -342,6 +349,20 @@ mod tests {
         let pq = open(Path::new("/x/data.parquet"), None).units().unwrap();
         assert_eq!(pq.len(), 1);
         assert!(pq[0].signature.is_none());
+    }
+
+    #[test]
+    fn jsonl_tree_orders_subagents_last() {
+        let dir = tempfile::tempdir().unwrap();
+        for name in ["sess-a.jsonl", "agent-x.jsonl", "sess-b.jsonl", "agent-y.jsonl"] {
+            std::fs::write(dir.path().join(name), b"{}\n").unwrap();
+        }
+        let units = open(dir.path(), None).units().unwrap();
+        // Whatever the mtimes, every main precedes every subagent.
+        let first_sub = units.iter().position(|u| u.is_subagent).expect("has a subagent unit");
+        assert!(units[..first_sub].iter().all(|u| !u.is_subagent));
+        assert!(units[first_sub..].iter().all(|u| u.is_subagent));
+        assert_eq!(units.iter().filter(|u| u.is_subagent).count(), 2);
     }
 
     #[test]

--- a/tests/first_index.rs
+++ b/tests/first_index.rs
@@ -66,4 +66,12 @@ async fn seed_indexes_text_then_budgeted_run_adds_deeper_tiers() {
         "ToolResult",
         "a finished backfill records the top tier"
     );
+
+    // A deleted store self-heals: the store dir is gone but state.json survived — the next run
+    // must re-index everything, not trust the stale state and skip against an empty store.
+    std::fs::remove_dir_all(home.path().join("store")).unwrap();
+    funes::index::run_index_budgeted(&roots, false, None, false)
+        .await
+        .unwrap();
+    assert_eq!(chunk_count().await, full, "deleted store rebuilt in full");
 }

--- a/tests/first_index.rs
+++ b/tests/first_index.rs
@@ -1,10 +1,11 @@
-//! The `funes add` seed (text tier, L1) indexes text only; a later budgeted run adds the deeper
-//! tiers. Own test binary so its `$FUNES_HOME` can't race the other integration tests'.
+//! The `funes add` seed drives the budgeted drain end to end: a small history finishes whole
+//! within the budget, a rerun is a no-op, and a deleted store self-heals. Own test binary so its
+//! `$FUNES_HOME` can't race the other integration tests'.
 
 use std::io::Write;
 
-/// A session with a user text turn, an assistant `tool_use`, and a `tool_result` — so text-tier and
-/// full indexing differ.
+/// A session with a user text turn, an assistant `tool_use`, and a `tool_result` — one block in
+/// each tier.
 fn write_session(source: &std::path::Path) {
     let dir = source.join("projects").join("-home-u-dev-demo");
     std::fs::create_dir_all(&dir).unwrap();
@@ -37,35 +38,31 @@ fn state_level(home: &std::path::Path) -> String {
 }
 
 #[tokio::test]
-async fn seed_indexes_text_then_budgeted_run_adds_deeper_tiers() {
+async fn seed_finishes_a_small_history_and_a_rerun_is_a_noop() {
     let src = tempfile::tempdir().unwrap();
     let home = tempfile::tempdir().unwrap();
     std::env::set_var("FUNES_HOME", home.path());
     write_session(src.path());
 
-    // The seed `funes add` runs: text tier only.
+    // The seed `funes add` runs: budgeted, tier-major. This history fits the budget, so every
+    // tier lands and the unit is stamped at the top one.
     funes::index::run_index_seed(src.path(), funes::harness::Harness::Claude)
         .await
         .unwrap();
-    let text_only = chunk_count().await;
-    assert!(text_only > 0, "seed indexed the text");
-    assert_eq!(state_level(home.path()), "Text", "seed records the text tier");
+    let full = chunk_count().await;
+    assert!(full > 0, "seed indexed the session");
+    assert_eq!(
+        state_level(home.path()),
+        "ToolResult",
+        "a finished seed records the top tier"
+    );
 
-    // The budgeted no-path run (the per-turn hook): finishes the owed tool_use + tool_result.
+    // The budgeted no-path run (the per-turn hook): nothing owed, nothing added.
     let roots = [(src.path().to_path_buf(), Some(funes::harness::Harness::Claude))];
     funes::index::run_index_budgeted(&roots, false, None, false)
         .await
         .unwrap();
-    let full = chunk_count().await;
-    assert!(
-        full > text_only,
-        "budgeted run adds deeper tiers (text={text_only}, full={full})"
-    );
-    assert_eq!(
-        state_level(home.path()),
-        "ToolResult",
-        "a finished backfill records the top tier"
-    );
+    assert_eq!(chunk_count().await, full, "rerun adds nothing");
 
     // A deleted store self-heals: the store dir is gone but state.json survived — the next run
     // must re-index everything, not trust the stale state and skip against an empty store.

--- a/tests/first_index.rs
+++ b/tests/first_index.rs
@@ -1,0 +1,69 @@
+//! The `funes add` seed (text tier, L1) indexes text only; a later budgeted run adds the deeper
+//! tiers. Own test binary so its `$FUNES_HOME` can't race the other integration tests'.
+
+use std::io::Write;
+
+/// A session with a user text turn, an assistant `tool_use`, and a `tool_result` — so text-tier and
+/// full indexing differ.
+fn write_session(source: &std::path::Path) {
+    let dir = source.join("projects").join("-home-u-dev-demo");
+    std::fs::create_dir_all(&dir).unwrap();
+    let mut f = std::fs::File::create(dir.join("sess-0001.jsonl")).unwrap();
+    for l in [
+        r#"{"type":"user","uuid":"t0","timestamp":"2026-01-01T00:00:00Z","message":{"role":"user","content":"decide how to parse transcripts and index them into lancedb"}}"#,
+        r#"{"type":"assistant","uuid":"t1","parentUuid":"t0","timestamp":"2026-01-01T00:00:01Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"c1","name":"Bash","input":{"command":"ls the project directory tree"}}]}}"#,
+        r#"{"type":"user","uuid":"t2","parentUuid":"t1","timestamp":"2026-01-01T00:00:02Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"c1","content":[{"type":"text","text":"a long directory listing output with many files"}]}]}}"#,
+    ] {
+        writeln!(f, "{l}").unwrap();
+    }
+}
+
+async fn chunk_count() -> usize {
+    let s = funes::recall::status(funes::hub::Store::local()).await.unwrap();
+    s.lines()
+        .find_map(|l| l.strip_prefix("chunks: "))
+        .and_then(|n| n.trim().parse().ok())
+        .expect("status reports a chunk count")
+}
+
+fn state_level(home: &std::path::Path) -> String {
+    let s = std::fs::read_to_string(home.join("state.json")).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&s).unwrap();
+    v.as_object()
+        .and_then(|m| m.values().next())
+        .and_then(|e| e["level"].as_str())
+        .expect("state.json entry has a level")
+        .to_string()
+}
+
+#[tokio::test]
+async fn seed_indexes_text_then_budgeted_run_adds_deeper_tiers() {
+    let src = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+    std::env::set_var("FUNES_HOME", home.path());
+    write_session(src.path());
+
+    // The seed `funes add` runs: text tier only.
+    funes::index::run_index_seed(src.path(), funes::harness::Harness::Claude)
+        .await
+        .unwrap();
+    let text_only = chunk_count().await;
+    assert!(text_only > 0, "seed indexed the text");
+    assert_eq!(state_level(home.path()), "Text", "seed records the text tier");
+
+    // The budgeted no-path run (the per-turn hook): finishes the owed tool_use + tool_result.
+    let roots = [(src.path().to_path_buf(), Some(funes::harness::Harness::Claude))];
+    funes::index::run_index_budgeted(&roots, false, None, false)
+        .await
+        .unwrap();
+    let full = chunk_count().await;
+    assert!(
+        full > text_only,
+        "budgeted run adds deeper tiers (text={text_only}, full={full})"
+    );
+    assert_eq!(
+        state_level(home.path()),
+        "ToolResult",
+        "a finished backfill records the top tier"
+    );
+}


### PR DESCRIPTION
Indexing is currently all-or-nothing: a first `funes index` is one long unbounded build (~80 min for a 30-day cohort on a Mac), and after a `--limit N` first run the next per-turn hook silently sweeps everything else. This PR makes indexing progressive: blocks are split into tiers by recall value per byte — `text` (~17% of bytes, most of the value) → `tool_use` → `tool_result` — and every automated run is budgeted.

What changes:

- `funes add` asks, then builds a text-first first index (about a minute); declining aborts with nothing installed. Recall works immediately; deeper tiers and older sessions backfill as you work.
- The per-turn hook drains the backlog tier-major for up to 60s per turn — newest sessions first, subagents last — so progress scales with use and no run blocks long.
- An interactive `funes index` plans upfront (`to index — text: A, tool_use: B, tool_result: C`) and, when the budget expires, offers `Finish it now? [Y/n]` with an ETA; `--yes` finishes without asking; a drained store answers `up to date (N sessions, all tiers)`. It also waits out a briefly held store lock instead of bailing.
- The automated-first-index guard is gone: the budget bounds any cold-store run, and a deleted store self-heals (a first index ignores a stale `state.json`). An explicit `funes index <path>`/`<org/repo>` still indexes in full.

Mechanics: `state.json` records `{sig, level}` per unit and a unit is skipped only when its stamp matches *and* it already reached the run's target tier; chunk ids are tier-pass independent, so partial passes dedup exactly against a full index (pinned by test). Redaction scans only the blocks a pass stores. Indexing itself is now a caller-driven `Indexer` primitive — the seed, the budgeted drain, and the full sweep are three loops over `index_unit` — and a no-op run skips the index rebuild.

Best reviewed commit by commit: each lands one piece and is green on fmt/clippy/tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)