### PR TITLE
Improve status report

### DIFF
--- a/docs/push.md
+++ b/docs/push.md
@@ -87,11 +87,14 @@ funes curate <memory> --include <session> --exclude <session>
 
 ```bash
 funes status                 # memory label, chunk/session counts, last indexed (and an update check)
-funes status <org>/<repo>    # …for a remote memory
+funes status <org>/<repo>    # …and what this host has or has not pushed there
 ```
 
 `funes status` tells you whether recall is reading your own memory yet, and whether a newer funes
-release is out.
+release is out. For a personal remote memory it reports how many local sessions are fully pushed
+and how many have new or unpushed chunks. This comes from a per-remote receipt kept on this host,
+so sessions contributed by other hosts do not distort the result and status never scans the remote
+to compute it. Run `funes push <memory>` once to initialize the receipt for an existing memory.
 
 ## See also
 

--- a/docs/push.md
+++ b/docs/push.md
@@ -91,12 +91,13 @@ funes status <org>/<repo>    # …and what this host has or has not pushed there
 ```
 
 `funes status` tells you whether recall is reading your own memory yet, and whether a newer funes
-release is out. When work exists, local-index sections report how many source sessions need indexing
-and the command to run; an up-to-date index stays quiet. For a personal remote memory, one `local
-push` line says either that this host is up to date or how many local sessions are pending. This
-comes from a per-remote receipt kept on this host, so sessions contributed by other hosts do not
-distort the result and status never scans the remote to compute it. Run `funes push <memory>` once
-to initialize the receipt for an existing memory.
+release is out. When work exists, local-index sections report how many source sessions the latest
+indexing sweep left pending and the command to run; a completed sweep stays quiet. The status read
+uses the sweep's small coverage snapshot rather than recursively scanning transcript trees. For a
+personal remote memory, one `local push` line says either that this host is up to date or how many
+local sessions are pending. This comes from a per-remote receipt kept on this host, so sessions
+contributed by other hosts do not distort the result and status never scans the remote to compute
+it. Run `funes push <memory>` once to initialize the receipt for an existing memory.
 
 ## See also
 

--- a/docs/push.md
+++ b/docs/push.md
@@ -91,10 +91,12 @@ funes status <org>/<repo>    # …and what this host has or has not pushed there
 ```
 
 `funes status` tells you whether recall is reading your own memory yet, and whether a newer funes
-release is out. For a personal remote memory it reports how many local sessions are fully pushed
-and how many have new or unpushed chunks. This comes from a per-remote receipt kept on this host,
-so sessions contributed by other hosts do not distort the result and status never scans the remote
-to compute it. Run `funes push <memory>` once to initialize the receipt for an existing memory.
+release is out. Local-index sections also report native sessions still pending a full index, using
+the lightweight transcript signatures in `state.json`. For a personal remote memory, status reports
+how many local sessions are fully pushed and how many have new or unpushed chunks. This comes from
+a per-remote receipt kept on this host, so sessions contributed by other hosts do not distort the
+result and status never scans the remote to compute it. Run `funes push <memory>` once to initialize
+the receipt for an existing memory.
 
 ## See also
 

--- a/docs/push.md
+++ b/docs/push.md
@@ -91,12 +91,12 @@ funes status <org>/<repo>    # …and what this host has or has not pushed there
 ```
 
 `funes status` tells you whether recall is reading your own memory yet, and whether a newer funes
-release is out. Local-index sections also report native sessions still pending a full index, using
-the lightweight transcript signatures in `state.json`. For a personal remote memory, status reports
-how many local sessions are fully pushed and how many have new or unpushed chunks. This comes from
-a per-remote receipt kept on this host, so sessions contributed by other hosts do not distort the
-result and status never scans the remote to compute it. Run `funes push <memory>` once to initialize
-the receipt for an existing memory.
+release is out. When work exists, local-index sections report how many source sessions need indexing
+and the command to run; an up-to-date index stays quiet. For a personal remote memory, one `local
+push` line says either that this host is up to date or how many local sessions are pending. This
+comes from a per-remote receipt kept on this host, so sessions contributed by other hosts do not
+distort the result and status never scans the remote to compute it. Run `funes push <memory>` once
+to initialize the receipt for an existing memory.
 
 ## See also
 

--- a/src/curate.rs
+++ b/src/curate.rs
@@ -195,7 +195,7 @@ pub fn file_for(memory_uri: &str) -> PathBuf {
 
 /// A memory URI as a filename — every path-hostile byte becomes `_`, deterministically, so the
 /// canonical `hf://…` URI always maps to the same file.
