### PR TITLE
fix: make push → scrub → push converge

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -98,7 +98,7 @@ bounded step at a time. `--no-thinking` drops thinking blocks from the `text` ti
 or Hub repo skips the budget and indexes all tiers in one pass.
 
 Inline `data:` URI payloads are elided to `data:image/png;base64,[elided]` before a block is
-stored: a pasted screenshot is megabytes of base64 with nothing recallable in it.
+scanned or stored: a pasted screenshot is megabytes of base64 with nothing recallable in it.
 
 ## Flags
 

--- a/docs/push.md
+++ b/docs/push.md
@@ -71,12 +71,16 @@ block, then makes one replacement commit:
   block is re-chunked and its replacement chunks are re-embedded.
 - If a finding cannot be reconstructed safely—for example, an encoded value with no reliable byte
   match—the entire block is dropped instead of risking a partial redaction.
+- A redaction is kept only if the redacted block scans clean. Excising one match can expose another
+  (removing one from a long base64 run re-aligns the window the next is found in), and such a block
+  is dropped rather than stored.
 - Clean rows retain their existing embeddings. The vector and full-text indexes are rebuilt after
   the replacement.
 
 The source transcripts are never modified. Scrub reports how many secrets and blocks it redacted and
-how many rows it had to drop. Run `funes push <memory>` afterward; the repaired local rows then pass
-through the independent egress gate.
+how many rows it had to drop. A completed scrub leaves a memory that scans clean, so the next
+`funes push <memory>` has nothing left to hold back; the repaired local rows pass through the
+independent egress gate.
 
 Scrub does **not** alter an already-published remote. If a live credential reached the Hub, revoke or
 rotate it first, then remediate the dataset separately; funes can prevent another upload but does not

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -92,8 +92,9 @@ fn is_data_uri_head(head: &str) -> bool {
 
 /// `text` with every inline base64 `data:` URI payload replaced by `[elided]`. A pasted screenshot
 /// is megabytes of base64 that swamp its block, carry nothing recallable, and trip secret detectors
-/// on values that are not secrets.
-fn elide_data_uris(text: &str) -> Cow<'_, str> {
+/// on values that are not secrets. Applied before a block is scanned: a redaction marker planted
+/// inside a payload ends the run this walks, stranding the rest of it.
+pub(crate) fn elide_data_uris(text: &str) -> Cow<'_, str> {
     if !text.contains(BASE64_MARKER) {
         return Cow::Borrowed(text);
     }
@@ -121,7 +122,6 @@ fn is_base64_char(c: char) -> bool {
 }
 
 fn render(block_type: &str, text: &str, tool_name: &Option<String>) -> String {
-    let text = elide_data_uris(text);
     match block_type {
         "tool_use" => format!("[tool_use {}] {}", py_opt(tool_name), text).trim().to_string(),
         "tool_result" => {
@@ -131,7 +131,7 @@ fn render(block_type: &str, text: &str, tool_name: &Option<String>) -> String {
             };
             format!("[{label}] {text}").trim().to_string()
         }
-        _ => text.into_owned(),
+        _ => text.to_string(),
     }
 }
 
@@ -402,27 +402,27 @@ mod tests {
     }
 
     #[test]
-    fn render_elides_inline_base64_payloads() {
+    fn elides_inline_base64_payloads() {
         let text = r#"{"image_url":"data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==","detail":"original"}"#;
         assert_eq!(
-            render("tool_result", text, &None),
-            r#"[tool_result] {"image_url":"data:image/png;base64,[elided]","detail":"original"}"#
+            elide_data_uris(text),
+            r#"{"image_url":"data:image/png;base64,[elided]","detail":"original"}"#
         );
         assert_eq!(
-            render("text", "a data:image/gif;base64,R0lGOD b data:;base64,QUJD c", &None),
+            elide_data_uris("a data:image/gif;base64,R0lGOD b data:;base64,QUJD c"),
             "a data:image/gif;base64,[elided] b data:;base64,[elided] c"
         );
     }
 
     #[test]
-    fn render_leaves_a_base64_mention_that_is_not_a_data_uri() {
+    fn leaves_a_base64_mention_that_is_not_a_data_uri() {
         for text in [
             "encode it as ;base64,AAAA",
             "Content-Transfer-Encoding;base64,AAAA",
             "data: image/png;base64,AAAA",
             "metadata:image/png;base64,AAAA",
         ] {
-            assert_eq!(render("text", text, &None), text, "must not elide: {text}");
+            assert_eq!(elide_data_uris(text), text, "must not elide: {text}");
         }
     }
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -17,6 +17,7 @@ use arrow_array::{Array, FixedSizeListArray, Int64Array, RecordBatch, RecordBatc
 use arrow_schema::{DataType, Field, Schema};
 use lance::dataset::{Dataset, WriteParams};
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::io::{IsTerminal, Write as _};
 use std::path::{Path, PathBuf};
@@ -150,6 +151,18 @@ async fn stored_ids(ds: &Dataset) -> Result<HashSet<String>> {
         }
     }
     Ok(ids)
+}
+
+/// Elide every block's inline base64 `data:` URI payloads, before [`redact_turns`] scans them: a
+/// screenshot's entropy trips detectors on values that are not secrets, and excising one of those
+/// plants a marker mid-payload that strands the rest of it in the store. Runs whether or not a
+/// scanner is installed — the payload is unrecallable either way.
+fn elide_turns(turns: &mut [trace::Turn]) {
+    for b in turns.iter_mut().flat_map(|t| t.blocks.iter_mut()) {
+        if let Cow::Owned(elided) = chunk::elide_data_uris(&b.text) {
+            b.text = elided;
+        }
+    }
 }
 
 /// Redact secrets from a session's turns *before* chunking — so a long key that chunking would
@@ -505,6 +518,7 @@ impl Indexer {
         };
 
         let (sessions, label) = unit_summary(&turns, &key);
+        elide_turns(&mut turns);
         if let Some(scanner) = &self.scanner {
             redact_turns(&mut turns, scanner, tiers, self.include_thinking)?;
         }
@@ -1237,6 +1251,45 @@ mod tests {
         assert_eq!(
             turns[0].blocks[1].text, "output SECRET dump",
             "unindexed tool_result untouched"
+        );
+    }
+
+    #[test]
+    fn elide_turns_strips_payloads_before_anything_scans_them() {
+        struct Recorder(std::cell::RefCell<String>);
+        impl scan::SecretScanner for Recorder {
+            fn scan(&self, blob: &str) -> Result<Vec<scan::Finding>> {
+                self.0.borrow_mut().push_str(blob);
+                Ok(Vec::new())
+            }
+        }
+        let mut turns = vec![trace::Turn {
+            session_id: "sess".into(),
+            workdir: "proj".into(),
+            turn_uuid: "turn".into(),
+            parent_uuid: None,
+            seq: 0,
+            ts: String::new(),
+            role: "tool".into(),
+            blocks: vec![trace::Block {
+                block_type: "tool_result".into(),
+                text: r#"{"image_url":"data:image/png;base64,iVBORw0KGgoAAAANSUhEUg=="}"#.into(),
+                tool_name: None,
+                tool_use_id: None,
+            }],
+            source_path: String::new(),
+            harness: "codex".into(),
+        }];
+        let scanner = Recorder(std::cell::RefCell::new(String::new()));
+        elide_turns(&mut turns);
+        redact_turns(&mut turns, &scanner, &chunk::Tier::ALL, true).unwrap();
+        assert_eq!(
+            turns[0].blocks[0].text,
+            r#"{"image_url":"data:image/png;base64,[elided]"}"#
+        );
+        assert!(
+            !scanner.0.borrow().contains("iVBORw0KGgo"),
+            "the scanner must never see the payload: excising a match inside it would strand the rest"
         );
     }
 }

--- a/src/scrub.rs
+++ b/src/scrub.rs
@@ -16,8 +16,8 @@ use std::time::Instant;
 
 /// Reconstruct each block, scan them all in one pass, and for any block holding a secret either
 /// redact the matching values in place (re-chunked, re-embedded) or — when a value can't be matched
-/// (e.g. a key stored with escaped `\n`) — drop the block whole. Fail-closed on the scanner:
-/// scrubbing is the whole point.
+/// (e.g. a key stored with escaped `\n`), or the redaction doesn't scan clean — drop the block
+/// whole. Fail-closed on the scanner: scrubbing is the whole point.
 pub async fn run() -> Result<()> {
     // scrub rewrites the whole table, so hold the memory lock to be the sole writer.
     let _lock = lock::MemoryLock::acquire()?;
@@ -61,7 +61,10 @@ pub async fn run() -> Result<()> {
             remove[i] = true;
         }
         let r = scan::excise(text, findings);
-        if r.fully_redacted {
+        // Excising one match can expose another: removing it from a long base64 run re-aligns the
+        // window the next is found in. So a redaction counts only if the result scans clean.
+        let clean = r.fully_redacted && scan::scan_blocks(&[r.text.as_str()], &scanner)?[0].is_empty();
+        if clean {
             replacements.extend(chunk::resplit(&chunks[idxs[0]], &r.text));
             redacted_detectors.extend(r.removed_detectors);
             redacted_blocks += 1;


### PR DESCRIPTION
Closes #110.

Follows #111, which stopped inline base64 from entering the store. This makes the loop terminate for
whatever is already in it — and fixes an ordering bug in that merged elision.