### PR TITLE
Fix/hermes optional cwd

### DIFF
--- a/src/hermes_traces.rs
+++ b/src/hermes_traces.rs
@@ -1,7 +1,7 @@
 //! Parse hermes sessions from its SQLite state store (`~/.hermes/state.db`) into the shared
 //! [`crate::trace`] turn/block model. Unlike Claude/Codex/pi (one JSONL file per session), hermes
 //! keeps every session's messages in one WAL SQLite DB: a `sessions` table (one row per session,
-//! carrying `cwd`) and a `messages` table (one row per message, ordered by the `id` autoincrement).
+//! optionally carrying `cwd`) and a `messages` table (one row per message, ordered by the `id`).
 //!
 //! One `messages` row becomes one [`Turn`]: `user`/`assistant`/`tool` roles map straight across,
 //! an assistant row expands into thinking (`reasoning_content`) + text (`content`) + tool_use
@@ -38,9 +38,21 @@ fn open_ro(db: &Path) -> Result<Connection> {
         .with_context(|| format!("opening hermes state.db at {}", db.display()))
 }
 
+/// Whether the `sessions` table has a `cwd` column. Hermes schema versions differ — some omit it —
+/// and naming a missing column is a hard SQL error, not a NULL, so callers probe before selecting
+/// it; without it the workdir facet just falls back.
+fn sessions_has_cwd(conn: &Connection) -> Result<bool> {
+    Ok(conn
+        .prepare("SELECT 1 FROM pragma_table_info('sessions') WHERE name = 'cwd'")?
+        .exists([])?)
+}
+
 /// The workdir facet for a session: its `sessions.cwd`, munged the way every parser munges a cwd,
 /// or `None` when the session has no recorded cwd.
 fn session_workdir(conn: &Connection, session_id: &str) -> Result<Option<String>> {
+    if !sessions_has_cwd(conn)? {
+        return Ok(None);
+    }
     let cwd: Option<String> = conn
         .query_row("SELECT cwd FROM sessions WHERE id = ?1", [session_id], |r| r.get(0))
         .or_else(|e| match e {
@@ -55,14 +67,20 @@ fn session_workdir(conn: &Connection, session_id: &str) -> Result<Option<String>
 /// unchanged since the last index is skipped.
 pub fn sessions_with_watermark(db: &Path) -> Result<Vec<SessionUnit>> {
     let conn = open_ro(db)?;
-    // `messages` drives the query, so a session with no messages is already excluded (nothing to
-    // index) whatever the join. The join is LEFT to tolerate a message whose `session_id` has no
-    // `sessions` row: `sessions.cwd` is then NULL, coalesced to '' (workdir falls back).
-    let mut stmt = conn.prepare(
-        "SELECT m.session_id, COALESCE(s.cwd, ''), MAX(m.id) \
+    // Select `s.cwd` only when the column exists (see `sessions_has_cwd`). The LEFT join tolerates a
+    // message whose `session_id` has no `sessions` row; `messages` driving the query already
+    // excludes sessions with no messages.
+    let cwd = if sessions_has_cwd(&conn)? {
+        "COALESCE(s.cwd, '')"
+    } else {
+        "''"
+    };
+    let sql = format!(
+        "SELECT m.session_id, {cwd}, MAX(m.id) \
          FROM messages m LEFT JOIN sessions s ON s.id = m.session_id \
-         GROUP BY m.session_id ORDER BY m.session_id",
-    )?;
+         GROUP BY m.session_id ORDER BY m.session_id"
+    );
+    let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map([], |r| {
         let session_id: String = r.get(0)?;
         let cwd: String = r.get(1)?;
@@ -283,8 +301,46 @@ mod tests {
         (dir, path)
     }
 
+    /// A temp state.db whose `sessions` table omits `cwd` entirely (the hermes schema_version 11
+    /// shape) — the case that used to crash the index.
+    fn make_db_no_cwd() -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.db");
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE sessions (id TEXT PRIMARY KEY, started_at REAL);
+             CREATE TABLE messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT, session_id TEXT NOT NULL, role TEXT NOT NULL,
+                content TEXT, tool_call_id TEXT, tool_calls TEXT, tool_name TEXT,
+                timestamp REAL NOT NULL, reasoning TEXT, reasoning_content TEXT
+             );",
+        )
+        .unwrap();
+        conn.execute("INSERT INTO sessions (id) VALUES ('sess')", []).unwrap();
+        (dir, path)
+    }
+
     fn insert(path: &Path, sql: &str) {
         Connection::open(path).unwrap().execute_batch(sql).unwrap();
+    }
+
+    #[test]
+    fn tolerates_a_sessions_table_without_cwd() {
+        let (_dir, path) = make_db_no_cwd();
+        insert(
+            &path,
+            "INSERT INTO messages (session_id, role, content, timestamp) \
+             VALUES ('sess','user','hi',1000.0);",
+        );
+        // The watermark query must not crash on the missing `cwd` column.
+        let units = sessions_with_watermark(&path).unwrap();
+        assert_eq!(units.len(), 1);
+        assert_eq!(units[0].session_id, "sess");
+        assert_eq!(units[0].workdir, "", "no cwd column → no workdir facet");
+        // Parsing falls back to the caller's workdir.
+        let turns = turns_from_state_db(&path, "sess", "fallback").unwrap();
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].workdir, "fallback");
     }
 
     #[test]

--- a/src/index.rs
+++ b/src/index.rs
@@ -279,7 +279,7 @@ fn collect_units(sources: &[Box<dyn source::TraceSource>]) -> Result<Vec<(usize,
             Ok(src_units) => units.extend(src_units.into_iter().map(|u| (i, u))),
             Err(e) if isolate => {
                 errors += 1;
-                eprintln!("skipping source ({}): {:#}", src.describe(), e);
+                eprintln!("{}: enumeration failed, skipping — {:#}", src.describe(), e);
             }
             Err(e) => return Err(e.context(src.describe())),
         }

--- a/src/index.rs
+++ b/src/index.rs
@@ -264,6 +264,24 @@ struct Indexer {
     n_chunks: u64,
 }
 
+/// Enumerate every source's units (each source orders its own — recency-desc, subagents last),
+/// tagged with the source index. When several sources are indexed at once (e.g. every known
+/// harness), one that fails to enumerate — say a hermes state.db this build can't read — is warned
+/// and skipped instead of aborting the rest; a lone source stays fatal, since its failure is then
+/// the whole result.
+fn collect_units(sources: &[Box<dyn source::TraceSource>]) -> Result<Vec<(usize, source::Unit)>> {
+    let isolate = sources.len() > 1;
+    let mut units = Vec::new();
+    for (i, src) in sources.iter().enumerate() {
+        match src.units() {
+            Ok(src_units) => units.extend(src_units.into_iter().map(|u| (i, u))),
+            Err(e) if isolate => eprintln!("skipping source ({}): {:#}", src.describe(), e),
+            Err(e) => return Err(e.context(src.describe())),
+        }
+    }
+    Ok(units)
+}
+
 impl Indexer {
     /// Acquire the memory lock, open (or plan to create) the dataset, load incremental state, bring
     /// up the embedder and secret scanner, and enumerate `sources`' units.
@@ -321,13 +339,7 @@ impl Indexer {
             None => HashSet::new(),
         };
 
-        // Each source orders its own units (recency-desc, subagents last); tag each with its source.
-        let mut units = Vec::new();
-        for (i, src) in sources.iter().enumerate() {
-            for unit in src.units()? {
-                units.push((i, unit));
-            }
-        }
+        let units = collect_units(&sources)?;
 
         Ok(Indexer {
             uri,
@@ -809,6 +821,71 @@ fn fmt_eta(d: Duration) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A source whose enumeration yields fixed unit keys, or fails — for `collect_units` tests.
+    struct MockSource {
+        name: &'static str,
+        keys: Vec<&'static str>,
+        fail: bool,
+    }
+
+    impl source::TraceSource for MockSource {
+        fn describe(&self) -> String {
+            self.name.to_string()
+        }
+        fn units(&self) -> Result<Vec<source::Unit>> {
+            if self.fail {
+                anyhow::bail!("enumerate failed: {}", self.name);
+            }
+            Ok(self
+                .keys
+                .iter()
+                .map(|k| source::Unit {
+                    key: k.to_string(),
+                    signature: None,
+                    is_subagent: false,
+                })
+                .collect())
+        }
+        fn read(&self, _: &source::Unit) -> Result<Vec<trace::Turn>> {
+            Ok(vec![])
+        }
+    }
+
+    #[test]
+    fn collect_units_skips_a_failing_source_among_several() {
+        let srcs: Vec<Box<dyn source::TraceSource>> = vec![
+            Box::new(MockSource {
+                name: "good-a",
+                keys: vec!["a1"],
+                fail: false,
+            }),
+            Box::new(MockSource {
+                name: "bad",
+                keys: vec![],
+                fail: true,
+            }),
+            Box::new(MockSource {
+                name: "good-b",
+                keys: vec!["b1", "b2"],
+                fail: false,
+            }),
+        ];
+        let units = collect_units(&srcs).unwrap();
+        // The failing source (index 1) is skipped; the others keep their source-tagged units.
+        let got: Vec<(usize, &str)> = units.iter().map(|(i, u)| (*i, u.key.as_str())).collect();
+        assert_eq!(got, vec![(0, "a1"), (2, "b1"), (2, "b2")]);
+    }
+
+    #[test]
+    fn collect_units_is_fatal_for_a_lone_failing_source() {
+        let srcs: Vec<Box<dyn source::TraceSource>> = vec![Box::new(MockSource {
+            name: "only",
+            keys: vec![],
+            fail: true,
+        })];
+        assert!(collect_units(&srcs).is_err());
+    }
 
     #[test]
     fn unit_current_needs_matching_sig_and_reached_target_tier() {

--- a/src/index.rs
+++ b/src/index.rs
@@ -268,16 +268,29 @@ struct Indexer {
 /// tagged with the source index. When several sources are indexed at once (e.g. every known
 /// harness), one that fails to enumerate — say a hermes state.db this build can't read — is warned
 /// and skipped instead of aborting the rest; a lone source stays fatal, since its failure is then
-/// the whole result.
+/// the whole result. But if the skips left nothing to index and at least one source errored, that's
+/// a failure, not a silent success — whereas an all-empty run with no errors is a legitimate no-op.
 fn collect_units(sources: &[Box<dyn source::TraceSource>]) -> Result<Vec<(usize, source::Unit)>> {
     let isolate = sources.len() > 1;
     let mut units = Vec::new();
+    let mut errors = 0usize;
     for (i, src) in sources.iter().enumerate() {
         match src.units() {
             Ok(src_units) => units.extend(src_units.into_iter().map(|u| (i, u))),
-            Err(e) if isolate => eprintln!("skipping source ({}): {:#}", src.describe(), e),
+            Err(e) if isolate => {
+                errors += 1;
+                eprintln!("skipping source ({}): {:#}", src.describe(), e);
+            }
             Err(e) => return Err(e.context(src.describe())),
         }
+    }
+    // `errors > 0` implies the isolate path (a lone failure returned above), so this fires only
+    // when every collected source was empty and at least one was skipped for erroring.
+    if units.is_empty() && errors > 0 {
+        anyhow::bail!(
+            "no sessions to index — {errors} of {} sources failed to enumerate (see the warnings above)",
+            sources.len()
+        );
     }
     Ok(units)
 }
@@ -885,6 +898,42 @@ mod tests {
             fail: true,
         })];
         assert!(collect_units(&srcs).is_err());
+    }
+
+    #[test]
+    fn collect_units_fails_when_every_source_errors_and_nothing_is_collected() {
+        let srcs: Vec<Box<dyn source::TraceSource>> = vec![
+            Box::new(MockSource {
+                name: "bad-a",
+                keys: vec![],
+                fail: true,
+            }),
+            Box::new(MockSource {
+                name: "bad-b",
+                keys: vec![],
+                fail: true,
+            }),
+        ];
+        // 0 units + a skipped error must not look like a successful no-op.
+        assert!(collect_units(&srcs).is_err());
+    }
+
+    #[test]
+    fn collect_units_is_a_noop_for_empty_sources_without_errors() {
+        let srcs: Vec<Box<dyn source::TraceSource>> = vec![
+            Box::new(MockSource {
+                name: "empty-a",
+                keys: vec![],
+                fail: false,
+            }),
+            Box::new(MockSource {
+                name: "empty-b",
+                keys: vec![],
+                fail: false,
+            }),
+        ];
+        // Nothing to index but nothing errored → a legitimate empty result, not a failure.
+        assert!(collect_units(&srcs).unwrap().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Older versions of the Hermes client might not have the same schema as the one we expect.

This also makes sure failing to index for one harness does not stop indexing the others. 