-fn sanitize(uri: &str) -> String {
+pub(crate) fn sanitize(uri: &str) -> String {
     uri.chars()
         .map(|c| {
             if c.is_ascii_alphanumeric() || c == '-' || c == '.' {

--- a/src/index.rs
+++ b/src/index.rs
@@ -230,7 +230,6 @@ fn unit_current(entry: Option<&UnitState>, sig: &str, target: Tier) -> bool {
 /// Lightweight coverage of the native session sources present on this host. This uses only unit
 /// enumeration/stat signatures plus `state.json`; it never parses transcripts or starts inference.
 pub(crate) struct IndexCoverage {
-    pub total: usize,
     pub pending: usize,
 }
 
@@ -244,10 +243,7 @@ fn index_coverage(units: &[source::Unit], state: &HashMap<String, UnitState>) ->
                 .is_none_or(|sig| !unit_current(state.get(&unit.key), sig, target))
         })
         .count();
-    IndexCoverage {
-        total: units.len(),
-        pending,
-    }
+    IndexCoverage { pending }
 }
 
 /// Current native sessions that have not reached every indexing tier. `None` means the local
@@ -1040,7 +1036,6 @@ mod tests {
             ),
         ]);
         let coverage = index_coverage(&units, &state);
-        assert_eq!(coverage.total, 5);
         assert_eq!(coverage.pending, 4);
     }
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -227,6 +227,48 @@ fn unit_current(entry: Option<&UnitState>, sig: &str, target: Tier) -> bool {
     entry.is_some_and(|e| e.sig == sig && e.level >= target)
 }
 
+/// Lightweight coverage of the native session sources present on this host. This uses only unit
+/// enumeration/stat signatures plus `state.json`; it never parses transcripts or starts inference.
+pub(crate) struct IndexCoverage {
+    pub total: usize,
+    pub pending: usize,
+}
+
+fn index_coverage(units: &[source::Unit], state: &HashMap<String, UnitState>) -> IndexCoverage {
+    let target = *Tier::ALL.iter().max().expect("Tier::ALL is non-empty");
+    let pending = units
+        .iter()
+        .filter(|unit| {
+            unit.signature
+                .as_ref()
+                .is_none_or(|sig| !unit_current(state.get(&unit.key), sig, target))
+        })
+        .count();
+    IndexCoverage {
+        total: units.len(),
+        pending,
+    }
+}
+
+/// Current native sessions that have not reached every indexing tier. `None` means the local
+/// incremental state is absent/unreadable or every present source failed to enumerate; status then
+/// omits the line rather than guessing from the Lance rows.
+pub(crate) fn local_index_coverage() -> Option<IndexCoverage> {
+    let state: HashMap<String, UnitState> = std::fs::read_to_string(dataset::funes_dir().join("state.json"))
+        .ok()
+        .and_then(|text| serde_json::from_str(&text).ok())?;
+    let roots = crate::harness::known_harness_roots();
+    let mut units = Vec::new();
+    let mut enumerated = false;
+    for (path, harness) in roots {
+        if let Ok(found) = source::open_with_harness(&path, None, Some(harness)).units() {
+            enumerated = true;
+            units.extend(found);
+        }
+    }
+    enumerated.then(|| index_coverage(&units, &state))
+}
+
 /// A set-up indexer: it holds the memory lock, embedder, dataset, redaction scanner, and incremental
 /// state, so a caller can index units in whatever batches it likes — one at a time to check the
 /// clock between them, or all at once — without reloading the model. Build the indexes once at the
@@ -958,6 +1000,48 @@ mod tests {
         assert!(unit_current(Some(&full), "10:20", Tier::ToolResult));
         // No record → not current.
         assert!(!unit_current(None, "10:20", Tier::Text));
+    }
+
+    #[test]
+    fn index_coverage_counts_stale_partial_and_unrecorded_units() {
+        let unit = |key: &str, sig: Option<&str>| source::Unit {
+            key: key.to_string(),
+            signature: sig.map(str::to_string),
+            is_subagent: false,
+        };
+        let units = vec![
+            unit("current", Some("1")),
+            unit("partial", Some("2")),
+            unit("stale", Some("new")),
+            unit("new", Some("4")),
+            unit("unsigned", None),
+        ];
+        let state = HashMap::from([
+            (
+                "current".to_string(),
+                UnitState {
+                    sig: "1".into(),
+                    level: Tier::ToolResult,
+                },
+            ),
+            (
+                "partial".to_string(),
+                UnitState {
+                    sig: "2".into(),
+                    level: Tier::Text,
+                },
+            ),
+            (
+                "stale".to_string(),
+                UnitState {
+                    sig: "old".into(),
+                    level: Tier::ToolResult,
+                },
+            ),
+        ]);
+        let coverage = index_coverage(&units, &state);
+        assert_eq!(coverage.total, 5);
+        assert_eq!(coverage.pending, 4);
     }
 
     #[test]

