### PR TITLE
fix(claude): drop --scope from the marketplace remove call

### DIFF
--- a/src/claude.rs
+++ b/src/claude.rs
@@ -107,7 +107,7 @@ pub fn uninstall() -> Result<()> {
 fn remove_instructions() -> &'static str {
     "  claude mcp remove funes -s user\n  \
      claude plugin uninstall funes@huggingface -s user\n  \
-     claude plugin marketplace remove huggingface --scope user"
+     claude plugin marketplace remove huggingface"
 }
 
 fn uninstall_registrations() -> Result<crate::integration::RemoveCommand> {
@@ -128,7 +128,7 @@ fn uninstall_registrations() -> Result<crate::integration::RemoveCommand> {
     )?;
     run_remove(
         "claude",
-        &["plugin", "marketplace", "remove", "huggingface", "--scope", "user"],
+        &["plugin", "marketplace", "remove", "huggingface"],
         &["Marketplace 'huggingface' not found"],
     )?;
     Ok(outcome)

--- a/tests/remove.rs
+++ b/tests/remove.rs
@@ -27,7 +27,7 @@ fn remove_claude_unregisters_both_surfaces_and_deletes_the_extracted_plugin() {
         fs::read_to_string(&log).unwrap(),
         "mcp remove funes -s user\n\
          plugin uninstall funes@huggingface -s user\n\
-         plugin marketplace remove huggingface --scope user\n"
+         plugin marketplace remove huggingface\n"
     );
 
     // Already absent remains a successful no-op locally.


### PR DESCRIPTION
`claude plugin marketplace remove` accepts no --scope flag (only `plugin uninstall` does), so `funes remove claude` aborted with "unknown option '--scope'" after it had already unregistered the MCP server and deleted ~/.funes/integrations/claude-plugin — leaving a marketplace entry pointing at a directory that no longer exists, and no way to reach a clean state without running the CLI by hand.

The tests never caught it because the fake CLI accepts any argument list; it only asserts the args funes passes, so the expected log moves with the fix.