### PR TITLE
fix(claude): drop the redundant scope from the plugin uninstall

### DIFF
--- a/src/claude.rs
+++ b/src/claude.rs
@@ -106,7 +106,7 @@ pub fn uninstall() -> Result<()> {
 
 fn remove_instructions() -> &'static str {
     "  claude mcp remove funes -s user\n  \
-     claude plugin uninstall funes@huggingface -s user\n  \
+     claude plugin uninstall funes@huggingface\n  \
      claude plugin marketplace remove huggingface"
 }
 
@@ -123,7 +123,7 @@ fn uninstall_registrations() -> Result<crate::integration::RemoveCommand> {
     }
     run_remove(
         "claude",
-        &["plugin", "uninstall", PLUGIN_ID, "-s", "user"],
+        &["plugin", "uninstall", PLUGIN_ID],
         &["Plugin \"funes@huggingface\" not found"],
     )?;
     run_remove(

--- a/tests/remove.rs
+++ b/tests/remove.rs
@@ -26,7 +26,7 @@ fn remove_claude_unregisters_both_surfaces_and_deletes_the_extracted_plugin() {
     assert_eq!(
         fs::read_to_string(&log).unwrap(),
         "mcp remove funes -s user\n\
-         plugin uninstall funes@huggingface -s user\n\
+         plugin uninstall funes@huggingface\n\
          plugin marketplace remove huggingface\n"
     );
 


### PR DESCRIPTION
`claude plugin` already defaults to user scope, so the flag only made install and uninstall look like they target different places. `claude mcp` is the one that needs it — it defaults to `local`.