--- a/src/index.rs
+++ b/src/index.rs
@@ -11,7 +11,7 @@ use crate::chunk::{self, Tier};
 use crate::harness::Harness;
 use crate::inference::{self, Embedder};
 use crate::{dataset, hub, lock, repo, scan, source, trace};
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use arrow_array::types::Float32Type;
 use arrow_array::{Array, FixedSizeListArray, Int64Array, RecordBatch, RecordBatchIterator, StringArray};
 use arrow_schema::{DataType, Field, Schema};
@@ -227,42 +227,65 @@ fn unit_current(entry: Option<&UnitState>, sig: &str, target: Tier) -> bool {
     entry.is_some_and(|e| e.sig == sig && e.level >= target)
 }
 
-/// Lightweight coverage of the native session sources present on this host. This uses only unit
-/// enumeration/stat signatures plus `state.json`; it never parses transcripts or starts inference.
+/// Lightweight coverage snapshot written by indexing runs for `status` to read without walking
+/// the transcript trees again.
+#[derive(Serialize, Deserialize, Default)]
+struct IndexCoverageSnapshot {
+    pending: HashSet<String>,
+}
+
 pub(crate) struct IndexCoverage {
     pub pending: usize,
 }
 
-fn index_coverage(units: &[source::Unit], state: &HashMap<String, UnitState>) -> IndexCoverage {
+fn update_index_coverage<'a>(
+    mut snapshot: IndexCoverageSnapshot,
+    units: impl IntoIterator<Item = &'a source::Unit>,
+    state: &HashMap<String, UnitState>,
+) -> IndexCoverageSnapshot {
     let target = *Tier::ALL.iter().max().expect("Tier::ALL is non-empty");
-    let pending = units
-        .iter()
-        .filter(|unit| {
-            unit.signature
-                .as_ref()
-                .is_none_or(|sig| !unit_current(state.get(&unit.key), sig, target))
-        })
-        .count();
-    IndexCoverage { pending }
-}
-
-/// Current native sessions that have not reached every indexing tier. `None` means the local
-/// incremental state is absent/unreadable or every present source failed to enumerate; status then
-/// omits the line rather than guessing from the Lance rows.
-pub(crate) fn local_index_coverage() -> Option<IndexCoverage> {
-    let state: HashMap<String, UnitState> = std::fs::read_to_string(dataset::funes_dir().join("state.json"))
-        .ok()
-        .and_then(|text| serde_json::from_str(&text).ok())?;
-    let roots = crate::harness::known_harness_roots();
-    let mut units = Vec::new();
-    let mut enumerated = false;
-    for (path, harness) in roots {
-        if let Ok(found) = source::open_with_harness(&path, None, Some(harness)).units() {
-            enumerated = true;
-            units.extend(found);
+    for unit in units {
+        // Native sessions have incremental signatures. Bulk parquet and remote imports do not
+        // belong in the local-session status snapshot (and unsigned units never become current).
+        let Some(sig) = &unit.signature else {
+            continue;
+        };
+        if unit.key.starts_with("hf://") {
+            continue;
+        }
+        if unit_current(state.get(&unit.key), sig, target) {
+            snapshot.pending.remove(&unit.key);
+        } else {
+            snapshot.pending.insert(unit.key.clone());
         }
     }
-    enumerated.then(|| index_coverage(&units, &state))
+    snapshot
+}
+
+fn write_index_coverage(
+    path: &Path,
+    units: &[(usize, source::Unit)],
+    state: &HashMap<String, UnitState>,
+) -> Result<()> {
+    let snapshot = std::fs::read_to_string(path)
+        .ok()
+        .and_then(|text| serde_json::from_str(&text).ok())
+        .unwrap_or_default();
+    let snapshot = update_index_coverage(snapshot, units.iter().map(|(_, unit)| unit), state);
+    std::fs::write(path, serde_json::to_string(&snapshot)?)
+        .with_context(|| format!("writing index coverage at {}", path.display()))
+}
+
+/// Native sessions that the most recent indexing sweep found short of a complete index. `None`
+/// means no sweep has written a readable snapshot yet; status omits the line rather than doing an
+/// unbounded recursive transcript scan.
+pub(crate) fn local_index_coverage() -> Option<IndexCoverage> {
+    std::fs::read_to_string(dataset::funes_dir().join("index-coverage.json"))
+        .ok()
+        .and_then(|text| serde_json::from_str::<IndexCoverageSnapshot>(&text).ok())
+        .map(|snapshot| IndexCoverage {
+            pending: snapshot.pending.len(),
+        })
 }
 
 /// A set-up indexer: it holds the memory lock, embedder, dataset, redaction scanner, and incremental
@@ -281,6 +304,7 @@ struct Indexer {
     repo_cache: HashMap<String, String>,
     state: HashMap<String, UnitState>,
     state_path: PathBuf,
+    coverage_path: PathBuf,
     /// The memory didn't exist when this run opened it — the first index.
     first_index: bool,
     /// A human is watching (stdin is a terminal) — probed once here, so every prompt-or-proceed
@@ -364,6 +388,7 @@ impl Indexer {
         // empty. A first index (memory missing) owes everything, whatever an old state.json says — a
         // stale one would silently skip every unit against the empty memory.
         let state_path = dir.join("state.json");
+        let coverage_path = dir.join("index-coverage.json");
         let state = if first_index {
             HashMap::new()
         } else {
@@ -391,6 +416,7 @@ impl Indexer {
         };
 
         let units = collect_units(&sources)?;
+        write_index_coverage(&coverage_path, &units, &state)?;
 
         Ok(Indexer {
             uri,
@@ -402,6 +428,7 @@ impl Indexer {
             repo_cache: HashMap::new(),
             state,
             state_path,
+            coverage_path,
             first_index,
             interactive,
             work_remaining: false,
@@ -516,6 +543,7 @@ impl Indexer {
                 },
             );
             std::fs::write(&self.state_path, serde_json::to_string_pretty(&self.state)?)?;
+            write_index_coverage(&self.coverage_path, &self.units, &self.state)?;
         }
         // Count a unit's sessions once per run — later tier passes over it only add chunks.
         if self.counted.insert(i) {
@@ -999,18 +1027,19 @@ mod tests {
     }
 
     #[test]
-    fn index_coverage_counts_stale_partial_and_unrecorded_units() {
+    fn index_coverage_merges_native_pending_units_across_sweeps() {
         let unit = |key: &str, sig: Option<&str>| source::Unit {
             key: key.to_string(),
             signature: sig.map(str::to_string),
             is_subagent: false,
         };
-        let units = vec![
+        let first = vec![
             unit("current", Some("1")),
             unit("partial", Some("2")),
             unit("stale", Some("new")),
             unit("new", Some("4")),
             unit("unsigned", None),
+            unit("hf://datasets/acme/traces/shard.parquet", Some("oid")),
         ];
         let state = HashMap::from([
             (
@@ -1035,8 +1064,16 @@ mod tests {
                 },
             ),
         ]);
-        let coverage = index_coverage(&units, &state);
-        assert_eq!(coverage.pending, 4);
+        let snapshot = update_index_coverage(IndexCoverageSnapshot::default(), &first, &state);
+        assert_eq!(
+            snapshot.pending,
+            ["partial", "stale", "new"].into_iter().map(str::to_string).collect()
+        );
+
+        let second = [unit("other-harness", Some("5"))];
+        let snapshot = update_index_coverage(snapshot, &second, &state);
+        assert!(snapshot.pending.contains("partial"));
+        assert!(snapshot.pending.contains("other-harness"));
     }
 
     #[test]

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -124,7 +124,7 @@ impl Funes {
     }
 
     #[tool(
-        description = "Show funes memory status: chunk and session counts, when it was last indexed, and — for a remote memory — the last push."
+        description = "Show funes memory status: chunk and session counts, pending local indexing, and — for a remote memory — last push plus this host's pending push coverage."
     )]
     async fn status(&self, Parameters(StatusRequest { memory }): Parameters<StatusRequest>) -> String {
         // No update check here: it needs the network, and the "update available" notice belongs

--- a/src/push.rs
+++ b/src/push.rs
@@ -133,7 +133,6 @@ fn record_pushed<'a>(memory_uri: &str, ids: impl IntoIterator<Item = &'a String>
 /// `pending` until its new chunks are pushed.
 pub(crate) struct PushCoverage {
     pub total: usize,
-    pub pushed: usize,
     pub pending: usize,
 }
 
@@ -156,7 +155,6 @@ fn push_coverage(batches: &[RecordBatch], pushed_ids: &HashSet<String>) -> Optio
     let pushed = complete.values().filter(|&&all| all).count();
     Some(PushCoverage {
         total: complete.len(),
-        pushed,
         pending: complete.len() - pushed,
     })
 }
@@ -869,7 +867,6 @@ mod tests {
             .unwrap();
         let coverage = push_coverage(&batches, &pushed).unwrap();
         assert_eq!(coverage.total, 2);
-        assert_eq!(coverage.pushed, 1);
         assert_eq!(coverage.pending, 1);
     }
 

--- a/src/push.rs
+++ b/src/push.rs
@@ -32,6 +32,7 @@ use chrono::Utc;
 use hf_hub::{HFError, HFRepository, RepoTypeDataset};
 use lance::Dataset;
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::fs::File;
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -103,6 +104,22 @@ fn load_pushed(memory_uri: &str) -> Option<HashSet<String>> {
 }
 
 fn record_pushed_at<'a>(path: &Path, ids: impl IntoIterator<Item = &'a String>) -> Result<()> {
+    let dir = path.parent().context("push receipt has no parent directory")?;
+    std::fs::create_dir_all(dir).context("creating the push receipt directory")?;
+
+    // Lock a stable sibling rather than the receipt itself: the receipt is atomically replaced,
+    // so locking its inode would let a second writer lock the replacement and race the first.
+    let lock_dir = dir.join(".locks");
+    std::fs::create_dir_all(&lock_dir).context("creating the push receipt lock directory")?;
+    let lock_path = lock_dir.join(path.file_name().context("push receipt has no file name")?);
+    let lock = File::options()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        .open(&lock_path)
+        .with_context(|| format!("opening push receipt lock at {}", lock_path.display()))?;
+    lock.lock().context("locking the push receipt")?;
+
     let mut pushed = load_pushed_from(path).unwrap_or_default();
     let before = pushed.len();
     pushed.extend(ids.into_iter().cloned());
@@ -110,8 +127,6 @@ fn record_pushed_at<'a>(path: &Path, ids: impl IntoIterator<Item = &'a String>) 
         return Ok(());
     }
 
-    let dir = path.parent().context("push receipt has no parent directory")?;
-    std::fs::create_dir_all(dir).context("creating the push receipt directory")?;
     let mut ids: Vec<_> = pushed.into_iter().collect();
     ids.sort_unstable();
     let mut temp = tempfile::NamedTempFile::new_in(dir).context("creating a push receipt")?;
@@ -883,6 +898,33 @@ mod tests {
             ["a", "b", "c"].into_iter().map(str::to_string).collect()
         );
         assert_eq!(std::fs::read_to_string(path).unwrap(), "a\nb\nc\n");
+    }
+
+    #[test]
+    fn concurrent_push_receipt_updates_do_not_lose_ids() {
+        use std::sync::{Arc, Barrier};
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = Arc::new(dir.path().join("receipt"));
+        let writers = 16;
+        let barrier = Arc::new(Barrier::new(writers));
+        let threads: Vec<_> = (0..writers)
+            .map(|i| {
+                let path = Arc::clone(&path);
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    let id = format!("id-{i}");
+                    barrier.wait();
+                    record_pushed_at(&path, [&id]).unwrap();
+                })
+            })
+            .collect();
+        for thread in threads {
+            thread.join().unwrap();
+        }
+
+        let expected: HashSet<_> = (0..writers).map(|i| format!("id-{i}")).collect();
+        assert_eq!(load_pushed_from(&path).unwrap(), expected);
     }
 
     #[tokio::test]

--- a/src/push.rs
+++ b/src/push.rs
@@ -32,6 +32,8 @@ use chrono::Utc;
 use hf_hub::{HFError, HFRepository, RepoTypeDataset};
 use lance::Dataset;
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 /// Reindex the remote once this many appended rows are sitting unindexed (answered by a
@@ -78,6 +80,108 @@ async fn all_ids(ds: &Dataset) -> Result<HashSet<String>> {
         }
     }
     Ok(ids)
+}
+
+/// Per-remote local receipt of chunk ids this host has observed on that remote. It is deliberately
+/// local: a shared remote's sessions from other hosts say nothing about this host's push backlog.
+fn pushed_path(memory_uri: &str) -> PathBuf {
+    dataset::funes_dir().join("pushed").join(curate::sanitize(memory_uri))
+}
+
+fn load_pushed_from(path: &Path) -> Option<HashSet<String>> {
+    let text = std::fs::read_to_string(path).ok()?;
+    Some(
+        text.lines()
+            .filter(|line| !line.is_empty())
+            .map(str::to_string)
+            .collect(),
+    )
+}
+
+fn load_pushed(memory_uri: &str) -> Option<HashSet<String>> {
+    load_pushed_from(&pushed_path(memory_uri))
+}
+
+fn record_pushed_at<'a>(path: &Path, ids: impl IntoIterator<Item = &'a String>) -> Result<()> {
+    let mut pushed = load_pushed_from(path).unwrap_or_default();
+    let before = pushed.len();
+    pushed.extend(ids.into_iter().cloned());
+    if pushed.len() == before && path.is_file() {
+        return Ok(());
+    }
+
+    let dir = path.parent().context("push receipt has no parent directory")?;
+    std::fs::create_dir_all(dir).context("creating the push receipt directory")?;
+    let mut ids: Vec<_> = pushed.into_iter().collect();
+    ids.sort_unstable();
+    let mut temp = tempfile::NamedTempFile::new_in(dir).context("creating a push receipt")?;
+    for id in ids {
+        writeln!(temp, "{id}").context("writing the push receipt")?;
+    }
+    temp.flush().context("flushing the push receipt")?;
+    temp.persist(path)
+        .map_err(|e| anyhow::Error::new(e.error).context("saving the push receipt"))?;
+    Ok(())
+}
+
+fn record_pushed<'a>(memory_uri: &str, ids: impl IntoIterator<Item = &'a String>) -> Result<()> {
+    record_pushed_at(&pushed_path(memory_uri), ids)
+}
+
+/// This host's session-level push coverage for one remote. A session is fully pushed only when
+/// every chunk it currently has is in the local receipt, so a session that later grows returns to
+/// `pending` until its new chunks are pushed.
+pub(crate) struct PushCoverage {
+    pub total: usize,
+    pub pushed: usize,
+    pub pending: usize,
+}
+
+fn push_coverage(batches: &[RecordBatch], pushed_ids: &HashSet<String>) -> Option<PushCoverage> {
+    let mut complete: HashMap<String, bool> = HashMap::new();
+    for batch in batches {
+        let ids = batch.column_by_name("id")?.as_any().downcast_ref::<StringArray>()?;
+        let sessions = batch
+            .column_by_name("session_id")?
+            .as_any()
+            .downcast_ref::<StringArray>()?;
+        for i in 0..batch.num_rows() {
+            let present = pushed_ids.contains(ids.value(i));
+            complete
+                .entry(sessions.value(i).to_string())
+                .and_modify(|all| *all &= present)
+                .or_insert(present);
+        }
+    }
+    let pushed = complete.values().filter(|&&all| all).count();
+    Some(PushCoverage {
+        total: complete.len(),
+        pushed,
+        pending: complete.len() - pushed,
+    })
+}
+
+pub(crate) async fn local_push_coverage(local: &Dataset, memory_uri: &str) -> Option<PushCoverage> {
+    let pushed_ids = load_pushed(memory_uri)?;
+    let batches = dataset::scan_rows(local, &["id", "session_id"], None, None)
+        .await
+        .ok()?;
+    push_coverage(&batches, &pushed_ids)
+}
+
+fn ids_in_batches(batches: &[RecordBatch]) -> HashSet<String> {
+    let mut ids = HashSet::new();
+    for batch in batches {
+        if let Some(col) = batch
+            .column_by_name("id")
+            .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+        {
+            for i in 0..batch.num_rows() {
+                ids.insert(col.value(i).to_string());
+            }
+        }
+    }
+    ids
 }
 
 /// The to-push rows (all columns) from the local memory. An append reads just the missing ids via an
