### PR TITLE
Security/verified install and update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
       - "tests/**"
       - "Cargo.toml"
       - "Cargo.lock"
+      - "scripts/**"
       - ".github/workflows/ci.yml"
   push:
     branches: [main]
@@ -70,6 +71,9 @@ jobs:
       # real embedder lives in its own job below.
       - name: Unit tests
         run: cargo test --lib --profile ci
+
+      - name: Installer tests
+        run: sh scripts/test-install.sh
 
   integration-test:
     name: Integration Test (real embedder)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ on:
       - "tests/**"
       - "Cargo.toml"
       - "Cargo.lock"
+      - "scripts/install.sh"
       - ".github/workflows/release.yml"
   workflow_dispatch:
     inputs:
@@ -168,7 +169,7 @@ jobs:
       - name: Install aarch64 cross toolchain
         if: matrix.arch == 'aarch64'
         run: |
-          DEBIAN_FRONTEND=noninteractive apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+          DEBIAN_FRONTEND=noninteractive apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu qemu-user
           mkdir -p ~/.cargo
           {
             echo '[target.aarch64-unknown-linux-gnu]'
@@ -183,6 +184,17 @@ jobs:
 
       - name: Build
         run: cargo build --profile ${{ env.PROFILE }} --target ${{ matrix.target }} ${{ matrix.features }}
+
+      - name: Check binary version
+        run: |
+          BIN="target/${{ matrix.target }}/${{ env.PROFILE }}/funes"
+          EXPECTED=$(grep -m1 '^version' Cargo.toml | sed 's/.*"\(.*\)"/\1/')
+          if [ "${{ matrix.arch }}" = "aarch64" ]; then
+            REPORTED=$(qemu-aarch64 -L /usr/aarch64-linux-gnu "$BIN" --version)
+          else
+            REPORTED=$($BIN --version)
+          fi
+          test "$REPORTED" = "funes $EXPECTED"
 
       # The point of the container build: fail loudly if anything drags the floor above 22.04.
       - name: Check the glibc floor
@@ -239,6 +251,12 @@ jobs:
       - name: Build
         run: cargo build --profile ${{ env.PROFILE }} --target aarch64-apple-darwin
 
+      - name: Check binary version
+        run: |
+          EXPECTED=$(grep -m1 '^version' Cargo.toml | sed 's/.*"\(.*\)"/\1/')
+          REPORTED=$(target/aarch64-apple-darwin/${{ env.PROFILE }}/funes --version)
+          test "$REPORTED" = "funes $EXPECTED"
+
       - name: Package
         run: |
           mkdir -p dist
@@ -278,10 +296,44 @@ jobs:
           pattern: "{linux-*,macos-*}"
           merge-multiple: true
 
-      # Tag the released commit and publish the binaries. On dispatch we create + push the tag at the
-      # current main commit — tags aren't branch-protected, so this isn't blocked; on a manual tag
-      # push the tag already exists. The published binaries carry the computed version (stamped at
-      # build time); the tagged commit's Cargo.toml still shows the in-progress `+dev` marker.
+      - name: Validate release metadata and generate checksums
+        run: |
+          TAG="${{ needs.compute.outputs.tag || github.ref_name }}"
+          VERSION="${TAG#v}"
+          if ! printf '%s' "$TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::release tag must have the form vMAJOR.MINOR.PATCH: $TAG"
+            exit 1
+          fi
+          COMPUTED="${{ needs.compute.outputs.version }}"
+          if [ -n "$COMPUTED" ] && [ "$VERSION" != "$COMPUTED" ]; then
+            echo "::error::tag $TAG does not match computed version $COMPUTED"
+            exit 1
+          fi
+
+          set -- \
+            funes-x86_64-linux \
+            funes-aarch64-linux \
+            funes-arm64-apple-darwin
+          for ASSET in "$@"; do
+            test -f "artifacts/$ASSET" || {
+              echo "::error::missing release asset: $ASSET"
+              exit 1
+            }
+          done
+          COUNT=$(find artifacts -maxdepth 1 -type f -name 'funes-*' | wc -l | tr -d ' ')
+          if [ "$COUNT" -ne "$#" ]; then
+            echo "::error::expected $# release assets, found $COUNT"
+            exit 1
+          fi
+
+          printf '%s\n' "$VERSION" > artifacts/VERSION
+          (
+            cd artifacts
+            sha256sum "$@" > SHA256SUMS
+          )
+
+      # Tag the released commit and publish the binaries and their checksums. On dispatch we create
+      # and push the tag at the current main commit; on a tag push, the tag already exists.
       - name: Tag and publish the release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -296,27 +348,24 @@ jobs:
             --title "$TAG" \
             --generate-notes
 
-      # Publish the same binaries — plus install.sh itself — to the huggingface/funes storage bucket,
-      # so the one-liner and the binaries it fetches share one distribution channel. The bucket root
-      # holds the latest binaries; each release also keeps a pinned copy under its tag, so `funes -v
-      # <tag>` resolves to it. Bucket support landed in huggingface_hub 1.21 — newer than the system
-      # package — so install it into a throwaway venv.
+      # Publish the tagged release before advancing the root VERSION pointer. Root binaries remain
+      # available for clients released before tagged checksum verification was introduced.
       - name: Publish binaries and installer to the Hugging Face bucket
         env:
           HF_TOKEN: ${{ secrets.HF_FUNES_RELEASE_TOKEN }}
         run: |
           TAG="${{ needs.compute.outputs.tag || github.ref_name }}"
-          # The version marker `funes update` / `funes status` read to detect a newer release.
-          # Written after the GitHub Release above so it isn't uploaded there as a stray asset.
-          printf '%s' "${TAG#v}" > ./artifacts/VERSION
-          # The installer itself, so the one-liner resolves. Staged after the GitHub Release for the
-          # same reason as VERSION — otherwise it'd land as a stray release asset.
-          cp scripts/install.sh ./artifacts/install.sh
           python3 -m venv "$RUNNER_TEMP/hfvenv"
           "$RUNNER_TEMP/hfvenv/bin/pip" install -q -U "huggingface_hub>=1.21"
           HF="$RUNNER_TEMP/hfvenv/bin/hf"
-          "$HF" buckets sync ./artifacts hf://buckets/huggingface/funes
-          "$HF" buckets sync ./artifacts "hf://buckets/huggingface/funes/$TAG"
+          ROOT="hf://buckets/huggingface/funes"
+
+          "$HF" buckets sync ./artifacts "$ROOT/$TAG" --ignore-existing
+          for ASSET in funes-x86_64-linux funes-aarch64-linux funes-arm64-apple-darwin; do
+            "$HF" buckets cp "./artifacts/$ASSET" "$ROOT/$ASSET"
+          done
+          "$HF" buckets cp ./artifacts/VERSION "$ROOT/VERSION"
+          "$HF" buckets cp scripts/install.sh "$ROOT/install.sh"
 
       # Dispatch only: push a branch advancing main's version marker to `<version>+dev`. The org
       # blocks Actions from opening PRs, so the workflow stops at the branch and surfaces a one-click

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3114,6 +3114,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha1 0.10.6",
+ "sha2 0.10.9",
  "tempfile",
  "tokenizers",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ nucleo-matcher = "0.3"           # fuzzy filtering the browser's hit/turn lists
 serde = { version = "1", features = ["derive"] }               # MCP request structs
 serde_json = { version = "1", features = ["preserve_order"] }  # parse JSONL; preserve tool_use key order
 sha1 = "0.10"                    # chunk id = sha1(...)[:16]
+sha2 = "0.10"                    # verify release binaries before the installer/updater executes them
 hex = "0.4"
 walkdir = "2"                    # recursive *.jsonl walk
 rmcp = { version = "1", features = ["server", "macros", "transport-io", "schemars"] }  # MCP stdio server

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ or agent can recall from it.
 ## Get funes
 
 The [installer](scripts/install.sh) detects your platform, downloads the matching prebuilt binary,
-and puts it on your PATH (`~/.local/bin` by default):
+verifies its tagged release checksum and version, and puts it on your PATH (`~/.local/bin` by
+default):
 
 ```bash
 curl -fsSL https://huggingface.co/buckets/huggingface/funes/resolve/install.sh | sh
@@ -38,7 +39,8 @@ memory bound) publishes at each session boundary. From here you just work. See
 [docs/add.md](docs/add.md) for the agents, memory binding, and what a run does; `funes status` tells
 you whether recall is reading your own memory yet.
 
-Alternatively, grab a [binary](https://huggingface.co/buckets/huggingface/funes) by hand:
+Tagged binaries and their `SHA256SUMS` manifest are also available in the
+[release bucket](https://huggingface.co/buckets/huggingface/funes):
 
 | Platform | Binary |
 | --- | --- |
@@ -46,10 +48,8 @@ Alternatively, grab a [binary](https://huggingface.co/buckets/huggingface/funes)
 | Linux aarch64 | `funes-aarch64-linux` |
 | macOS Apple Silicon | `funes-arm64-apple-darwin` |
 
-```bash
-curl -fsSL https://huggingface.co/buckets/huggingface/funes/resolve/funes-x86_64-linux -o funes
-chmod +x funes && ./funes add claude
-```
+The checksum detects corrupt, truncated, or mismatched release downloads. Because the binary and
+checksum share the same bucket, it does not authenticate the bucket itself.
 
 Already installed? **`funes update`** replaces the binary in place with the latest build for your
 platform (`--force` reinstalls the current one); `funes status` tells you when a newer release is

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -12,7 +12,7 @@ set -eu
 REPO="huggingface/funes"
 BUCKET="huggingface/funes"
 BINDIR="${FUNES_INSTALL_DIR:-$HOME/.local/bin}"
-VERSION="${FUNES_VERSION:-latest}"
+REQUESTED_VERSION="${FUNES_VERSION:-latest}"
 
 usage() {
     echo "usage: install.sh [-b install-dir] [-v release-tag]" >&2
@@ -22,7 +22,7 @@ usage() {
 while getopts "b:v:h" opt; do
     case "$opt" in
         b) BINDIR="$OPTARG" ;;
-        v) VERSION="$OPTARG" ;;
+        v) REQUESTED_VERSION="$OPTARG" ;;
         h) usage 0 ;;
         *) usage 2 ;;
     esac
@@ -41,18 +41,6 @@ case "$(uname -s)-$(uname -m)" in
         ;;
 esac
 
-# Bucket files have no revision: the root holds the latest binaries, and each release keeps a
-# pinned copy under its tag. Buckets are non-versioned, so the resolve path carries no `main`.
-if [ "$VERSION" = latest ]; then
-    url="https://huggingface.co/buckets/$BUCKET/resolve/$asset"
-else
-    url="https://huggingface.co/buckets/$BUCKET/resolve/$VERSION/$asset"
-fi
-
-# Download to a temp file so a failed/partial fetch never lands on PATH.
-tmp="$(mktemp 2>/dev/null || mktemp -t funes)"
-trap 'rm -f "$tmp"' EXIT INT TERM
-
 if command -v curl >/dev/null 2>&1; then
     fetch() { curl -fsSL "$1" -o "$2"; }
 elif command -v wget >/dev/null 2>&1; then
@@ -62,17 +50,119 @@ else
     exit 1
 fi
 
-echo "Downloading $asset ($VERSION)…"
-if ! fetch "$url" "$tmp"; then
-    echo "funes: download failed: $url" >&2
-    echo "  (no matching release published yet? see https://huggingface.co/buckets/$BUCKET)" >&2
+valid_version() {
+    case "$1" in
+        '' | *[!0-9.]* | .* | *. | *..*) return 1 ;;
+    esac
+    old_ifs=$IFS
+    IFS=.
+    set -- $1
+    IFS=$old_ifs
+    [ "$#" -eq 3 ] || return 1
+    for part in "$@"; do
+        case "$part" in
+            '' | *[!0-9]*) return 1 ;;
+        esac
+    done
+}
+
+read_version() {
+    awk '
+        NF == 0 { next }
+        NF != 1 || seen { bad = 1; next }
+        { value = $1; seen = 1 }
+        END {
+            if (bad || !seen) exit 1
+            print value
+        }
+    ' "$1"
+}
+
+manifest_digest() {
+    awk -v wanted="$2" '
+        NF != 2 || length($1) != 64 || $1 ~ /[^0-9a-f]/ || $2 ~ /\// || seen[$2]++ {
+            bad = 1
+            next
+        }
+        $2 == wanted { digest = $1; found++ }
+        END {
+            if (bad || found != 1) exit 1
+            print digest
+        }
+    ' "$1"
+}
+
+sha256_file() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{ print $1 }'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" | awk '{ print $1 }'
+    else
+        echo "funes: need sha256sum or shasum on PATH to verify the download." >&2
+        return 1
+    fi
+}
+
+mkdir -p "$BINDIR"
+tmpdir=$(mktemp -d "$BINDIR/.funes-install.XXXXXX") || {
+    echo "funes: could not create a staging directory in $BINDIR." >&2
+    exit 1
+}
+trap 'rm -rf "$tmpdir"' EXIT HUP INT TERM
+
+root="https://huggingface.co/buckets/$BUCKET/resolve"
+if [ "$REQUESTED_VERSION" = latest ]; then
+    if ! fetch "$root/VERSION" "$tmpdir/latest-version"; then
+        echo "funes: could not resolve the latest release." >&2
+        exit 1
+    fi
+    if ! version=$(read_version "$tmpdir/latest-version"); then
+        echo "funes: the latest release has an invalid VERSION marker." >&2
+        exit 1
+    fi
+else
+    version=${REQUESTED_VERSION#v}
+fi
+
+if ! valid_version "$version"; then
+    echo "funes: invalid release version: $version" >&2
     exit 1
 fi
 
-mkdir -p "$BINDIR"
-chmod +x "$tmp"
-mv "$tmp" "$BINDIR/funes"
-trap - EXIT INT TERM
+tag="v$version"
+release="$root/$tag"
+if ! fetch "$release/VERSION" "$tmpdir/release-version" ||
+   ! fetch "$release/SHA256SUMS" "$tmpdir/SHA256SUMS"; then
+    echo "funes: release metadata is incomplete for $tag." >&2
+    exit 1
+fi
+if ! tagged_version=$(read_version "$tmpdir/release-version") || [ "$tagged_version" != "$version" ]; then
+    echo "funes: release metadata does not match $tag." >&2
+    exit 1
+fi
+if ! expected=$(manifest_digest "$tmpdir/SHA256SUMS" "$asset"); then
+    echo "funes: SHA256SUMS is malformed or does not contain $asset." >&2
+    exit 1
+fi
+
+binary="$tmpdir/$asset"
+echo "Downloading $asset ($tag)…"
+if ! fetch "$release/$asset" "$binary"; then
+    echo "funes: download failed: $release/$asset" >&2
+    exit 1
+fi
+if ! actual=$(sha256_file "$binary") || [ "$actual" != "$expected" ]; then
+    echo "funes: checksum verification failed for $asset; nothing was installed." >&2
+    exit 1
+fi
+
+chmod +x "$binary"
+if ! reported=$("$binary" --version 2>/dev/null) || [ "$reported" != "funes $version" ]; then
+    echo "funes: $asset does not report the expected version $version; nothing was installed." >&2
+    exit 1
+fi
+
+mv -f "$binary" "$BINDIR/funes"
 
 echo "Installed funes -> $BINDIR/funes"
 "$BINDIR/funes" --version 2>/dev/null || true

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+set -eu
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT HUP INT TERM
+
+fixtures="$work/fixtures"
+fakebin="$work/bin"
+install="$work/install"
+asset="funes-x86_64-linux"
+version="9.9.9"
+mkdir -p "$fixtures/v$version" "$fakebin" "$install"
+
+cat > "$fakebin/curl" <<'SH'
+#!/bin/sh
+set -eu
+url=
+output=
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -o) output=$2; shift 2 ;;
+        -*) shift ;;
+        *) url=$1; shift ;;
+    esac
+done
+relative=${url#*/resolve/}
+cp "$FIXTURE_ROOT/$relative" "$output"
+SH
+chmod +x "$fakebin/curl"
+
+printf '%s\n' "$version" > "$fixtures/VERSION"
+printf '%s\n' "$version" > "$fixtures/v$version/VERSION"
+cat > "$fixtures/v$version/$asset" <<SH
+#!/bin/sh
+echo 'funes $version'
+SH
+digest=$(sha256sum "$fixtures/v$version/$asset" | awk '{ print $1 }')
+printf '%s  %s\n' "$digest" "$asset" > "$fixtures/v$version/SHA256SUMS"
+
+PATH="$fakebin:$PATH" FIXTURE_ROOT="$fixtures" FUNES_INSTALL_DIR="$install" \
+    sh scripts/install.sh >/dev/null
+test "$("$install/funes" --version)" = "funes $version"
+
+sentinel="$work/sentinel"
+executed="$work/executed"
+mkdir -p "$sentinel"
+printf '%s\n' 'existing install' > "$sentinel/funes"
+cat > "$fixtures/v$version/$asset" <<'SH'
+#!/bin/sh
+touch "$EXECUTED"
+echo 'funes 9.9.9'
+SH
+
+if PATH="$fakebin:$PATH" FIXTURE_ROOT="$fixtures" FUNES_INSTALL_DIR="$sentinel" EXECUTED="$executed" \
+    sh scripts/install.sh >/dev/null 2>&1; then
+    echo "installer accepted a binary with the wrong checksum" >&2
+    exit 1
+fi
+test ! -e "$executed"
+test "$(cat "$sentinel/funes")" = "existing install"

--- a/src/update.rs
+++ b/src/update.rs
@@ -103,7 +103,9 @@ pub async fn run(force: bool) -> Result<()> {
 
     let release_version = read_release_version(&tagged_version).with_context(|| format!("validating {tag}/VERSION"))?;
     if release_version != latest {
-        bail!("release metadata for {tag} reports version {release_version} — nothing changed");
+        bail!(
+            "release metadata mismatch: {tag}/VERSION reports {release_version}, expected {latest}; update aborted and the installed binary was left unchanged"
+        );
     }
 
     let installed = install_verified(&staged, &exe, &manifest, asset, &latest)?;

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,18 +1,19 @@
 //! `funes update`: replace the running binary in place with the latest release, and the
 //! version check behind `funes status`'s "update available" notice.
 //!
-//! Both read from the same Hugging Face bucket `install.sh` and the binary download use — a
-//! plain `VERSION` marker at the bucket root (written by the release workflow) for the latest
-//! version, and `<asset>` for the binary — via hf-hub, so there's one host and one failure
-//! mode. The self-replace is the standard unix trick: you can't open the running executable
-//! for writing (ETXTBSY), but you can `rename` a freshly-downloaded file over its path — the
-//! live process keeps its original inode, and the next run picks up the new binary.
+//! The root `VERSION` marker resolves latest to a tagged directory containing `VERSION`,
+//! `SHA256SUMS`, and the binaries. The checksum and tagged version are verified before a binary is
+//! made executable. Replacement uses a same-filesystem rename, so the live process keeps its old
+//! inode and the next run picks up the new binary.
 
 use crate::hub;
 use anyhow::{anyhow, bail, Context, Result};
 use hf_hub::buckets::BucketDownload;
 use hf_hub::HFBucket;
-use std::fs::Permissions;
+use sha2::{Digest, Sha256};
+use std::collections::HashSet;
+use std::fs::{File, Permissions};
+use std::io::Read;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::process::Command;
@@ -59,6 +60,7 @@ pub async fn run(force: bool) -> Result<()> {
     let latest = fetch_latest_version(&bucket)
         .await
         .context("checking the latest funes version")?;
+    let tag = format!("v{latest}");
 
     // Compare when both parse; if either is unreadable, proceed rather than block an update.
     let up_to_date = matches!(
@@ -84,37 +86,45 @@ pub async fn run(force: bool) -> Result<()> {
         )
     })?;
     let staged = staging.path().join("funes");
+    let manifest = staging.path().join("SHA256SUMS");
+    let tagged_version = staging.path().join("VERSION");
 
     println!("Downloading funes {latest} ({asset})…");
     bucket
         .download_files()
-        .files(vec![BucketDownload::new(asset, &staged)])
+        .files(vec![
+            BucketDownload::new(format!("{tag}/{asset}"), &staged),
+            BucketDownload::new(format!("{tag}/SHA256SUMS"), &manifest),
+            BucketDownload::new(format!("{tag}/VERSION"), &tagged_version),
+        ])
         .send()
         .await
-        .with_context(|| format!("downloading {asset} from the {BUCKET_OWNER}/{BUCKET_NAME} bucket"))?;
+        .with_context(|| format!("downloading {tag} from the {BUCKET_OWNER}/{BUCKET_NAME} bucket"))?;
 
-    let installed = install_over(&staged, &exe)?;
+    let release_version = read_release_version(&tagged_version).with_context(|| format!("validating {tag}/VERSION"))?;
+    if release_version != latest {
+        bail!("release metadata for {tag} reports version {release_version} — nothing changed");
+    }
+
+    let installed = install_verified(&staged, &exe, &manifest, asset, &latest)?;
     println!("Updated {} ({current} → {installed}).", exe.display());
     println!("Running agents keep using the old funes until you restart them or start a new session.");
     Ok(())
 }
 
-/// Make the staged binary runnable, run it once to confirm it executes on this platform, then
-/// atomically rename it over `exe` with the existing binary's permissions. Returns the version the
-/// new binary reports. A truncated, corrupt, or wrong-arch download fails the verify step and
-/// never lands on PATH.
-fn install_over(staged: &Path, exe: &Path) -> Result<String> {
+/// Verify the staged binary, confirm its reported version, and atomically rename it over `exe`.
+fn install_verified(staged: &Path, exe: &Path, manifest: &Path, asset: &str, expected_version: &str) -> Result<String> {
+    verify_checksum(staged, manifest, asset)?;
     std::fs::set_permissions(staged, Permissions::from_mode(0o755)).context("making the new binary executable")?;
 
     let out = verify_runs(staged)?;
     if !out.status.success() {
         bail!("the downloaded binary failed to run (corrupt download, or wrong platform) — nothing changed");
     }
-    let installed = String::from_utf8_lossy(&out.stdout)
-        .trim()
-        .trim_start_matches("funes")
-        .trim()
-        .to_string();
+    let reported = String::from_utf8(out.stdout).context("reading the downloaded binary's version")?;
+    if reported.trim() != format!("funes {expected_version}") {
+        bail!("the downloaded binary does not report the expected version {expected_version} — nothing changed");
+    }
 
     // Preserve the existing binary's mode so an update never broadens it (e.g. 0700 → 0755); fall
     // back to 0755 when there's no existing binary to copy the mode from.
@@ -132,7 +142,69 @@ fn install_over(staged: &Path, exe: &Path) -> Result<String> {
             exe.parent().unwrap_or(exe).display(),
         )
     })?;
-    Ok(installed)
+    Ok(expected_version.to_string())
+}
+
+/// Verify `asset` against its one unambiguous entry in a strict SHA256SUMS manifest.
+fn verify_checksum(path: &Path, manifest: &Path, asset: &str) -> Result<()> {
+    let text = std::fs::read_to_string(manifest).context("reading SHA256SUMS")?;
+    let expected = expected_digest(&text, asset)?;
+    let actual = sha256_file(path)?;
+    if actual != expected {
+        bail!("checksum verification failed for {asset} — nothing changed");
+    }
+    Ok(())
+}
+
+fn expected_digest(manifest: &str, asset: &str) -> Result<[u8; 32]> {
+    let mut names = HashSet::new();
+    let mut expected = None;
+
+    for (index, line) in manifest.lines().enumerate() {
+        let line_number = index + 1;
+        let mut fields = line.split_ascii_whitespace();
+        let digest = fields
+            .next()
+            .ok_or_else(|| anyhow!("SHA256SUMS line {line_number} is empty"))?;
+        let name = fields
+            .next()
+            .ok_or_else(|| anyhow!("SHA256SUMS line {line_number} has no asset name"))?;
+        if fields.next().is_some() || name.contains('/') {
+            bail!("SHA256SUMS line {line_number} is malformed");
+        }
+        if digest.len() != 64
+            || !digest
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        {
+            bail!("SHA256SUMS line {line_number} has an invalid digest");
+        }
+        if !names.insert(name) {
+            bail!("SHA256SUMS contains duplicate entries for {name}");
+        }
+        if name == asset {
+            let bytes = hex::decode(digest).context("decoding the release checksum")?;
+            expected = Some(bytes.try_into().expect("a 64-character hex digest is 32 bytes"));
+        }
+    }
+
+    expected.ok_or_else(|| anyhow!("SHA256SUMS does not contain {asset}"))
+}
+
+fn sha256_file(path: &Path) -> Result<[u8; 32]> {
+    let mut file = File::open(path).with_context(|| format!("opening {} for checksum verification", path.display()))?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .with_context(|| format!("reading {} for checksum verification", path.display()))?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(hasher.finalize().into())
 }
 
 /// Run `<path> --version`, retrying briefly on `ETXTBSY`. A just-written executable can
@@ -198,8 +270,26 @@ async fn fetch_latest_version(bucket: &HFBucket) -> Result<String> {
         .send()
         .await
         .context("downloading the VERSION marker from the bucket")?;
-    let text = std::fs::read_to_string(&path).context("reading the VERSION marker")?;
-    Ok(text.trim().to_string())
+    read_release_version(&path).context("reading the VERSION marker")
+}
+
+fn read_release_version(path: &Path) -> Result<String> {
+    let text = std::fs::read_to_string(path).context("reading release version metadata")?;
+    let mut tokens = text.split_ascii_whitespace();
+    let raw = tokens.next().ok_or_else(|| anyhow!("release version is empty"))?;
+    if tokens.next().is_some() {
+        bail!("release version must contain exactly one value");
+    }
+    let version = raw.strip_prefix('v').unwrap_or(raw);
+    let parts: Vec<_> = version.split('.').collect();
+    if parts.len() != 3
+        || parts
+            .iter()
+            .any(|part| part.is_empty() || !part.bytes().all(|byte| byte.is_ascii_digit()))
+    {
+        bail!("release version must have the form MAJOR.MINOR.PATCH");
+    }
+    Ok(version.to_string())
 }
 
 /// Parse a leading `MAJOR.MINOR.PATCH` (tolerates a `v` prefix, extra tokens, and a
@@ -219,29 +309,32 @@ pub(crate) fn parse_semver(s: &str) -> Option<(u32, u32, u32)> {
 
 #[cfg(test)]
 mod tests {
-    use super::{install_over, notice_for, parse_semver};
+    use super::{expected_digest, install_verified, notice_for, parse_semver, read_release_version, sha256_file};
+    use std::path::Path;
+
+    fn write_manifest(path: &Path, binary: &Path, asset: &str) {
+        let digest = hex::encode(sha256_file(binary).unwrap());
+        std::fs::write(path, format!("{digest}  {asset}\n")).unwrap();
+    }
 
     #[test]
-    fn install_over_verifies_then_atomically_replaces() {
+    fn install_verified_atomically_replaces() {
         use std::fs::Permissions;
         use std::os::unix::fs::PermissionsExt;
 
-        // A stand-in "binary" that reports a version, like `funes --version` would.
         let dir = tempfile::tempdir().unwrap();
         let staged = dir.path().join("staged");
         std::fs::write(&staged, "#!/bin/sh\necho 'funes 9.9.9'\n").unwrap();
+        let manifest = dir.path().join("SHA256SUMS");
+        write_manifest(&manifest, &staged, "funes-test");
         let exe = dir.path().join("funes");
         std::fs::write(&exe, "old binary").unwrap();
-        // The existing binary is user-only (0700): the update must preserve this, not broaden it.
         std::fs::set_permissions(&exe, Permissions::from_mode(0o700)).unwrap();
 
-        // install_over makes it runnable, runs it to verify, and renames it over the target.
-        let installed = install_over(&staged, &exe).unwrap();
-        assert_eq!(installed, "9.9.9"); // reported version, `funes` prefix stripped (so verify ran it)
-        assert!(!staged.exists()); // staged was moved, not copied
+        let installed = install_verified(&staged, &exe, &manifest, "funes-test", "9.9.9").unwrap();
+        assert_eq!(installed, "9.9.9");
+        assert!(!staged.exists());
 
-        // Compared by content, not a second exec (which would reintroduce the fork/exec race under
-        // parallel tests): the target now holds the staged binary, with the preserved 0700 mode.
         assert_eq!(
             std::fs::read_to_string(&exe).unwrap(),
             "#!/bin/sh\necho 'funes 9.9.9'\n"
@@ -250,17 +343,73 @@ mod tests {
     }
 
     #[test]
-    fn install_over_rejects_a_binary_that_will_not_run() {
-        // A non-executable, non-binary staged file: the verify step must fail and leave the
-        // target untouched — a bad download never lands on PATH.
+    fn checksum_mismatch_is_rejected_before_execution() {
+        use std::os::unix::fs::PermissionsExt;
+
         let dir = tempfile::tempdir().unwrap();
         let staged = dir.path().join("staged");
-        std::fs::write(&staged, "not a real binary").unwrap();
+        let marker = dir.path().join("executed");
+        std::fs::write(
+            &staged,
+            format!("#!/bin/sh\ntouch {}\necho 'funes 9.9.9'\n", marker.display()),
+        )
+        .unwrap();
+        let manifest = dir.path().join("SHA256SUMS");
+        std::fs::write(&manifest, format!("{}  funes-test\n", "0".repeat(64))).unwrap();
         let exe = dir.path().join("funes");
         std::fs::write(&exe, "old binary").unwrap();
 
-        assert!(install_over(&staged, &exe).is_err());
-        assert_eq!(std::fs::read_to_string(&exe).unwrap(), "old binary"); // untouched
+        assert!(install_verified(&staged, &exe, &manifest, "funes-test", "9.9.9").is_err());
+        assert!(!marker.exists());
+        assert_eq!(std::fs::metadata(&staged).unwrap().permissions().mode() & 0o111, 0);
+        assert_eq!(std::fs::read_to_string(&exe).unwrap(), "old binary");
+    }
+
+    #[test]
+    fn reported_version_mismatch_does_not_replace() {
+        let dir = tempfile::tempdir().unwrap();
+        let staged = dir.path().join("staged");
+        std::fs::write(&staged, "#!/bin/sh\necho 'funes 9.9.8'\n").unwrap();
+        let manifest = dir.path().join("SHA256SUMS");
+        write_manifest(&manifest, &staged, "funes-test");
+        let exe = dir.path().join("funes");
+        std::fs::write(&exe, "old binary").unwrap();
+
+        assert!(install_verified(&staged, &exe, &manifest, "funes-test", "9.9.9").is_err());
+        assert_eq!(std::fs::read_to_string(&exe).unwrap(), "old binary");
+    }
+
+    #[test]
+    fn checksum_manifest_is_strict_and_target_bound() {
+        let a = "1".repeat(64);
+        let b = "2".repeat(64);
+        let valid = format!("{a}  funes-a\n{b}  funes-b\n");
+        assert_eq!(expected_digest(&valid, "funes-b").unwrap(), [0x22; 32]);
+
+        for malformed in [
+            format!("{a}  funes-a extra\n"),
+            format!("{}  funes-a\n", "A".repeat(64)),
+            format!("{a}  nested/funes-a\n"),
+            format!("{a}  funes-a\n{b}  funes-a\n"),
+            "\n".to_string(),
+        ] {
+            assert!(expected_digest(&malformed, "funes-a").is_err(), "{malformed:?}");
+        }
+        assert!(expected_digest(&valid, "missing").is_err());
+    }
+
+    #[test]
+    fn release_version_metadata_is_strict() {
+        let dir = tempfile::tempdir().unwrap();
+        let version = dir.path().join("VERSION");
+        for (text, expected) in [("1.2.3\n", "1.2.3"), ("v1.2.3", "1.2.3")] {
+            std::fs::write(&version, text).unwrap();
+            assert_eq!(read_release_version(&version).unwrap(), expected);
+        }
+        for malformed in ["", "1.2", "1.2.3 extra", "1.2.x", "1..3"] {
+            std::fs::write(&version, malformed).unwrap();
+            assert!(read_release_version(&version).is_err(), "{malformed:?}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
This pull request introduces a secure, checksum-verified installer and release process for the `funes` project. The installer script now verifies downloaded binaries against release metadata before installation, and the release workflow generates and validates checksums for all release assets. The workflows and documentation have been updated accordingly, and automated installer tests have been added.

These changes significantly improve the reliability of binary distribution and installation for `funes`.