@@ -209,6 +313,12 @@ pub async fn run_push(target: Memory, force_reindex: bool, confirm: Confirm) -> 
     let held_back = pending_note(not_reviewed.len(), &target.label());
     let to_push: HashSet<String> = candidates.difference(&remote_ids).cloned().collect();
 
+    // Bootstrap/refresh the local receipt from facts the push comparison has already established.
+    // This makes a no-op push enough to initialize status for a legacy remote, with no extra scan.
+    if remote.is_some() {
+        record_pushed(&uri, candidates.intersection(&remote_ids))?;
+    }
+
     // Nothing to push => done (no token needed), unless this is a forced reindex of an existing
     // remote, which is still work.
     if to_push.is_empty() && (first_publish || !force_reindex) {
@@ -282,6 +392,7 @@ pub async fn run_push(target: Memory, force_reindex: bool, confirm: Confirm) -> 
             blocked: true,
         });
     }
+    let pushed_ids = ids_in_batches(&batches);
 
     // The dataset card rides the data commit — created when the repo has none, refreshed when it
     // carries the funes markers, a hand-written card left alone (see `card_file`). Root stores
@@ -326,6 +437,7 @@ pub async fn run_push(target: Memory, force_reindex: bool, confirm: Confirm) -> 
         let Some(oid) = oid else {
             return Ok(format!("{}: nothing new to upload\n", target.label()).into());
         };
+        record_pushed(&uri, &pushed_ids)?;
         return Ok(format!(
             "{}: pushed {n_chunks} chunks (commit {oid})\n{card_note}{held_back}{}",
             target.label(),
@@ -360,6 +472,7 @@ pub async fn run_push(target: Memory, force_reindex: bool, confirm: Confirm) -> 
             }
         }
     };
+    record_pushed(&uri, &pushed_ids)?;
     let mut out = format!("{}: pushed {n_chunks} chunks (commit {oid})\n", target.label());
     out.push_str(&card_note);
     out.push_str(&held_back);
@@ -743,6 +856,36 @@ mod tests {
         assert_eq!(by_session.len(), 2, "one entry per session");
         assert!(by_session.contains_key("reviewed") && by_session.contains_key("private"));
         assert!(by_session.values().all(|ids| !ids.is_empty()));
+    }
+
+    #[tokio::test]
+    async fn push_coverage_requires_every_current_chunk_of_a_session() {
+        let dir = tempfile::tempdir().unwrap();
+        let ds = two_session_ds(dir.path()).await;
+        let by_session = curate::ids_by_session(&ds).await.unwrap();
+        let pushed: HashSet<String> = by_session["reviewed"].iter().cloned().collect();
+        let batches = dataset::scan_rows(&ds, &["id", "session_id"], None, None)
+            .await
+            .unwrap();
+        let coverage = push_coverage(&batches, &pushed).unwrap();
+        assert_eq!(coverage.total, 2);
+        assert_eq!(coverage.pushed, 1);
+        assert_eq!(coverage.pending, 1);
+    }
+
+    #[test]
+    fn push_receipt_is_an_atomic_growing_set() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("receipt");
+        let first = ["b".to_string(), "a".to_string()];
+        record_pushed_at(&path, &first).unwrap();
+        let second = ["b".to_string(), "c".to_string()];
+        record_pushed_at(&path, &second).unwrap();
+        assert_eq!(
+            load_pushed_from(&path).unwrap(),
+            ["a", "b", "c"].into_iter().map(str::to_string).collect()
+        );
+        assert_eq!(std::fs::read_to_string(path).unwrap(), "a\nb\nc\n");
     }
 
     #[tokio::test]

--- a/src/recall.rs
+++ b/src/recall.rs
@@ -802,12 +802,23 @@ async fn session_count(ds: &Dataset) -> Option<usize> {
     Some(sessions.len())
 }
 
+fn index_coverage_line() -> Option<String> {
+    let coverage = crate::index::local_index_coverage()?;
+    Some(format!(
+        "native sessions pending index: {}/{}\n",
+        coverage.pending, coverage.total
+    ))
+}
+
 /// The indexation lines of a local memory: how many sessions it holds and when it was last
 /// written to (an `index` or `scrub` run). A version with no recorded timestamp is omitted.
 async fn index_lines(ds: &Dataset, now: DateTime<Utc>) -> String {
     let mut out = String::new();
     if let Some(n) = session_count(ds).await {
         let _ = writeln!(out, "sessions: {n}");
+    }
+    if let Some(line) = index_coverage_line() {
+        out.push_str(&line);
     }
     let t = ds.version().timestamp;
     if t.timestamp() > 0 {
@@ -859,6 +870,9 @@ pub async fn status(memory: Memory) -> Result<String> {
                         let local_sessions = session_count(&local).await;
                         if let Some(n) = local_sessions {
                             let _ = writeln!(out, "sessions: {n}");
+                        }
+                        if let Some(line) = index_coverage_line() {
+                            out.push_str(&line);
                         }
                         // A shared remote's total says nothing about this host's backlog. Personal
                         // memories use the local receipt maintained by push; project memories have

--- a/src/recall.rs
+++ b/src/recall.rs
@@ -784,8 +784,9 @@ fn age(t: DateTime<Utc>, now: DateTime<Utc>) -> String {
     format!("{n} {unit}{} ago", if n == 1 { "" } else { "s" })
 }
 
-/// Distinct sessions in the memory — the human-scale size of the index. Best-effort: a failed
-/// scan omits the line rather than failing status.
+/// Distinct sessions in a local memory — the human-scale size of the index. Best-effort: a failed
+/// scan omits the line rather than failing status. Never call this for a remote: even a projected
+/// column scan can download an enormous published memory.
 async fn session_count(ds: &Dataset) -> Option<usize> {
     let batches = dataset::scan_rows(ds, &["session_id"], None, None).await.ok()?;
     let mut sessions = HashSet::new();
@@ -825,7 +826,8 @@ pub async fn status(memory: Memory) -> Result<String> {
                 Memory::Local { .. } => out.push_str(&index_lines(&ds, now).await),
                 Memory::Remote { uri } => {
                     // A project memory announces itself and this machine's review backlog.
-                    if let Some(project) = curate::project(&ds) {
+                    let project = curate::project(&ds);
+                    if let Some(project) = &project {
                         let _ = writeln!(out, "project memory of {project}");
                         let pending = curate::pending_count(&ds, uri).await?;
                         if pending > 0 {
@@ -849,14 +851,43 @@ pub async fn status(memory: Memory) -> Result<String> {
                     // answers both "what's published" and "what's indexed on this machine".
                     if let Ok(local) = Memory::local().open().await {
                         let local_rows = local.count_rows(None).await?;
-                        let _ = write!(out, "\nlocal index: {}\nchunks: {local_rows}", Memory::local().label());
-                        // A count difference only approximates the push delta (scrub-held
-                        // rows and other hosts' pushes also move it).
-                        if local_rows > rows {
-                            let _ = write!(out, " (≈{} not yet pushed)", local_rows - rows);
+                        let _ = writeln!(
+                            out,
+                            "\nlocal index: {}\nchunks: {local_rows}",
+                            Memory::local().label()
+                        );
+                        let local_sessions = session_count(&local).await;
+                        if let Some(n) = local_sessions {
+                            let _ = writeln!(out, "sessions: {n}");
                         }
-                        out.push('\n');
-                        out.push_str(&index_lines(&local, now).await);
+                        // A shared remote's total says nothing about this host's backlog. Personal
+                        // memories use the local receipt maintained by push; project memories have
+                        // their decision-aware pending-review report above.
+                        if project.is_none() {
+                            if let Some(coverage) = crate::push::local_push_coverage(&local, uri).await
+                            {
+                                let _ = writeln!(
+                                    out,
+                                    "local sessions fully pushed: {}/{}",
+                                    coverage.pushed, coverage.total
+                                );
+                                let _ = writeln!(
+                                    out,
+                                    "local sessions pending push: {}",
+                                    coverage.pending
+                                );
+                            } else {
+                                let _ = writeln!(
+                                    out,
+                                    "local push coverage: unknown — run `funes push {}` once",
+                                    memory.label()
+                                );
+                            }
+                        }
+                        let t = local.version().timestamp;
+                        if t.timestamp() > 0 {
+                            let _ = writeln!(out, "last indexed: {}", stamp(t, now));
+                        }
                     }
                 }
             }

--- a/src/recall.rs
+++ b/src/recall.rs
@@ -804,10 +804,13 @@ async fn session_count(ds: &Dataset) -> Option<usize> {
 
 fn index_coverage_line() -> Option<String> {
     let coverage = crate::index::local_index_coverage()?;
-    Some(format!(
-        "native sessions pending index: {}/{}\n",
-        coverage.pending, coverage.total
-    ))
+    (coverage.pending > 0).then(|| {
+        format!(
+            "pending indexing: {} source session{} — run `funes index`\n",
+            coverage.pending,
+            if coverage.pending == 1 { "" } else { "s" }
+        )
+    })
 }
 
 /// The indexation lines of a local memory: how many sessions it holds and when it was last
@@ -880,16 +883,23 @@ pub async fn status(memory: Memory) -> Result<String> {
                         if project.is_none() {
                             if let Some(coverage) = crate::push::local_push_coverage(&local, uri).await
                             {
-                                let _ = writeln!(
-                                    out,
-                                    "local sessions fully pushed: {}/{}",
-                                    coverage.pushed, coverage.total
-                                );
-                                let _ = writeln!(
-                                    out,
-                                    "local sessions pending push: {}",
-                                    coverage.pending
-                                );
+                                if coverage.pending == 0 {
+                                    let _ = writeln!(
+                                        out,
+                                        "local push: up to date ({} session{})",
+                                        coverage.total,
+                                        if coverage.total == 1 { "" } else { "s" }
+                                    );
+                                } else {
+                                    let _ = writeln!(
+                                        out,
+                                        "local push: {} of {} session{} pending — run `funes push {}`",
+                                        coverage.pending,
+                                        coverage.total,
+                                        if coverage.total == 1 { "" } else { "s" },
+                                        memory.label()
+                                    );
+                                }
                             } else {
                                 let _ = writeln!(
                                     out,


### PR DESCRIPTION
This pull request introduces a more accurate and user-focused reporting of local indexing and push status for both local and remote memories. It adds robust tracking of which sessions and chunks are pending indexing or pushing, and updates both the CLI output and internal bookkeeping to reflect only the work this host is responsible for. The changes also ensure that status reporting never scans the remote, and that push receipts are maintained locally and atomically per host, avoiding confusion from other hosts' contributions.

These changes together make `funes status` and `funes push` more accurate, user-friendly, and robust on multi-host or collaborative setups, with clear guidance for users on next actions.