### PR TITLE
Add session listing and scanning capabilties

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ rank) → cross-encoder rerank → recency reweight → neighbor expansion. Agen
 
 ```
 [<ts>] <harness> <workdir>/<session8> <block_type>  score=<s.sss>
-  → get <session_id> <turn_uuid> --memory <label>
+  → get <session_id> --from <seq> --to <seq> --memory <label>
 <the full chunk text>
   ~ [<role> <block_type> seq<N>] <neighbor chunk, first 160 chars>
 ---
@@ -40,19 +40,39 @@ fell back to).
 
 ### get
 
-`funes get <session_id> <turn_uuid> [--window 3] [--memory <label>]` — the named turn plus turns
-within the seq window, splits reassembled into whole blocks. Pass the `--memory` a recall hint
-names so the drill-down reads the same memory the hit came from. `--highlight <text>` marks the
-text in the human rendering (matched whitespace-insensitively; no effect on the agent format).
-Agent format, per turn:
+`funes get <session_id> [--from <seq>] [--to <seq>] [--memory <label>]` — a range of one session's
+turns, splits reassembled into whole blocks. Pass the `--memory` a hint names so the drill-down reads
+the same memory the hit came from.
+
+**Turns are addressed by `seq`, and only by seq.** It is the session's own dense counter over its
+turns, so a range is literally "turns n through m". A recall or scan hit's `→ get` line already
+carries the session, the range around the hit, and the memory — drilling into a hit is running what
+it printed, and widening it is editing two numbers. `--from` defaults to the session's start and
+`--to` to 20 turns on, so **a session id alone is a valid read**: that is how you read a session you
+picked out of `sessions` rather than found by searching.
+
+The turn uuid is provenance, not an address. It identifies a turn across re-indexing (chunk ids are
+keyed on it) and is printed with every turn, but nothing takes it as input.
+
+Agent format, per turn, closed by the coordinates read and the session's size:
 
 ```
 [<ts>] <role> seq<N> turn=<turn_uuid>
 <blocks, joined by blank lines>
 ---
+turns <first>-<last> of <total>
 ```
 
-`turn <uuid> not found in session <id>` when absent.
+A single turn can carry a whole file, so rendering stops at ~40,000 characters and says what it left
+out and where to resume:
+
+```
+turns 0-11 of 786
+9 more turn(s) in range not shown — read them with --from 12
+```
+
+One turn always renders, however large — a read that answers nothing cannot be narrowed further.
+`no turns in that range of session <id> (it holds <n>)` when the coordinates land outside it.
 
 ### ask
 
@@ -88,10 +108,9 @@ A non-zero agent exit fails funes (exit 1, the child's code quoted).
 claude/codex/hermes also installs the automation hooks — see [docs/automation.md](docs/automation.md)). A
 positional `memory` binds the server to a memory; `funes add <agent> <memory>` bakes it into the
 registration. `funes remove <agent>` reverses that agent integration without deleting memories or
-transcripts. Tools: `recall` (query, k, block_type/harness filters, memory), `get`
-(session_id, turn_uuid, window, memory), `status` (memory) — each returns the corresponding
-agent-format string verbatim. A tool call's `memory` overrides the server's; with neither, it reads
-the local memory.
+transcripts. Tools: `recall` (query, k, block_type/harness filters, memory), `get` (session_id,
+from, to, memory), `status` (memory) — each returns the corresponding agent-format string verbatim.
+A tool call's `memory` overrides the server's; with neither, it reads the local memory.
 
 ## Working on the repo
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,22 @@ turns 0-11 of 786
 One turn always renders, however large — a read that answers nothing cannot be narrowed further.
 `no turns in that range of session <id> (it holds <n>)` when the coordinates land outside it.
 
+### sessions
+
+`funes sessions [--memory <label>]` — every session in the memory, oldest first. Recall is ranked
+retrieval and reaches only what a query reaches; this is the enumerator, and the only thing that
+answers how much a memory holds or how much of it a pass covered. Agent format:
+
+```
+[<first_ts>] <harness> <workdir>/<session_id> <n> turns
+---
+<n> sessions
+```
+
+Turns are counted distinct, not as rows: chunking is an indexing artifact. The session id is
+printed whole, so it feeds `get`, `curate --include/--exclude`, and any other id-taking command
+directly. `no sessions in <label>` when the memory is empty.
+
 ### ask
 
 `funes ask claude|codex "<question>" [--memory <label>]` — one grounded answer from a coding
@@ -109,9 +125,9 @@ claude/codex/hermes also installs the automation hooks — see [docs/automation.
 positional `memory` binds the server to a memory; `funes add <agent> <memory>` bakes it into the
 registration. `funes remove <agent>` reverses that agent integration without deleting memories or
 transcripts. Tools: `recall` (query, k, half_life, neighbors, candidates, block_type/harness
-filters, memory), `get` (session_id, from, to, memory), `status` (memory) — each returns the
-corresponding agent-format string verbatim. A tool call's `memory` overrides the server's; with
-neither, it reads the local memory.
+filters, memory), `get` (session_id, from, to, memory), `sessions` (memory), `status` (memory) —
+each returns the corresponding agent-format string verbatim. A tool call's `memory` overrides the
+server's; with neither, it reads the local memory.
 
 ## Working on the repo
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,6 +173,44 @@ the session reports `no turns in that range`, never absence.
 
 Absence of a match clears only the literal actually passed, in the session actually named.
 
+### sketch
+
+`funes sketch <session_id> [--units <n>] [--max-chars <n>] [--from <seq>] [--to <seq>] [--memory
+<label>]` — what one session **contains**, asked without a query: the passages most distinctive
+within it, chosen from the stored vectors.
+
+**This is the only read that does not need to know what it is looking for.** `recall` needs a query,
+`scan` needs a literal, `get` needs coordinates, `sessions` gives the opening prompt and nothing
+after. Reach for `sketch` for every open-ended judgement about a session — is this worth publishing,
+does it reveal anything internal, what was accomplished here. The material that disqualifies a
+session is usually the material that does not belong in it, and a distinctiveness selector surfaces
+exactly that where a summary drops it.
+
+**Do not read the whole session instead.** A session runs to thousands of turns; reading one end to
+end costs more than every other call together and leaves you paging a transcript. Every place a
+sketch shows carries a `→ get` line for the surrounding turns verbatim.
+
+```
+sketch <session_id> — <n> of <units> places · <chars> of <max-chars> chars · <k> eligible units
+  (units clamped to <n>)
+[<ts>] <role> <block_type> seq<N> · shortened
+  → get <session_id> --from <seq> --to <seq> --memory <label>
+<the passage>
+---
+a sketch samples: it shows what it selected, so it cannot show that anything is absent — scan a literal for that
+```
+
+| Flag | Default | Meaning |
+| --- | --- | --- |
+| `--units` | 8 | distinct places to show; clamped to 40, and to what `--max-chars` fits at 240 chars each |
+| `--max-chars` | 8,000 | total characters rendered; clamped to 40,000 |
+| `--from` / `--to` | whole session | digest a stretch instead — a fixed number of places over 13,000 turns is thin, the same number over each 2,000 is proportional |
+| `--memory` | local memory | the memory holding the session |
+
+No passage may take more than its share of the budget, so one turn carrying a file cannot become the
+whole digest; a shortened passage says so. Every clamp is reported rather than applied quietly. It
+**samples**, so a sketch can never establish absence — `scan` a literal for that.
+
 ### ask
 
 `funes ask claude|codex "<question>" [--memory <label>]` — one grounded answer from a coding
@@ -209,7 +247,8 @@ positional `memory` binds the server to a memory; `funes add <agent> <memory>` b
 registration. `funes remove <agent>` reverses that agent integration without deleting memories or
 transcripts. Tools: `recall` (query, k, half_life, neighbors, candidates, block_type/harness
 filters, memory), `get` (session_id, from, to, memory), `sessions` (repo, since, until, limit,
-memory), `scan` (needle, session_id, ignore_case, context, memory), `status` (memory) — each returns
+offset, memory), `scan` (needle, session_id, from, to, ignore_case, context, memory), `sketch`
+(session_id, units, max_chars, from, to, memory), `status` (memory) — each returns
 the corresponding agent-format string verbatim. A tool call's `memory` overrides the server's; with
 neither, it reads the local memory.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,9 +108,10 @@ A non-zero agent exit fails funes (exit 1, the child's code quoted).
 claude/codex/hermes also installs the automation hooks — see [docs/automation.md](docs/automation.md)). A
 positional `memory` binds the server to a memory; `funes add <agent> <memory>` bakes it into the
 registration. `funes remove <agent>` reverses that agent integration without deleting memories or
-transcripts. Tools: `recall` (query, k, block_type/harness filters, memory), `get` (session_id,
-from, to, memory), `status` (memory) — each returns the corresponding agent-format string verbatim.
-A tool call's `memory` overrides the server's; with neither, it reads the local memory.
+transcripts. Tools: `recall` (query, k, half_life, neighbors, candidates, block_type/harness
+filters, memory), `get` (session_id, from, to, memory), `status` (memory) — each returns the
+corresponding agent-format string verbatim. A tool call's `memory` overrides the server's; with
+neither, it reads the local memory.
 
 ## Working on the repo
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,19 +76,50 @@ One turn always renders, however large — a read that answers nothing cannot be
 
 ### sessions
 
-`funes sessions [--memory <label>]` — every session in the memory, oldest first. Recall is ranked
-retrieval and reaches only what a query reaches; this is the enumerator, and the only thing that
-answers how much a memory holds or how much of it a pass covered. Agent format:
+`funes sessions [--repo <owner/name>] [--since <date>] [--until <date>] [--limit <n>] [--offset <n>]
+[--memory <label>]` — the memory's sessions, oldest first. Recall is ranked retrieval and reaches only what a
+query reaches; this is the enumerator, and the only thing that answers how much a memory holds,
+which sessions a criterion is about, or how much of it a pass covered.
+
+Agent format, two lines per session:
 
 ```
-[<first_ts>] <harness> <workdir>/<session_id> <n> turns
+[<date>] <harness> <repo-or-workdir> <n> turns <session_id>
+  <the prompt the session opened with, one line, cut at 120 chars>
 ---
 <n> sessions
 ```
 
-Turns are counted distinct, not as rows: chunking is an indexing artifact. The session id is
-printed whole, so it feeds `get`, `scan`, and any other id-taking command
-directly. `no sessions in <label>` when the memory is empty.
+The opening prompt is the cheapest triage there is: it says what a session was for without reading
+any of it. Injected scaffolding is skipped, so the line is the first thing a human actually typed; a
+session whose user turns are all scaffolding carries no second line. `<repo-or-workdir>` is the
+session's source repo when its checkout resolved at index time, else the working directory.
+
+Turns are counted distinct, not as rows: chunking is an indexing artifact. The session id is printed
+whole, so it feeds `get`, `scan`, and any other id-taking command directly.
+
+**Narrow rather than list everything.** `--repo` keeps the sessions whose checkout resolved to that
+repo — the population question rule 1 of a selection criterion actually asks. `--since`/`--until`
+bracket the start date inclusively, in `YYYY-MM-DD`.
+
+A listing renders **50 rows by default**, keeping the most recent, and is capped at **200 rows and
+~40,000 characters** whatever `--limit` asks for — a larger reply is one nobody receives. What it held
+back is both stated and reachable:
+
+```
+---
+50 of 726 sessions — 676 older: continue with --offset 50, or narrow with --repo/--since/--until
+```
+
+`--limit 0` is an **error**, not every match — it once meant that, before a listing had a ceiling.
+`--offset` skips that many of the most recent matches before taking `--limit`, so a walk covers the
+whole population without repeating or skipping a row: rows are ordered on (timestamp, session id), so
+a given offset always names the same session. Dates cannot do this — a day holds many sessions, so a
+`--until` resume would either repeat that day or skip part of it. The last page says `the oldest match
+reached` rather than offering an offset that returns nothing, and an offset past the matches says so.
+
+`no sessions in <label>` when the memory is empty; `no session in <label> matches` when the filters
+keep nothing.
 
 ### scan
 
@@ -177,10 +208,10 @@ claude/codex/hermes also installs the automation hooks — see [docs/automation.
 positional `memory` binds the server to a memory; `funes add <agent> <memory>` bakes it into the
 registration. `funes remove <agent>` reverses that agent integration without deleting memories or
 transcripts. Tools: `recall` (query, k, half_life, neighbors, candidates, block_type/harness
-filters, memory), `get` (session_id, from, to, memory), `sessions` (memory), `scan` (needle,
-session_id, ignore_case, context, memory), `status` (memory) — each returns the corresponding
-agent-format string verbatim. A tool call's `memory` overrides the server's; with neither, it reads
-the local memory.
+filters, memory), `get` (session_id, from, to, memory), `sessions` (repo, since, until, limit,
+memory), `scan` (needle, session_id, ignore_case, context, memory), `status` (memory) — each returns
+the corresponding agent-format string verbatim. A tool call's `memory` overrides the server's; with
+neither, it reads the local memory.
 
 ## Working on the repo
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,8 +87,60 @@ answers how much a memory holds or how much of it a pass covered. Agent format:
 ```
 
 Turns are counted distinct, not as rows: chunking is an indexing artifact. The session id is
-printed whole, so it feeds `get`, `curate --include/--exclude`, and any other id-taking command
+printed whole, so it feeds `get`, `scan`, and any other id-taking command
 directly. `no sessions in <label>` when the memory is empty.
+
+### scan
+
+`funes scan <needle> <session_id> [--from <seq>] [--to <seq>] [--ignore-case] [--context <chars>]
+[--memory <label>]` — a literal string found in every block of **one session**. Exhaustive and unranked, where `recall` is
+ranked and partial: this is what settles a question of absence, which recall cannot. Both the needle
+and the session are required; there is no projection mode.
+
+**One session, by design.** Every question worth asking of a literal is a claim about a session —
+does *this* one name an internal project, quote a credential, mention a customer. A memory-wide hit
+was never a clearance for any particular session, so the verb cannot make that shape of claim.
+Enumerate with `sessions`, then scan the ones you mean to screen.
+
+**Literal, never a pattern.** The step this exists for reads zero hits as clean, so a regex that
+silently matched nothing would be a false clearance. `--ignore-case` covers case variation. A
+session id that isn't in the memory is an **error**, for the same reason: a typo must not read as
+absence.
+
+Splits are stitched back into their block before matching, so a needle straddling a chunk boundary
+is still found and a split block reports once rather than once per chunk. Agent format:
+
+```
+scan "<needle>" in <session_id> — <m> hits
+[<ts>] <block_type> seq<N>
+  → get <session_id> --from <seq> --to <seq> --memory <label>
+  … <context chars each side of the match, whitespace-collapsed> …
+---
+```
+
+Hits come in reading order. `no matches for "<needle>" in <session_id>` when zero — needle and
+session are both echoed, so a zero is attributable to a specific query against a specific session.
+
+**A cap you can walk past.** Listing stops at 200 hits and names the coordinate to continue at:
+`<k> more hits not shown — continue with --from <seq>`. A common word in a long session runs to
+thousands of hits (4,402 for `"the"` in a 10,000-turn session), so an elision you cannot reach past
+would make the count a dead end. The resume coordinate is the first *dropped* hit's seq, not one past
+the last shown: a turn can hold several matching blocks, and `last + 1` would skip the rest of it —
+so continuing may repeat a hit but never skips one. The header count is always what was found, not
+what was listed.
+
+`--from`/`--to` also scan a stretch of a session on their own, in the same `seq` coordinate `get`
+uses. **A window scopes the clearance**: a zero over `--from 500 --to 999` reads `no matches for
+"<needle>" in <session_id> turns 500-999`, and clears only those turns. A window that lands outside
+the session reports `no turns in that range`, never absence.
+
+| Flag | Default | Meaning |
+| --- | --- | --- |
+| `--ignore-case` / `-i` | off | fold case when matching |
+| `--context` | 100 | chars of surrounding text shown each side of a match |
+| `--memory` | local memory | the memory holding the session |
+
+Absence of a match clears only the literal actually passed, in the session actually named.
 
 ### ask
 
@@ -125,9 +177,10 @@ claude/codex/hermes also installs the automation hooks — see [docs/automation.
 positional `memory` binds the server to a memory; `funes add <agent> <memory>` bakes it into the
 registration. `funes remove <agent>` reverses that agent integration without deleting memories or
 transcripts. Tools: `recall` (query, k, half_life, neighbors, candidates, block_type/harness
-filters, memory), `get` (session_id, from, to, memory), `sessions` (memory), `status` (memory) —
-each returns the corresponding agent-format string verbatim. A tool call's `memory` overrides the
-server's; with neither, it reads the local memory.
+filters, memory), `get` (session_id, from, to, memory), `sessions` (memory), `scan` (needle,
+session_id, ignore_case, context, memory), `status` (memory) — each returns the corresponding
+agent-format string verbatim. A tool call's `memory` overrides the server's; with neither, it reads
+the local memory.
 
 ## Working on the repo
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ workflow-oriented [documentation index](docs/README.md) for the complete guides.
 | --- | --- |
 | `funes add <agent> [memory]` / `funes remove <agent>` / `funes mcp [memory]` | [docs/add.md](docs/add.md) — supported agents, integration lifecycle, generic MCP clients, hooks, and memory binding |
 | `funes index [path]` | [docs/index.md](docs/index.md) — build/update the memory; sources, incremental, flags |
-| `funes recall "…"` / `funes get …` / `funes sessions` / `funes scan …` | [docs/recall.md](docs/recall.md) — recall passages and drill into them; enumerate and filter a memory's sessions; find a literal in every block of one |
+| `funes recall "…"` / `funes get …` / `funes sessions` / `funes scan …` / `funes sketch …` | [docs/recall.md](docs/recall.md) — recall passages and drill into them; enumerate and filter a memory's sessions; find a literal in every block of one; digest one without a query |
 | `funes ask <agent> "…"` | [docs/ask.md](docs/ask.md) — borrow an agent for a grounded answer |
 | `funes push <memory>` (+ `curate`, `scrub`, `status`) | [docs/push.md](docs/push.md) — publish and share a memory |
 | `funes update` | [installation and updating](#get-funes) — replace the installed binary with a verified release |

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ workflow-oriented [documentation index](docs/README.md) for the complete guides.
 | --- | --- |
 | `funes add <agent> [memory]` / `funes remove <agent>` / `funes mcp [memory]` | [docs/add.md](docs/add.md) — supported agents, integration lifecycle, generic MCP clients, hooks, and memory binding |
 | `funes index [path]` | [docs/index.md](docs/index.md) — build/update the memory; sources, incremental, flags |
-| `funes recall "…"` / `funes get …` | [docs/recall.md](docs/recall.md) — recall passages and drill into them |
+| `funes recall "…"` / `funes get …` / `funes sessions` / `funes scan …` | [docs/recall.md](docs/recall.md) — recall passages and drill into them; enumerate and filter a memory's sessions; find a literal in every block of one |
 | `funes ask <agent> "…"` | [docs/ask.md](docs/ask.md) — borrow an agent for a grounded answer |
 | `funes push <memory>` (+ `curate`, `scrub`, `status`) | [docs/push.md](docs/push.md) — publish and share a memory |
 | `funes update` | [installation and updating](#get-funes) — replace the installed binary with a verified release |
@@ -143,7 +143,8 @@ nothing. `funes recall` prints the raw ranked passages behind an answer, and `fu
 any cited turn in full.
 
 - [docs/index.md](docs/index.md) — the indexing pipeline, tiers, and incremental behavior.
-- [docs/recall.md](docs/recall.md) — retrieval, drill-down with `get`, and reading a shared memory.
+- [docs/recall.md](docs/recall.md) — retrieval, drill-down with `get`, enumeration with `sessions`,
+  exhaustive literal search of a session with `scan`, and reading a shared memory.
 - [docs/ask.md](docs/ask.md) — borrow an agent for a grounded answer, nothing installed.
 - [docs/automation.md](docs/automation.md) — the per-turn hooks that keep it all fresh.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,8 @@ This directory contains the user guides and design notes for
 - [Configuration and local files](configuration.md) — state paths, caches, authentication,
   integration files, and environment overrides.
 - [Remote-memory caching](hub-caching.md) — how `hf://` recall caches immutable Lance files.
+- [Extracting a corpus from a memory](corpus-extraction.md) — the spec for delegating session
+  selection to an agent, and why it prescribes no method.
 
 ## Design and reference
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ This directory contains the user guides and design notes for
 - [Building the memory](index.md) — index session transcripts and understand the indexing
   pipeline.
 - [Recalling](recall.md) — retrieve passages, drill into their surrounding turns, enumerate a
-  memory's sessions, and search one of them for a literal.
+  memory's sessions, search one of them for a literal, and digest one without a query.
 - [Asking](ask.md) — borrow a coding agent for one answer grounded in a memory.
 
 ## Sharing and automation

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,8 @@ This directory contains the user guides and design notes for
   Codex, pi, or Hermes.
 - [Building the memory](index.md) — index session transcripts and understand the indexing
   pipeline.
-- [Recalling](recall.md) — retrieve passages and drill into their surrounding turns.
+- [Recalling](recall.md) — retrieve passages, drill into their surrounding turns, enumerate a
+  memory's sessions, and search one of them for a literal.
 - [Asking](ask.md) — borrow a coding agent for one answer grounded in a memory.
 
 ## Sharing and automation

--- a/docs/agent-assisted-curation.md
+++ b/docs/agent-assisted-curation.md
@@ -1,0 +1,828 @@
+# Agent-assisted curation
+
+Status: design proposal
+
+Scope: assist `funes curate`; do not change indexing, recall, or publication authority
+
+## Summary
+
+Project memories are valuable only when someone reviews the sessions that enter them. That review is
+currently inexpensive to operate but expensive to judge: the picker shows the session's user
+prompts, while an included decision publishes the entire session. Long, tool-heavy sessions can
+therefore require reading hundreds of chunks to understand what was accomplished and whether the
+session is worth sharing.
+
+This design adds an optional, agent-assisted review layer:
+
+```text
+verbatim session
+      │
+      ▼
+deterministic session sketch
+      │  small, diverse, chronological evidence set
+      ▼
+LLM curation dossier
+      │  title, outcome, themes, cited claims, risks, recommendation
+      ▼
+human include / exclude / pending decision
+```
+
+The **session sketch** is the important boundary. It uses the embeddings already stored by funes to
+select a compact set of source passages before an LLM is called. The LLM describes only that
+evidence and cites its source turns. The human remains the only actor that can change a curation
+decision or publish a memory.
+
+The raw session is never summarized in place, rewritten, or deleted. The sketch and dossier are
+disposable sidecars over the verbatim memory. This keeps the design compatible with funes's
+deterministic ingest and exact provenance contracts.
+
+## Motivation
+
+The initial use case is a public memory of real Transformers maintainer sessions. A raw trace dump
+would be difficult to browse; manually writing a catalog of the useful sessions would not scale.
+Agent-assisted curation can produce both:
+
+- a reviewed, verbatim memory that `funes recall` and `funes ask` can read;
+- a human-oriented catalog explaining what each session contains and why it matters;
+- cited evidence that lets reviewers and readers inspect the original words behind every summary.
+
+This is especially valuable because the discoverable agent-trace datasets evaluated during funes's
+development were mostly synthetic or benchmark-generated. Very few individuals or organizations
+publish authentic working sessions. A reviewed Transformers memory would therefore contribute a
+kind of data the Hub does not already have in useful quantity, rather than another repackaging of a
+benchmark corpus.
+
+The same workflow should work for any organization publishing a project memory. It is deliberately
+optional because curation may send selected passages to the model provider configured behind an
+agent CLI.
+
+## Existing contracts
+
+The design must preserve these properties:
+
+1. **No LLM in ingest.** Indexing remains parse, chunk, embed, and append. The transcript stays the
+   source of truth.
+2. **Verbatim provenance.** Generated claims cite `session_id` and `turn_uuid`; the source passage is
+   always inspectable.
+3. **Human publication authority.** Agent output never writes `include` or `exclude` decisions.
+4. **Whole-session publication.** In the first version, an included session still publishes all of
+   its chunks. A sketch helps assess value; it does not prove that unselected content is safe.
+5. **Local-first operation.** No model is contacted unless the user explicitly requests assistance.
+6. **Fail-safe curation.** A missing, invalid, or stale dossier falls back to the existing review
+   experience. It never makes a pending session publishable.
+
+## Goals
+
+- Reduce a long session to a small evidence set that preserves its principal topics, pivots, and
+  outcome.
+- Make the evidence set deterministic for a fixed memory and selector version.
+- Give an LLM enough grounded context to produce a useful session title and dossier.
+- Require citations for every factual claim in the dossier.
+- Cut human review time without weakening the existing include gate.
+- Cache results and invalidate them whenever the source session changes.
+- Keep the selector small enough to run locally and quickly over ordinary project memories.
+
+## Non-goals
+
+- Automatically approving sessions for publication.
+- Certifying that an entire session is free of PII, confidential information, or unsafe content.
+- Replacing the existing push-time secret scanner.
+- Deleting low-value chunks from the local or remote memory.
+- Generating mutable facts or a canonical summary used by recall.
+- Selecting evidence from a two-dimensional visualization projection.
+- Solving query-specific retrieval; `recall` already does that.
+
+## Terminology
+
+- **Stored chunk:** one embedded row in the Lance memory. Long blocks may be split into overlapping
+  chunks.
+- **Evidence unit:** one reconstructed source block with its stored metadata and an aggregate
+  embedding. Selection operates on evidence units, not raw chunk splits.
+- **Context envelope:** the selected evidence unit plus enough neighboring conversation to make it
+  intelligible to a reviewer or LLM.
+- **Semantic axis:** a direction of variation discovered from actual session evidence. It is
+  data-anchored, not a label invented by an LLM.
+- **Session sketch:** an ordered, budgeted set of context envelopes plus selector diagnostics.
+- **Curation dossier:** structured agent output grounded exclusively in a session sketch.
+
+## Why not select directly from UMAP or PCA?
+
+`funes-viz` projects the stored embeddings with UMAP for interactive exploration. A two-dimensional
+projection is useful for seeing neighborhoods, but it can distort distances and is not a reliable
+selection space. Session sketching must use the original normalized 384-dimensional vectors.
+
+Plain PCA is also insufficient as an importance measure. A high-variance direction can be repeated
+compiler output, harness scaffolding, or an unusually large failed detour. Furthermore, a principal
+component has two ends; selecting only the highest projection silently discards half of the semantic
+contrast.
+
+The proposed selector retains the useful intuition—find the few directions that span a session—but
+adds three controls:
+
+1. semantic axes generate candidates rather than final decisions;
+2. both ends of every axis are represented;
+3. a final coverage objective prefers candidates that explain the rest of the session.
+
+This resembles semantic-volume extractive summarization, which repeatedly selects evidence that
+adds a new direction to the current span, and submodular summarization, which balances coverage and
+diversity:
+
+- [Extractive Summarization by Maximizing Semantic Volume](https://aclanthology.org/D15-1228/)
+- [A Class of Submodular Functions for Document Summarization](https://aclanthology.org/P11-1052/)
+
+## Session sketch design
+
+### 1. Load and reconstruct evidence units
+
+Read the candidate session's rows with the columns needed for provenance, display, and selection:
+
+```text
+id, text, session_id, turn_uuid, parent_uuid, seq, ts, role,
+block_type, tool_name, block_idx, split_idx, vector
+```
+
+Group rows by `(session_id, turn_uuid, block_idx)`, sort by `split_idx`, and use the existing stitch
+logic to reconstruct each block. This prevents overlap text from appearing twice in the LLM prompt
+and avoids selecting an unintelligible middle split.
+
+Aggregate the split embeddings into one block embedding:
+
+1. Give the first split its character length as weight.
+2. For each later split, subtract the overlap matched by the stitch operation from its character
+   length.
+3. Compute the weighted mean of the stored split embeddings.
+4. L2-normalize the result.
+
+The weighting is approximate—the embedding of a concatenation is not exactly the mean of its
+parts—but it prevents a 150-character overlap from being counted as new semantic mass. It also
+avoids re-embedding private source text or loading the embedder during curation.
+
+Preserve the original block text separately. The aggregate vector is a selection aid, never a new
+stored representation.
+
+### 2. Assign deterministic eligibility and weights
+
+The selector distinguishes whether a block may become evidence from how much it should influence
+coverage.
+
+| Block | Eligible by default | Coverage weight | Notes |
+| --- | --- | --- | --- |
+| Real user text | yes | 1.0 | Opening request and later corrections are valuable. |
+| Assistant text | yes | 1.0 | Usually contains decisions, explanations, and outcomes. |
+| Tool use | yes | 0.35 | Useful for concrete actions, but often redundant with prose. |
+| Tool result | yes | 0.20 | Can prove tests or failures; large logs must not dominate. |
+| Thinking | no | 0 | Excluded from agent assistance in v1, even when indexed. |
+| Harness scaffolding | no | 0 | Reuse and extend `curate::is_scaffolding`. |
+
+Additional deterministic adjustments:
+
+- Collapse exact duplicate reconstructed text within a session.
+- Initially treat cosine similarity `>= 0.97` as a near-duplicate relation. Keep the earliest and
+  latest occurrences as candidates but divide their coverage mass across the duplicate group. The
+  threshold is an evaluation parameter, not a public CLI knob.
+- Do not discard short closing messages solely by length; the final assistant text is an explicit
+  anchor below.
+
+These are selection weights, not value judgments. A low-weight tool result can still be selected if
+it is the only evidence for a distinct topic or transition.
+
+For the formulas below, define two values per eligible unit:
+
+```text
+length_factor_i = clamp(sqrt(characters_i / 200), 0.25, 1.0)
+quality_i       = type_weight_i * length_factor_i
+mass_i          = type_weight_i / duplicate_group_size_i
+```
+
+`quality_i` controls whether a block is a good representative of an axis; a one-word response is a
+weaker exemplar than a self-contained paragraph. `mass_i` controls how much of the session the block
+represents and deliberately does not grow with length. Consequently a 20,000-character log cannot
+outvote twenty concise reasoning blocks merely because it is long. Mandatory anchors are exempt
+from the quality preference.
+
+### 3. Build turn vectors for chronology
+
+Semantic coverage treats a session as a set. Agent sessions are also trajectories, and their pivots
+are often the interesting parts.
+
+Group evidence units by `(seq, turn_uuid)` and compute a normalized turn vector from their weighted
+block vectors. For every boundary between turns, compare a small mean vector on the left with a
+small mean vector on the right:
+
+```text
+transition(i) = 1 - cosine(mean(turn[i-w .. i]), mean(turn[i+1 .. i+w]))
+```
+
+Use a default window of two turns on each side. Apply non-maximum suppression within two sequence
+positions so one topic change contributes one candidate rather than several adjacent ones. Keep the
+strongest `T = min(6, max(1, floor(B / 2)))` transition points for evidence-unit budget `B`.
+
+This captures events that global geometry alone can miss:
+
+- the user corrects a mistaken premise;
+- a planned implementation changes after a test failure;
+- exploration becomes a concrete decision;
+- an apparent solution is reverted near the end.
+
+### 4. Add mandatory anchors
+
+Reserve space for up to three anchors:
+
+1. the first eligible user text block;
+2. the last eligible assistant text block;
+3. the medoid nearest the weighted session centroid, unless already represented.
+
+Compute the centroid as `mu = sum_i(mass_i * x_i) / sum_i(mass_i)`, without normalizing it before
+centering. The medoid is the evidence unit with greatest cosine similarity to the normalized
+centroid. The opening and closing anchors preserve the requested task and apparent outcome. The
+medoid represents the session's dominant semantic region. An absent role simply omits its anchor;
+it is not synthesized.
+
+Anchors are mandatory candidates, but their context envelopes remain subject to the overall input
+budget. If the closing block is a trivial acknowledgement, the final coverage stage may retain it as
+context without treating it as a key event in the dossier.
+
+### 5. Discover data-anchored semantic axes
+
+Let `x_i` be an eligible unit's normalized vector and `mu` the weighted session centroid. Work with
+the centered vector `y_i = x_i - mu`.
+
+Use a bounded pivoted residual procedure rather than a full SVD:
+
+```text
+Q = empty orthonormal basis
+repeat up to R axes:
+    for every unit i:
+        residual_i = y_i - projection_Q(y_i)
+        pivot_score_i = quality_i * norm(residual_i)
+    pivot = argmax(pivot_score)
+    q = normalize(residual_pivot)
+    add q to Q using modified Gram-Schmidt
+    add argmax_i(quality_i * max(0, dot(q, y_i))) to the pool
+    add argmax_i(quality_i * max(0, -dot(q, y_i))) to the pool
+    stop only if every residual is numerically zero
+```
+
+For evidence-unit budget `B` and `A` distinct anchors, start with
+`R = min(6, max(1, floor((B - A) / 2)))`; retain an absolute cap of eight for experiments. The
+default `B = 12` therefore discovers four axes when all three anchors exist. Both extremes are added
+because the sign of an axis is arbitrary and the contrast can encode the session's progression—for
+example, rejected approach versus final approach.
+
+This is effectively a small pivoted-QR sketch over the session. It has useful properties for funes:
+
+- it is deterministic with stable tie-breaking by `(seq, block_idx, id)`;
+- it uses only dot products and vector updates, so no new linear-algebra dependency is required;
+- its cost is `O(R × units × 384)`;
+- every axis is anchored by inspectable source evidence;
+- unlike farthest-point sampling alone, it does not repeatedly select the same already-covered
+  direction.
+
+Do not introduce a semantic residual threshold in v1. Stop only at the fixed axis cap or numerical
+rank exhaustion. An explained-variance-looking number would be poorly calibrated for these
+embeddings and could make otherwise identical review behavior depend on floating-point noise.
+
+### 6. Form the candidate pool
+
+The pool is the union of:
+
+- mandatory anchors;
+- positive and negative semantic-axis extremes;
+- for each strongest chronological transition, the last eligible text block on its left and the
+  first eligible text block on its right.
+
+Deduplicate the pool by evidence-unit identity. Cap it at four times the final unit budget, retaining
+anchors first, then axis candidates, then transitions with stable score ordering. For a 12-unit
+sketch, at most 48 candidates enter final selection.
+
+### 7. Select for weighted session coverage
+
+Choose the final set greedily under both a unit limit and an approximate character budget. Anchors
+seed the set. For each remaining candidate `c`, calculate its marginal gain:
+
+```text
+coverage_gain(c) =
+    sum over all eligible units i of
+        mass_i * max(0, cosine(x_i, x_c) - covered_i)
+
+average_mass       = sum_i(mass_i) / B
+transition_bonus(c)= 0.5 * average_mass * normalized_transition(c)
+marginal_chars(c)  = characters added after merging c's envelope with selected envelopes
+
+score(c) = (coverage_gain(c) + transition_bonus(c))
+           / sqrt(1 + marginal_chars(c) / 4000)
+```
+
+`covered_i` is the best cosine similarity between unit `i` and anything already selected. Divide a
+candidate's score by a sublinear function of its marginal context-envelope character cost so long
+evidence must add more coverage but is not categorically excluded. `normalized_transition(c)` is
+the boundary score from step 3 divided by the greatest boundary score in the session; it is zero for
+non-transition candidates. The `0.5` prior makes the strongest pivot worth half an average selection
+slot before considering its semantic coverage. This constant and the cost scale are hypotheses for
+the offline evaluation, not user-facing controls.
+
+The coverage objective already supplies the redundancy penalty: once a region is covered, another
+nearby candidate has little marginal gain. The closing outcome needs no separate bonus because it is
+a mandatory anchor.
+
+Precompute the candidate-to-unit similarity matrix once. With `M` evidence units, `P <= 48`
+candidates, dimension 384, and budget `B <= 16`, the expensive work is bounded by
+`O(P × M × 384)`; greedy updates are `O(B × P × M)`. There is no `M × M` similarity matrix.
+
+Raw cosine coverage must not be displayed as a percentage in v1. Sentence embeddings are
+anisotropic, and an apparently precise "82% covered" would not yet have a calibrated human meaning.
+Coverage is an internal objective and evaluation diagnostic until it is correlated with reviewer
+labels.
+
+### 8. Build context envelopes
+
+Selection identifies blocks; reviewers and LLMs need conversational context. Each selected block
+expands to an envelope containing:
+
+- all otherwise-eligible blocks in its containing turn;
+- the nearest preceding eligible user-text turn, if different;
+- the nearest following eligible assistant-text turn, if different;
+- exact `session_id`, `turn_uuid`, `seq`, role, and block type for every included block.
+
+Thinking and scaffolding remain excluded during expansion. A neighboring turn cannot reintroduce a
+block that was ineligible for agent assistance.
+
+Overlapping envelopes are merged. The final evidence is sorted by sequence, not selector score, so
+the LLM sees the session as a compressed narrative rather than a relevance ranking.
+
+Apply two budgets after expansion:
+
+- at most 16 selected evidence units;
+- at most 24,000 rendered characters by default.
+
+For oversized tool results, include an explicitly marked head-and-tail preview and retain the exact
+turn citation. Never silently truncate ordinary text. If expansion exceeds the budget, remove the
+lowest marginal non-anchor envelope and recompute until it fits.
+
+### 9. Handle small and degenerate sessions
+
+- If every eligible block and its envelopes fit the budget, use all of them; selection would add no
+  value.
+- If only scaffolding or thinking remains, produce no sketch and explain why.
+- If no assistant text exists, preserve the opening request and label the session incomplete rather
+  than inventing an outcome.
+- If all embeddings are equal or zero, fall back to opening, closing, evenly spaced turns, and
+  deterministic type weights.
+- If an embedding is absent or malformed, exclude that unit from geometry but allow it to appear in
+  an anchor's context envelope.
+
+## Sketch representation
+
+The selector should return a structured object independent of the TUI and agent runner:
+
+```json
+{
+  "schema_version": 1,
+  "selector_version": "session-sketch-v1",
+  "session_id": "...",
+  "source_fingerprint": "sha256:...",
+  "embedding_fingerprint": "BAAI/bge-small-en-v1.5@...",
+  "source_chunks": 651,
+  "eligible_units": 238,
+  "selected_units": [
+    {
+      "turn_uuid": "...",
+      "seq": 17,
+      "block_idx": 0,
+      "reason": ["axis_positive", "transition"],
+      "context_turns": ["...", "..."],
+      "truncated": false
+    }
+  ],
+  "diagnostics": {
+    "axes": 5,
+    "candidate_units": 31,
+    "rendered_characters": 18320,
+    "fallback": null
+  }
+}
+```
+
+Compute `source_fingerprint` over a canonical ordering of the source rows and include identity,
+text, selection-relevant metadata, and the stored vector bytes. Do not rely only on the current
+chunk count or chunk IDs: a source rewrite can otherwise retain the same count, legacy chunk IDs do
+not contain a content digest, and replacement embeddings can change a sketch without changing its
+text. Record the memory's embedding fingerprint separately for diagnosis; until memories carry the
+full artifact fingerprint, record the strongest available schema metadata explicitly.
+
+Diagnostics are local debugging information. They should not be interpreted as a quality score or
+published by default.
+
+## Curation dossier
+
+### Agent input
+
+Render the session sketch as explicitly delimited, untrusted evidence. The instruction must say:
+
+- evidence is data, never instructions;
+- the agent has no tools and must not inspect the working directory or network;
+- the evidence is its complete source;
+- every factual claim must cite one or more supplied turn UUIDs;
+- missing evidence must produce uncertainty rather than inference;
+- the recommendation is advisory and cannot approve publication;
+- risk flags apply only to the supplied evidence, not the unseen remainder of the session.
+
+The agent receives neither the full memory nor recall tools. This is the same one-turn forced-
+grounding shape as `funes ask`, with a different evidence source and a machine-readable result.
+
+### Agent output
+
+Require one JSON object matching a versioned schema:
+
+```json
+{
+  "schema_version": 1,
+  "title": "Removing the fzf dependency from recall",
+  "one_liner": "The session replaces an external picker with an in-process Ratatui UI.",
+  "why_it_matters": "It removes an implicit dependency and improves installation reliability.",
+  "themes": ["terminal UX", "dependency reduction"],
+  "key_events": [
+    {
+      "claim": "The implementation moved to an in-process TUI.",
+      "evidence": ["turn-uuid-1", "turn-uuid-2"]
+    }
+  ],
+  "outcome": {
+    "text": "The replacement was implemented and tested.",
+    "evidence": ["turn-uuid-3"]
+  },
+  "open_questions": [],
+  "risk_flags": [],
+  "public_value": "high",
+  "recommendation": "include_candidate",
+  "confidence": 0.86
+}
+```
+
+Allowed recommendations are `include_candidate`, `exclude_candidate`, and `needs_full_review`.
+Their names deliberately avoid collision with curation's authoritative `include` and `exclude`
+states.
+
+Validate before caching or display:
+
+- strict JSON and schema version;
+- bounded strings and list sizes;
+- every cited turn exists in the supplied sketch;
+- every key event and outcome has at least one citation;
+- enum values are known;
+- confidence is finite and in `[0, 1]`.
+
+Citation existence is not proof of entailment. The TUI must make the cited evidence one key away,
+and the reviewer remains responsible for the decision. Dialogue summarization has substantial
+faithfulness failure rates, so an uncited fluent summary is not acceptable evidence:
+
+- [Analyzing and Evaluating Faithfulness in Dialogue Summarization](https://aclanthology.org/2022.emnlp-main.325/)
+- [On Positional Bias of Faithfulness for Long-form Summarization](https://aclanthology.org/2025.naacl-long.442/)
+
+## CLI and TUI experience
+
+The existing command remains deterministic and contacts no model:
+
+```console
+funes curate <memory>
+```
+
+Explicit assistance generates or refreshes dossiers for pending and stale candidate sessions before
+opening the picker:
+
+```console
+funes curate <memory> --assist claude
+funes curate <memory> --assist codex
+```
+
+The first run must disclose that selected session passages will be sent to the configured agent
+provider and ask for confirmation in a terminal. Non-interactive use requires an explicit consent
+flag; it must not infer consent from the presence of an agent CLI.
+
+Inside the picker:
+
+- the row keeps the authoritative `✓`, `✗`, or pending glyph;
+- an additional neutral glyph indicates that a fresh dossier exists;
+- the default preview shows title, one-line summary, recommendation, key events, and risk flags;
+- `e` shows the cited sketch evidence in chronological order;
+- `f` opens the full reassembled session transcript for human review;
+- `a` generates or refreshes assistance for the selected session;
+- right and left arrows remain the only include and exclude actions;
+- agent failure leaves the row pending and the current prompt preview usable.
+
+Batch assistance should process only pending or stale sessions and reuse fresh cached results.
+
+## Persistence and invalidation
+
+Keep generated material separate from the human-editable curation decision file:
+
+```text
+<funes-home>/curation-assist/<sanitized-memory>/<session-id>.json
+```
+
+Persist:
+
+- the complete session sketch;
+- the validated dossier;
+- source fingerprint;
+- embedding fingerprint;
+- selector and dossier schema versions;
+- prompt version;
+- agent name and reported model when available;
+- generation timestamp;
+- failure diagnostics that contain no evidence text.
+
+A cache entry is stale when any of the source fingerprint, embedding fingerprint, selector version,
+prompt version, or output schema changes. Changing a human include/exclude decision does not
+invalidate it. A stale dossier may be displayed as historical information but cannot seed a fresh
+recommendation.
+
+Nothing in this directory is pushed by `funes push`. Publishing a catalog is a separate, future,
+explicit operation.
+
+## Privacy, safety, and isolation
+
+### Assistance is data egress
+
+Agent CLIs may use hosted models. Before spawning one, funes must say that the rendered sketch—not
+the entire memory—will be sent to that agent's configured provider. A future local-model backend can
+offer a no-egress option, but the first version must not describe hosted assistance as local.
+
+Thinking blocks are excluded from v1 agent assistance regardless of whether the memory indexed
+them. This reduces accidental disclosure and avoids presenting hidden reasoning as public evidence.
+
+### The sketch is not a safety review
+
+If an included decision publishes the whole session, unselected text also publishes. Therefore:
+
+- the push-time secret scan must still inspect all to-push blocks;
+- a maintainer must still perform whatever full-session privacy and confidentiality review the
+  organization requires;
+- dossier risk flags must be labeled "observed in selected evidence," never "session is safe";
+- no confidence threshold may bypass human review.
+
+Known-secret detection also does not constitute PII or confidential-information detection. Broader
+policy scanning is a separate design.
+
+### Treat trace text as untrusted
+
+A trace can contain prompt injection written by a user, model, repository, or tool result. The
+curation child must run with:
+
+- MCP servers and other tools disabled rather than merely discouraged;
+- no network tool access beyond the model call itself;
+- an empty temporary working directory;
+- closed stdin;
+- strict structured-output parsing;
+- no authority to edit curation files or publish.
+
+If an agent CLI cannot enforce this isolation, that agent is not supported for curation assistance
+until it can.
+
+### Do not index the curation child
+
+An assistant session contains copied private evidence and can otherwise become a new session that
+funes indexes, creating duplication or recursive curation. The implementation must establish a
+reliable exclusion mechanism before shipping:
+
+1. mark the child as a funes-internal run so installed per-turn and session hooks no-op;
+2. run it outside every project checkout so it cannot acquire project attribution;
+3. capture its agent session identifier and persist it in an ignored-session registry so a later
+   manual index sweep also skips it;
+4. test both immediate hooks and later full harness-directory indexing.
+
+An ephemeral/no-history CLI mode may be used where available, but the design must not rely on an
+unstable provider-specific flag as its only defense.
+
+## Publication model
+
+### Version 1: whole sessions plus a local dossier
+
+The first implementation changes review only. An included decision still ships the complete
+session. Dossiers remain local. This is the smallest change and preserves every current remote-memory
+contract.
+
+For an official Transformers launch, a separate release tool or deliberate manual process can turn
+approved dossiers into a catalog after maintainers review their wording. The memory itself remains
+the verbatim source.
+
+### Future: public catalog
+
+A public catalog could contain:
+
+- session title and one-line summary;
+- maintainer-approved themes and why-it-matters text;
+- cited turn UUIDs;
+- source fingerprint and generation provenance;
+- an explicit `generated_with` label.
+
+It should be an auxiliary table or file, not rows mixed into the recall index. Updating a generated
+summary must not mutate the underlying event log.
+
+### Future: session capsules
+
+Publishing only selected turns could reduce noise and disclosure surface, but it creates a lossy
+artifact with a different promise from a project memory. If developed, call it a **session capsule**
+and publish it as a separate view with explicit omissions. Never make an ordinary `include` decision
+silently mean "publish only the sketch."
+
+## Across-session curation
+
+The within-session sketch answers: "What happened here?" A public collection also needs to answer:
+"Which sessions make a varied, compelling corpus?"
+
+After the first version is validated, add a collection-level pass over human-approved dossiers:
+
+1. represent each session by the normalized mean of its selected evidence vectors, while retaining
+   the individual evidence vectors as its richer signature;
+2. group sessions by approved dossier themes;
+3. use the same coverage objective to identify redundant sessions and underrepresented areas;
+4. show suggestions such as "similar to three already included sessions," never automatic
+   exclusions;
+5. let maintainers assemble a balanced launch set: architecture decisions, debugging, tests,
+   regressions, API design, release work, and failed approaches.
+
+This second level is likely what turns a Transformers memory from a large dataset into an editorial
+event, but it depends on trustworthy within-session sketches and should not block the MVP.
+
+## Evaluation
+
+### Gold set
+
+Build a reviewed set of 30–50 real sessions spanning:
+
+- short and very long sessions;
+- prose-heavy and tool-heavy work;
+- clean successes, abandoned attempts, and reversals;
+- multiple harnesses;
+- sessions a maintainer would include and exclude;
+- sessions with sensitive or internal-looking content.
+
+For each session, humans label:
+
+- salient source blocks or turns;
+- opening task, major pivots, decision, and outcome;
+- whether the session is worth including;
+- whether the generated dossier's claims are supported;
+- time needed to make the publication decision.
+
+Safety labels exercise warnings and escalation only. They do not train an automatic publication
+gate.
+
+### Selector baselines
+
+Compare:
+
+1. current user-prompts preview;
+2. opening and closing turns plus evenly spaced evidence;
+3. centroid plus PCA positive/negative extremes;
+4. data-anchored axes alone;
+5. axes plus chronological transitions;
+6. the complete proposed selector with final coverage optimization;
+7. full-session LLM summarization as an expensive reference, not a target architecture.
+
+### Metrics
+
+- **Salient evidence recall:** fraction of human-marked turns represented directly or in an
+  envelope.
+- **Compression:** sketch characters divided by eligible source characters.
+- **Redundancy:** mean maximum similarity among selected non-anchor units.
+- **Citation precision:** fraction of dossier claims supported by their cited evidence, judged by a
+  human.
+- **Decision agreement:** assisted versus full-review include/exclude choice.
+- **Review time:** median time to a confident human decision.
+- **Failure rate:** sessions with no valid sketch or dossier.
+- **Cost and latency:** per session and per 50-session batch for each agent.
+
+### Initial success criteria
+
+Proceed from experiment to product integration when the complete selector:
+
+- recalls at least 90% of human-marked salient evidence within 16 selected units;
+- keeps the median rendered sketch at or below 24,000 characters;
+- reduces median review time by at least 50%;
+- produces no statistically meaningful reduction in include/exclude agreement versus full review;
+- yields fully valid citations for at least 95% of dossier claims after one generation attempt;
+- never writes a curation decision or publishes as a side effect.
+
+These thresholds are hypotheses to validate, not claims about current performance.
+
+## Implementation plan
+
+### Phase 0: offline selector experiment
+
+- Add a read-only experimental command or benchmark that emits session-sketch JSON.
+- Implement block reconstruction, weighted vector aggregation, axes, transitions, coverage, and
+  envelopes.
+- Run the selector baselines on the gold set.
+- Tune only the small set of documented constants; avoid project-specific keyword rules.
+
+Exit criterion: the deterministic selector meets the salient-evidence and compression targets.
+
+### Phase 1: sketch in the existing picker
+
+- Add a structured `SessionSketch` API in the library.
+- Generate sketches locally for pending project sessions.
+- Add sketch evidence as an alternate TUI preview without calling an LLM.
+- Cache by content fingerprint and exercise invalidation on session growth and rewrites.
+
+Exit criterion: maintainers prefer sketch-assisted review to the current prompt-only preview and no
+publication behavior changes.
+
+### Phase 2: agent-generated dossiers
+
+- Refactor the safe common child-runner seam from `ask` without coupling curation to recall.
+- Enforce no-tools isolation and internal-session exclusion.
+- Add versioned prompt and output schemas for Claude and Codex.
+- Validate, cache, and render dossiers with one-key citation drill-down.
+- Add explicit egress consent and non-interactive safeguards.
+
+Exit criterion: dossier validity, faithfulness, latency, and review-time targets are met.
+
+### Phase 3: approved public catalog
+
+- Define a Hub-side catalog schema and generation provenance.
+- Require a separate maintainer approval for generated wording.
+- Publish the Transformers maintainer memory and its catalog together.
+- Update funes-viz to use catalog titles and themes while its maps continue to project raw stored
+  vectors.
+
+Exit criterion: public readers can browse the stories, inspect cited source turns, and recall over
+the unchanged verbatim memory.
+
+### Phase 4: collection balancing and capsules
+
+- Evaluate across-session redundancy and theme coverage.
+- Design session capsules separately if there is demand for a deliberately lossy public view.
+- Do not alter ordinary project-memory semantics without a new explicit contract.
+
+## Testing requirements
+
+Unit tests:
+
+- overlap-aware vector aggregation and zero-vector handling;
+- stable evidence-unit ordering and tie-breaking;
+- axis selection chooses both extrema and stops at the cap;
+- transition non-maximum suppression;
+- candidate-pool bounds;
+- coverage updates, budget removal, and mandatory anchors;
+- exact and near-duplicate behavior;
+- source fingerprint changes on text or metadata rewrites;
+- strict dossier schema and citation validation.
+
+Integration tests:
+
+- a long fixture produces the same sketch across repeated runs;
+- a grown session invalidates its sketch and dossier;
+- a same-count source rewrite invalidates the cache;
+- agent failure falls back to deterministic review;
+- neither agent output nor trace instructions can set a decision;
+- the child has no tools, runs outside the repo, and is not indexed by immediate or later sweeps;
+- push ships exactly the same rows with assistance enabled or disabled for identical human
+  decisions.
+
+Adversarial tests:
+
+- evidence containing instructions to ignore the schema or publish the session;
+- malicious tool output containing JSON delimiters and fake turn UUIDs;
+- oversized logs, repeated boilerplate, and all-identical embeddings;
+- invalid UTF-8 boundaries are impossible because all budgets operate on Unicode scalar values;
+- a dossier cites unseen or nonexistent evidence;
+- hosted-agent disclosure is declined or unavailable in a non-terminal run.
+
+## Persona review
+
+**Early adopter:** The dossier makes a thousand-chunk session understandable in a minute, while the
+evidence view keeps it auditable.
+
+**Project maintainer:** The workflow removes mechanical reading but preserves the only decision that
+matters: whether the whole session may enter the project memory.
+
+**Skeptic:** Semantic variance is not importance and an LLM can hallucinate. The selector therefore
+uses axes only to generate candidates, optimizes final coverage, and requires source citations.
+
+**Privacy reviewer:** A sketch cannot clear unseen content. The design labels its risk observations
+as incomplete and leaves whole-session review and push scanning in place.
+
+**Community reader:** A catalog turns an opaque trace corpus into stories about decisions, failures,
+and discoveries, with direct paths back to the source.
+
+**Funes maintainer:** The feature composes above the existing memory instead of weakening its core
+contract: deterministic ingest below, optional synthesis at review time, and human authority at the
+publication boundary.
+
+## Recommended decisions
+
+1. Name the deterministic artifact **session sketch** and the generated artifact **curation
+   dossier**.
+2. Use original stored vectors; never select from UMAP coordinates.
+3. Use bounded data-anchored axes plus transitions to generate candidates, then coverage to select
+   the final set.
+4. Select reconstructed blocks and present context envelopes, not raw split chunks.
+5. Exclude thinking from agent assistance in v1.
+6. Keep dossiers out of `funes push` until a separate public-catalog contract exists.
+7. Preserve whole-session curation semantics in the MVP.
+8. Do not ship the LLM layer until its child sessions are reliably isolated from tools, hooks, and
+   later indexing.
+9. Validate the selector before investing in prompt or TUI polish; if the evidence is wrong, fluent
+   summaries only conceal the error.

--- a/docs/corpus-extraction.md
+++ b/docs/corpus-extraction.md
@@ -1,0 +1,50 @@
+# Extracting a corpus from a memory
+
+A worked example of building on funes: instead of a feature that selects sessions, delegate the
+selection to an agent that uses the memory as its substrate.
+
+The task below picks the sessions of one memory that are worth publishing — either because the work
+landed, or because the session shows a claim of a reference document being argued — and safe to
+publish. The result is a list of session ids.
+
+This is a **spec**, not a procedure. It states what qualifies and what the answer must report.
+Nothing here says how to find the sessions: that is the agent's problem.
+
+## The prompt
+
+```markdown
+Extract from `<org>/<repo>` the sessions worth publishing as a public corpus.
+
+A session qualifies if rule 1 holds, either form of rule 2 does, and rule 3
+does not exclude it.
+
+1. It is an <org>/<repo> session.
+
+2a. It ended in a pull request that was merged into main.
+2b. It illustrates a specific claim in <reference document> — shows the claim
+    being reasoned about, decided, or demonstrated, not merely sharing its
+    vocabulary.
+
+3. Exclude the session when its evidence mentions or reveals any of:
+   - an internal or non-public project, codename, repository, system,
+     customer, or partner;
+   - a private/internal discussion, strategy, negotiation, or decision;
+   - an identifiable person in an internal or non-public context;
+   - unannounced intent, roadmap work, planned action, or other non-public
+     future activity.
+
+   Do not infer that an ordinary open-source project name, public issue, or
+   publicly documented person is internal merely because it is specific. Cite
+   the exact evidence that creates or resolves the risk. Absence of a match is
+   not clearance: report a session you could not clear as unverified, never as
+   qualifying.
+
+Output: the qualifying session ids, one per line, each naming the form of
+rule 2 it qualifies under and what it shows — for 2a, the pull request it
+produced; for 2b, the claim it illustrates and a one-line description. Then,
+which claims found no session, which sessions rule 3 excluded and on what
+evidence, and which you could not clear either way.
+```
+
+Adapt the memory, the project, the source of the claims, and what rule 3 treats as internal.
+The shape carries over.

--- a/docs/recall.md
+++ b/docs/recall.md
@@ -46,6 +46,9 @@ from. `no results` prints when nothing matched. The exact shape is a contract �
 | `--harness` | — | restrict to `claude \| codex \| pi \| hermes` |
 | `--memory` | local | the memory to read (see below) |
 
+The MCP `recall` tool takes the same parameters and defaults, so an agent can widen a search it finds
+too narrow — most usefully `half_life: 0` when the answer may be old.
+
 ## Reading turns with `get`
 
 ```bash

--- a/docs/recall.md
+++ b/docs/recall.md
@@ -93,24 +93,55 @@ outside it.
 ## Enumerating with `sessions`
 
 ```bash
-funes sessions [--memory <label>]
+funes sessions [--repo <owner/name>] [--since <date>] [--until <date>] [--limit <n>] [--offset <n>] [--memory <label>]
 ```
 
 Recall ranks: it returns the passages closest to a query and says nothing about everything it did
-not reach. So it cannot answer *how much is in here* or *how much of it have I looked at*.
-`sessions` can — it lists every session in the memory, oldest first, with its provenance and turn
-count:
+not reach. So it cannot answer *how much is in here*, *which sessions is this about*, or *how much
+of it have I looked at*. `sessions` can — it lists the memory's sessions, oldest first, each with
+its provenance, turn count, and the prompt it opened with:
 
 ```console
-$ funes sessions --memory huggingface/funes-memory
-[2026-06-19T01:29:59.000Z] claude_code -home-u-funes/0123456789abcdef 47 turns
+$ funes sessions --memory huggingface/funes-memory --since 2026-06-01
+[2026-06-19] claude_code huggingface/funes 47 turns 0123456789abcdef
+  why did we switch off the streaming parser
 …
 ---
 28 sessions
 ```
 
+That opening prompt is the point. It is the cheapest triage there is — what a session was for,
+without reading any of it — and it is the first thing a human actually typed, since injected
+scaffolding (`<system-reminder>` wrappers, agent-notes preambles, compaction recaps) is skipped. The
+provenance column is the session's source repo when its checkout resolved at index time, and the
+working directory when it didn't.
+
 Turns are counted distinct rather than by row, since a long turn is stored as several chunks. The
 session id is printed in full, so the line feeds `funes get` or `funes scan` as is.
+
+### Narrowing
+
+Prompts make a row worth reading and also make it longer, so a listing is **bounded to 50 rows by
+default**, keeping the most recent, and tells you both what it held back and how to get it:
+
+```console
+---
+50 of 726 sessions — 676 older: continue with --offset 50, or narrow with --repo/--since/--until
+```
+
+The closing line always states the full match count, so coverage stays knowable even when the
+listing is partial. `--limit` raises the page to at most 200 rows, and the reply stops at around
+40,000 characters regardless — past that it is an answer nobody receives.
+
+To cover the whole population, walk it: `--offset` skips that many of the most recent matches before
+taking `--limit`, and the trailer names the offset to use next. (`--limit 0` used to mean "every
+match", before a listing had a ceiling; it is now an error rather than an empty reply.) Rows are ordered on (timestamp,
+session id), so a given offset always names the same session — a walk neither repeats a row nor skips
+one. Date-stepping cannot promise that, since a single day holds many sessions.
+
+Better still, narrow: `--repo owner/name` keeps the sessions whose checkout resolved to that repo
+(worktrees and scratch directories of the same clone included, which matching on the working
+directory would miss), and `--since`/`--until` bracket the start date inclusively as `YYYY-MM-DD`.
 
 ## Finding a literal with `scan`
 

--- a/docs/recall.md
+++ b/docs/recall.md
@@ -110,7 +110,54 @@ $ funes sessions --memory huggingface/funes-memory
 ```
 
 Turns are counted distinct rather than by row, since a long turn is stored as several chunks. The
-session id is printed in full, so the line feeds `funes get` or `funes curate --include` as is.
+session id is printed in full, so the line feeds `funes get` or `funes scan` as is.
+
+## Finding a literal with `scan`
+
+```bash
+funes scan <needle> <session_id> [--from <seq>] [--to <seq>] [--ignore-case] [--context <chars>] [--memory <label>]
+```
+
+Recall proves presence. It ranks passages by similarity and returns the best few, so it can show
+that a memory discusses something — never that it does not. `scan` is the other half: a literal
+string checked against **every** block of one session, so a zero means the string is nowhere in
+that session.
+
+```console
+$ funes scan "acme-internal" af33dfe0-8576-435d-bc7a-016595b65402 --memory huggingface/funes-memory
+scan "acme-internal" in af33dfe0-8576-435d-bc7a-016595b65402 — 2 hits
+[2026-07-07T11:34:19.737Z] tool_result seq214
+  → get af33dfe0-8576-435d-bc7a-016595b65402 4c1e… --memory huggingface/funes-memory
+  … remote add upstream git@github.com:acme-internal/pipeline.git …
+```
+
+**A session at a time**, because that is the shape of the question. "Does this session mention an
+internal project" is answerable; "is this term anywhere in the memory" was never a clearance for any
+particular session, and the verb no longer offers it. Use [`sessions`](#listing-a-memorys-sessions)
+to enumerate what to screen, and scan each one you care about — a session read costs a filtered scan
+of its own rows, not a pass over the memory.
+
+It is **literal, not a regex** — deliberately. The whole point of the verb is that zero hits reads
+as *clean*, and a pattern that silently matches nothing is a false clearance. `--ignore-case` covers
+case variation. For the same reason a session id that isn't in the memory is an error rather than an
+empty result: a mistyped id must never read as absence.
+
+Splits are stitched back into their block before matching, so a needle spanning a chunk boundary is
+still found, and a long block reports one hit rather than one per chunk.
+
+Listing stops at 200 hits, and says where to pick up: `4202 more hits not shown — continue with
+--from 3891`. A common word in a long session really does run that far — `"the"` finds 4,402 hits in
+a 10,000-turn session — so a cap you could not walk past would turn the count into a dead end. The
+resume coordinate is the first hit that was dropped rather than one past the last shown, because a
+turn can hold several matching blocks: continuing may repeat a hit, but it never skips one.
+
+`--from`/`--to` take the same `seq` coordinate as [`get`](#reading-turns-with-get), and scan a
+stretch of a session on their own — useful for the part you have not screened yet. A window scopes
+what a zero means: over `--from 500 --to 999` the reply names those turns and clears only them. A
+window that falls outside the session says `no turns in that range` rather than reporting absence.
+
+Absence of a match clears only the literal you passed, in the session you named — pick the spellings
+that matter.
 
 ## Reading a different memory
 

--- a/docs/recall.md
+++ b/docs/recall.md
@@ -24,7 +24,7 @@ Each hit carries its provenance and a ready-to-run drill-down line:
 
 ```
 [<ts>] <harness> <workdir>/<session8> <block_type>  score=<s.sss>
-  → get <session_id> <turn_uuid> --memory <label>
+  → get <session_id> --from <seq> --to <seq> --memory <label>
 <the full chunk text>
   ~ [<role> <block_type> seq<N>] <neighbor chunk, first 160 chars>
 ---
@@ -46,18 +46,46 @@ from. `no results` prints when nothing matched. The exact shape is a contract �
 | `--harness` | — | restrict to `claude \| codex \| pi \| hermes` |
 | `--memory` | local | the memory to read (see below) |
 
-## Drilling in with `get`
+## Reading turns with `get`
 
 ```bash
-funes get <session_id> <turn_uuid> [--window 3] [--memory <label>] [--highlight <text>] [--format human|agent]
+funes get <session_id> [--from <seq>] [--to <seq>] [--memory <label>]
 ```
 
-`get` returns the named turn plus the turns within the seq window, with splits reassembled into whole
-blocks. Pass the same `--memory` the recall hint named, so the drill-down reads the memory the hit came
-from. Unlike `recall`, `get` has a **human** rendering in addition to the agent format — chosen when
-both stdin and stdout are terminals, overridable with `--format`. `--highlight` marks text in that
-human rendering (whitespace-insensitive; no effect on the agent format). It prints `turn <uuid> not
-found in session <id>` when the turn is absent.
+`get` returns a range of a session's turns, with their splits reassembled into whole blocks. Pass the
+same `--memory` the recall hint named, so the drill-down reads the memory the hit came from. The
+output is the agent format, the same in a terminal as when piped.
+
+**Turns are addressed by `seq`** — the session's own dense counter over its turns — so `--from 40
+--to 60` is exactly "turns 40 through 60". There is one way to name a turn, and a hit's `→ get` line
+hands it to you already formed:
+
+```bash
+funes get 987a1e04-… --from 37 --to 43   # printed by the hit; run it as it stands
+funes get 987a1e04-… --from 40 --to 60   # or move and widen, by editing two numbers
+funes get 987a1e04-…                     # or start at the beginning of a session you just chose
+```
+
+That last form matters as much as the first. `sessions` hands you a session id, so without a
+coordinate read there is no way to *start* reading a session you picked — which is how you end up
+dumping one to a file and paging it by line number. `--from` alone reads 20 turns on.
+
+The turn uuid is provenance, not an address: it identifies a turn across re-indexing, and is printed
+with every turn, but nothing takes it as input.
+
+Every read closes with the coordinates it covered and the session's size, so a partial read says
+what it is part of and the next range is obvious:
+
+```
+---
+turns 0-19 of 786
+```
+
+A single turn can carry a whole file, so rendering stops at around 40,000 characters and states the
+remainder with the coordinate to resume from — `9 more turn(s) in range not shown — read them with
+--from 12`. One turn always renders however large, since a read that answers nothing cannot be
+narrowed further. It prints `no turns in that range of session <id>` when the coordinates land
+outside it.
 
 ## Reading a different memory
 

--- a/docs/recall.md
+++ b/docs/recall.md
@@ -190,6 +190,52 @@ window that falls outside the session says `no turns in that range` rather than 
 Absence of a match clears only the literal you passed, in the session you named — pick the spellings
 that matter.
 
+## Digesting a session with `sketch`
+
+```bash
+funes sketch <session_id> [--units <n>] [--max-chars <n>] [--from <seq>] [--to <seq>] [--memory <label>]
+```
+
+Every other read needs you to know what you are looking for: `recall` a query, `scan` a literal,
+`get` coordinates, `sessions` the opening prompt and nothing after it. `sketch` asks the session
+instead — it selects the passages most *distinctive within it*, using the vectors funes already
+stored, with no query at all.
+
+```console
+$ funes sketch 987a1e04-98cc-4d18-a618-8efebca34b0d --units 4
+sketch 987a1e04-98cc-4d18-a618-8efebca34b0d — 4 of 4 places · 2103 of 8000 chars · 164 eligible units
+[2026-08-26T07:27:41.111Z] user text seq0
+  → get 987a1e04-98cc-4d18-a618-8efebca34b0d --from 0 --to 3 --memory local
+retrieve the personas that were used for the last adversarial review of this blog post
+…
+---
+a sketch samples: it shows what it selected, so it cannot show that anything is absent — scan a literal for that
+```
+
+That is the read for an open-ended judgement — *is this session worth publishing, does it reveal
+anything internal, what was actually accomplished here.* The selector picks the largest residual off
+the session's own mean, so it favours what does not belong: an internal codename inside a session
+about refactoring a parser is exactly what it surfaces, and exactly what a summary would drop.
+
+**It is not for reading a session.** Every place carries a `→ get` line, so the surrounding turns are
+one call away, verbatim. Reading a session end to end costs more than everything else together.
+
+`--units` sets how many places (default 8, at most 40), `--max-chars` the total budget (default
+8,000, at most 40,000). They interact: each place is guaranteed 240 characters, so `--units` is
+clamped to what the budget can render — and every clamp is stated in the reply rather than applied
+quietly. No single passage may take more than its share, so one turn carrying a file cannot become
+the whole digest; a shortened passage says so.
+
+For a long session, digest it in stretches with `--from`/`--to`: eight places over 13,000 turns is
+thin, where eight over each 2,000 is proportional. A whole-session digest is cached (it is
+deterministic in the session's content), which takes a 13,000-turn sketch from 1.8 s to 0.15 s on a
+second pass.
+
+A sketch **samples**. It states what it selected and what it left out, so it can never show that
+something is absent — that is [`scan`](#finding-a-literal-with-scan), for the literal you pass. The
+pipeline is: sketch to find out what is there, scan to establish how often a term you found occurs,
+get to read the evidence.
+
 ## Reading a different memory
 
 `--memory` takes an `<org>/<repo>` shorthand, a full `hf://…` URI, a local path, or `local`. This is

--- a/docs/recall.md
+++ b/docs/recall.md
@@ -90,6 +90,28 @@ remainder with the coordinate to resume from — `9 more turn(s) in range not sh
 narrowed further. It prints `no turns in that range of session <id>` when the coordinates land
 outside it.
 
+## Enumerating with `sessions`
+
+```bash
+funes sessions [--memory <label>]
+```
+
+Recall ranks: it returns the passages closest to a query and says nothing about everything it did
+not reach. So it cannot answer *how much is in here* or *how much of it have I looked at*.
+`sessions` can — it lists every session in the memory, oldest first, with its provenance and turn
+count:
+
+```console
+$ funes sessions --memory huggingface/funes-memory
+[2026-06-19T01:29:59.000Z] claude_code -home-u-funes/0123456789abcdef 47 turns
+…
+---
+28 sessions
+```
+
+Turns are counted distinct rather than by row, since a long turn is stored as several chunks. The
+session id is printed in full, so the line feeds `funes get` or `funes curate --include` as is.
+
 ## Reading a different memory
 
 `--memory` takes an `<org>/<repo>` shorthand, a full `hf://…` URI, a local path, or `local`. This is

--- a/docs/sketch.md
+++ b/docs/sketch.md
@@ -1,0 +1,143 @@
+# `sketch` — what a session contains, without asking
+
+Status: design proposal — parameters and safeguards
+
+Scope: a new read verb and MCP tool over the existing `session_sketch` selector; no change to the
+selector's mathematics
+
+## Why it is a verb
+
+Every other read needs you to know what you are looking for. `recall` needs a query, `scan` needs a
+literal, `get` needs coordinates, `sessions` gives you the opening prompt and nothing after it.
+Nothing answers *what is in here*.
+
+`sketch` does, and it is the only read that uses the index without a query. The selector is pivoted
+Gram-Schmidt over a session's stored vectors: it centres each passage on the session's own mean,
+deflates against what it has already chosen, and takes the largest residual. It selects what is most
+*unlike* both the session's average and everything picked so far.
+
+That is the right instrument for judging a session against criteria you cannot turn into queries.
+The material that disqualifies a session — an internal codename, a customer, a private negotiation,
+inside a session otherwise about refactoring a parser — **is** the material that does not belong in
+it. A centroid summary drops exactly that; a novelty selector surfaces it.
+
+It samples, so it can never establish absence. The pipeline is **sketch to find out what is there →
+`scan` to establish the extent of a term it surfaced → `get` to read the evidence verbatim.**
+
+## Parameters
+
+Five, and the case for each is that an agent has a basis for choosing it. Everything an agent would
+be guessing at stays inside the selector — see [what is deliberately not a
+parameter](#what-is-deliberately-not-a-parameter).
+
+| parameter | default | range | what it is for |
+|---|---|---|---|
+| `session_id` | — | required | the session to digest. One per call |
+| `units` | 8 | 1–40 | how many distinct places to show — breadth |
+| `max_chars` | 8,000 | 1,000–40,000 | total rendered characters — cost |
+| `from` / `to` | whole session | any seq | digest a stretch instead of the whole session |
+| `memory` | local / server's | — | as every other read verb |
+
+**`units` against `max_chars`.** They trade off, and the trade is real: screening for a mention
+wants many short glimpses, understanding a session wants fewer long ones. They are not independent —
+40 units inside 1,000 characters is 25 characters each, which is noise. So each unit is guaranteed a
+floor of **240 characters**, and `units` is clamped to `max_chars / 240` when it exceeds that. The
+clamp is reported, never silent.
+
+**`from` / `to`** use the same coordinate as `get` and the same `seq` a `→ get` line prints. They
+matter for long sessions: 8 units over 10,000 turns is thin, so an agent working a large session
+digests it in windows — `--from 0 --to 2500`, then `2500`, and so on — and gets coverage proportional
+to the session rather than a fixed sample of it.
+
+## Safeguards
+
+The previous curation runs did not overflow because a parameter was wrong. They overflowed because
+one call asked for a whole session: run 3 produced a 664 KB dump from a single `get --window 1000`,
+and one of its children then spent 39 of its 59 shell calls paging that dump by line number. The
+safeguards below are written against that, not against arithmetic mistakes.
+
+The architectural rule: **clamp the output, never validate parameters against each other.** No
+combination of arguments can produce a reply past the ceiling, so there is no combination to get
+wrong.
+
+1. **One hard ceiling for the read surface.** `SKETCH_HARD_MAX = 40,000` characters — the same
+   ceiling `get` already renders under. `max_chars` is clamped to it; rendering stops at it whatever
+   selection produced. The selector's current `4_000..=200_000` validation is far too generous for an
+   agent-facing call: 200,000 characters is roughly 50,000 tokens in one reply.
+2. **A per-unit cap, derived.** No single item renders more than `max_chars / units`. A sketch is
+   explicitly a sample, so truncating an item is legitimate and is marked — unlike `get`, where one
+   turn must render whole because it is a verbatim read. Without this, one 200 KB tool result eats
+   the entire budget and the digest becomes a single blob.
+3. **Tool results additionally previewed** at `min(per-unit cap, 2,000)` characters. They are the
+   bulk of a session and the least dense per character, but they cannot be excluded: rule-3 evidence
+   turns up in them (`?? ../acme-internal/README.md` is a `tool_result`).
+4. **No context neighbours.** The picker's version renders unselected passages around each selected
+   one, and its own options say they "do not count against `budget`" — an uncounted leak. They are
+   dropped: every item carries a `→ get <session_id> --from <seq> --to <seq>` line, so reading around
+   an item is `get`'s job, addressed the way everything else is.
+5. **One session per call.** No batching, for the reason `scan` takes one session: a batched reply is
+   a blob whose per-session boundaries the caller has to re-derive, and N sessions multiply the
+   ceiling by N.
+6. **Every reply states what it left out.** Units rendered of units selected, characters of budget,
+   and the turn range covered of the session's total. An agent that believes it saw everything is the
+   failure this whole design is about.
+7. **Clamps are reported, not silently applied.** Asking for 100,000 characters returns 40,000 *and*
+   a line saying so. Same for a clamped `units`.
+8. **An unknown session is an error**, as in `scan` — a mistyped id must not read as "this session
+   holds nothing". A range that selects nothing says so, with the session's size.
+
+## Rendering
+
+Agent format, consistent with the rest of the read surface — a header, a runnable `→ get` line, the
+passage:
+
+```
+sketch <session_id> — <n> of <m> units · <chars> of <budget> chars · turns <a>-<b> of <total>
+[<ts>] <role> <block_type> seq<N>
+  → get <session_id> --from <a> --to <b> --memory <label>
+  <the passage, truncated at the per-unit cap and marked when it is>
+…
+---
+<k> unit(s) selected but not rendered — raise --max-chars, or digest a narrower --from/--to
+```
+
+Deterministic: the same arguments over the same session return the same digest, so a re-call is
+free and comparable. The cache is keyed on the session's content and the embedding model, and is
+invisible to the caller.
+
+## The tool description
+
+This is the text an agent reads before choosing, so it has to name the attractor it is competing
+with. Agents in all three curation runs reached for "read the whole session" first.
+
+> A query-independent digest of one session: the passages most distinctive *within* it, chosen from
+> the stored embeddings with no query at all. This is the only read that tells you what a session
+> contains when you do not already know what you are looking for — `recall` needs a query, `scan`
+> needs a literal, `get` needs coordinates.
+>
+> Use it to judge a session against open-ended criteria — is this worth publishing, does it reveal
+> anything internal, what was actually accomplished here. The material that disqualifies a session is
+> usually the material that does not belong in it, which is what a distinctiveness selector surfaces
+> and a summary drops.
+>
+> **Do not read the whole session instead.** Sessions run to thousands of turns; `get`-ing one end to
+> end costs more than every other call together, overflows the reply, and leaves you paging a
+> transcript by line number. A sketch is a handful of places and a few thousand characters, and every
+> one carries a `→ get` line for when you want the surrounding turns verbatim. Sketch to find out
+> what is there, `scan` to establish how often a term you found actually occurs, `get` to read the
+> evidence.
+>
+> A sketch samples. It states what it selected and what it left out, so it can never show that
+> something is *absent* — that is `scan`, and only for the literal you pass.
+
+## What is deliberately not a parameter
+
+- **The near-duplicate threshold, the LSH bands, the quality weights, the axis/transition split.**
+  Selector internals. An agent has no basis for choosing them, and exposing a number invites
+  cargo-culting it.
+- **`role` / `block_type` filters.** A filtered digest answers a different question, and the
+  user-text-only projection is the one already rejected in favour of this verb. Excluding tool results
+  would be actively wrong (safeguard 3).
+- **`neighbors`.** `get` reads around a coordinate; every item hands one over.
+- **A batch of sessions.** Safeguard 5.
+- **Output format toggles.** One format, as everywhere else in the read surface.

--- a/docs/sketch.md
+++ b/docs/sketch.md
@@ -1,6 +1,6 @@
 # `sketch` — what a session contains, without asking
 
-Status: design proposal — parameters and safeguards
+Status: implemented — this is the design the verb was built to
 
 Scope: a new read verb and MCP tool over the existing `session_sketch` selector; no change to the
 selector's mathematics
@@ -102,8 +102,10 @@ sketch <session_id> — <n> of <m> units · <chars> of <budget> chars · turns <
 ```
 
 Deterministic: the same arguments over the same session return the same digest, so a re-call is
-free and comparable. The cache is keyed on the session's content and the embedding model, and is
-invisible to the caller.
+comparable. A whole-session digest is cached, keyed on the session's content and the embedding
+model, and invisible to the caller — measured, that takes a 13,281-turn session from 1.78 s to
+0.15 s. A windowed digest is not cached: an entry keyed on the session must not answer for a stretch
+of it. On a small session the cache is neither help nor cost (0.12 s either way).
 
 ## The tool description
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -10,4 +10,5 @@ pub mod mcp;
 pub mod push;
 pub mod recall;
 pub mod scrub;
+pub mod sketch;
 pub mod update;

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -269,15 +269,29 @@ impl ServerHandler for Funes {
             .with_server_info(server_info)
             .with_protocol_version(ProtocolVersion::V_2024_11_05)
             .with_instructions(
-                "Recall over the user's past AI agent sessions (hybrid search + cross-encoder \
-                 rerank + recency). Call `recall` with a natural-language query when you need prior \
-                 decisions, rationale, or context — and before asserting the history of anything \
-                 (that it was never built, was dropped, or is out of scope): a confident claim \
-                 about a past decision is the cue to recall first. Recall subject-matter too, not \
-                 only decisions: before re-deriving how an API, library, or system behaves — or \
-                 anything a prior session (often a research subagent) investigated — query the \
-                 topic itself; recall surfaces those findings. Drill into a hit with `get`. Both \
-                 take an optional `memory` to read a different memory for one call."
+                "Read the user's past AI agent sessions, stored verbatim (hybrid search + \
+                 cross-encoder rerank + recency). Four verbs, and which one depends on the shape of \
+                 the question.\n\n\
+                 `recall` — a natural-language query, when you need prior decisions, rationale, or \
+                 context. Call it before asserting the history of anything (that it was never \
+                 built, was dropped, or is out of scope): a confident claim about a past decision \
+                 is the cue to recall first. Recall subject-matter too, not only decisions: before \
+                 re-deriving how an API, library, or system behaves — or anything a prior session \
+                 (often a research subagent) investigated — query the topic itself; recall surfaces \
+                 those findings.\n\n\
+                 `get` — read a session's turns. Turns are addressed by `seq`, the session's own \
+                 counter, and a hit's `→ get` line hands you the session and the range around it, \
+                 so drilling into a hit is running what it printed; widen by moving `from`/`to`. A \
+                 session id on its own reads from the start, which is how you read a session you \
+                 picked rather than searched for.\n\n\
+                 `sessions` — what the memory holds: every session, what each one was for, \
+                 narrowed by repo or date. Ranked search reaches what a query reaches and says \
+                 nothing about the rest, so this is the only thing that answers coverage — how much \
+                 is there, and how much of it you have looked at.\n\n\
+                 `scan` — a literal string in every block of one session. Exhaustive where recall \
+                 is ranked and partial, so this is what settles whether a session mentions \
+                 something at all; a zero is the clearance recall cannot give.\n\n\
+                 Every verb takes an optional `memory`, to read a different memory for one call."
                     .to_string(),
             )
     }

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -64,6 +64,30 @@ pub struct SessionsRequest {
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct ScanRequest {
+    #[schemars(
+        description = "The literal string to find. Not regex — a pattern that silently matched nothing would read as a clean result."
+    )]
+    pub needle: String,
+    #[schemars(description = "Session to scan — the id from a `sessions` row or a recall hit's `→ get` line")]
+    pub session_id: String,
+    #[schemars(
+        description = "First turn to scan, as the session's own seq. Omit to start at the session's beginning; pass the seq a capped scan told you to continue from."
+    )]
+    pub from: Option<i64>,
+    #[schemars(description = "Last turn to scan, as the session's own seq. Omit to scan to the end of the session.")]
+    pub to: Option<i64>,
+    #[schemars(description = "Match regardless of case (default false)")]
+    pub ignore_case: Option<bool>,
+    #[schemars(description = "Characters of surrounding text shown on each side of a match (default 100)")]
+    pub context: Option<usize>,
+    #[schemars(
+        description = "Memory to scan — `<org>/<repo>`, an `hf://…` URI, a local path, or `local`. Defaults to the server's memory."
+    )]
+    pub memory: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct StatusRequest {
     #[schemars(
         description = "Memory to inspect — `<org>/<repo>`, an `hf://…` URI, a local path, or `local`. Defaults to the server's memory."
@@ -157,6 +181,38 @@ impl Funes {
             Ok(s) if !s.is_empty() => s,
             Ok(_) => "no results".to_string(),
             Err(e) => format!("sessions error: {e}"),
+        }
+    }
+
+    #[tool(
+        description = "Find a literal string in every block of one session — exhaustive and unranked, where `recall` is ranked and partial. This is what answers questions of absence about a session: `recall` can show that something is present, never that it is nowhere, so a claim that a session does not mention some term has to be settled here. Use it to screen a session against a criterion — does this one name an internal project, a customer, a credential — and to locate where a term you already expect actually occurs. Splits are stitched back together first, so a needle straddling a chunk boundary is still found, and each hit carries a `→ get` line to read the turn around it. Scanning is per session by design: name the session with `session_id`, and use `sessions` to enumerate the ones to screen. A needle that returns nothing is absent from that session and says nothing about any other; absence clears only the exact spelling you passed, so pick the ones that matter and use `ignore_case` for case variation. Listing stops at 200 hits and names the `from` to continue at, so a common term in a long session is still walkable; `from`/`to` also scan just a stretch of a session — and then a zero clears only that stretch."
+    )]
+    async fn scan(
+        &self,
+        Parameters(ScanRequest {
+            needle,
+            session_id,
+            from,
+            to,
+            ignore_case,
+            context,
+            memory,
+        }): Parameters<ScanRequest>,
+    ) -> String {
+        match recall::scan(
+            self.memory(memory),
+            needle,
+            session_id,
+            from,
+            to,
+            ignore_case.unwrap_or(false),
+            context.unwrap_or(100),
+        )
+        .await
+        {
+            Ok(s) if !s.is_empty() => s,
+            Ok(_) => "no results".to_string(),
+            Err(e) => format!("scan error: {e}"),
         }
     }
 

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -57,6 +57,20 @@ pub struct GetRequest {
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct SessionsRequest {
+    #[schemars(description = "Keep only sessions whose checkout resolved to this repo, as `owner/name`")]
+    pub repo: Option<String>,
+    #[schemars(description = "Keep only sessions that started on or after this date, `YYYY-MM-DD`")]
+    pub since: Option<String>,
+    #[schemars(description = "Keep only sessions that started on or before this date, `YYYY-MM-DD`")]
+    pub until: Option<String>,
+    #[schemars(
+        description = "Rows to list, keeping the most recent (default 50, maximum 200). More than that cannot fit in one reply — walk with `offset` instead. Zero is an error, not every match."
+    )]
+    pub limit: Option<usize>,
+    #[schemars(
+        description = "Skip this many of the most recent matches before taking `limit` — how you walk a listing back through time. The closing line names the offset that continues, and a given offset always names the same session."
+    )]
+    pub offset: Option<usize>,
     #[schemars(
         description = "Memory to list — `<org>/<repo>`, an `hf://…` URI, a local path, or `local`. Defaults to the server's memory."
     )]
@@ -174,10 +188,27 @@ impl Funes {
     }
 
     #[tool(
-        description = "List every session in a memory, oldest first: first timestamp, harness, workdir, full session id, and how many turns it holds, closed by the total. `recall` is ranked retrieval — it surfaces what a query reaches and says nothing about the rest, so it can never tell you how much a memory holds or how much of it you have looked at. Call this whenever coverage is the question: sizing a memory before a sweep, reporting how many sessions you actually examined, or checking whether a session you heard about by id is in there at all."
+        description = "List a memory's sessions, oldest first: date, harness, source repo (or workdir when the checkout did not resolve), turn count, full session id, and the prompt each session opened with. That prompt is the cheapest triage there is — it says what a session was for without reading any of it. `recall` is ranked retrieval: it surfaces what a query reaches and says nothing about the rest, so it can never tell you how much a memory holds or how much of it you have looked at. Call this whenever the population is the question: sizing a memory before a sweep, picking the sessions a criterion is about, reporting how many you actually examined, or checking whether a session you heard about by id is in there at all. Narrow with `repo`, `since` and `until` rather than listing everything; the closing line always states the full match count, so an elided row is visible and never silently dropped."
     )]
-    async fn sessions(&self, Parameters(SessionsRequest { memory }): Parameters<SessionsRequest>) -> String {
-        match recall::sessions(self.memory(memory)).await {
+    async fn sessions(
+        &self,
+        Parameters(SessionsRequest {
+            repo,
+            since,
+            until,
+            limit,
+            offset,
+            memory,
+        }): Parameters<SessionsRequest>,
+    ) -> String {
+        let filter = recall::SessionFilter {
+            repo,
+            since,
+            until,
+            limit,
+            offset: offset.unwrap_or(0),
+        };
+        match recall::sessions(self.memory(memory), filter).await {
             Ok(s) if !s.is_empty() => s,
             Ok(_) => "no results".to_string(),
             Err(e) => format!("sessions error: {e}"),

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -17,6 +17,18 @@ pub struct RecallRequest {
     pub query: String,
     #[schemars(description = "Number of results to return (default 8)")]
     pub k: Option<usize>,
+    #[schemars(
+        description = "Recency half-life in days: a hit this old keeps half its score (default 30). Pass 0 to weigh every age alike — do that when the memory spans months and the answer may be old, such as a founding decision."
+    )]
+    pub half_life: Option<f64>,
+    #[schemars(
+        description = "Adjacent chunks to attach to each hit for context (default 1). Raise it to read more around a hit without a follow-up `get`; 0 returns the hits alone."
+    )]
+    pub neighbors: Option<i64>,
+    #[schemars(
+        description = "How many fused candidates to rerank (default 30). Raise it when a topic is rare and the first pass may not surface it."
+    )]
+    pub candidates: Option<usize>,
     #[schemars(description = "Restrict to a block type: text | thinking | tool_use | tool_result")]
     pub block_type: Option<String>,
     #[schemars(description = "Restrict to a harness: claude | codex | pi | hermes")]
@@ -83,6 +95,9 @@ impl Funes {
         Parameters(RecallRequest {
             query,
             k,
+            half_life,
+            neighbors,
+            candidates,
             block_type,
             harness,
             memory,
@@ -92,9 +107,9 @@ impl Funes {
             self.memory(memory),
             query,
             k.unwrap_or(8),
-            30,
-            30.0,
-            1,
+            candidates.unwrap_or(30),
+            half_life.unwrap_or(30.0),
+            neighbors.unwrap_or(1),
             block_type,
             harness,
         )

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -102,6 +102,30 @@ pub struct ScanRequest {
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct SketchRequest {
+    #[schemars(description = "Session to digest — the id from a `sessions` row or a hit's `→ get` line")]
+    pub session_id: String,
+    #[schemars(
+        description = "How many distinct places to show — breadth (default 8, maximum 40). Also held to what `max_chars` can render at 240 characters apiece, and any narrowing is reported in the reply."
+    )]
+    pub units: Option<usize>,
+    #[schemars(
+        description = "Total characters to render — cost (default 8000, maximum 40000). More than that is a reply no caller receives."
+    )]
+    pub max_chars: Option<usize>,
+    #[schemars(
+        description = "First turn to digest, as the session's own seq. Digest a long session in windows to get coverage proportional to its length rather than a fixed sample of it."
+    )]
+    pub from: Option<i64>,
+    #[schemars(description = "Last turn to digest, as the session's own seq.")]
+    pub to: Option<i64>,
+    #[schemars(
+        description = "Memory to read for this call — `<org>/<repo>`, an `hf://…` URI, a local path, or `local`. Defaults to the server's memory."
+    )]
+    pub memory: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct StatusRequest {
     #[schemars(
         description = "Memory to inspect — `<org>/<repo>`, an `hf://…` URI, a local path, or `local`. Defaults to the server's memory."
@@ -248,6 +272,27 @@ impl Funes {
     }
 
     #[tool(
+        description = "A query-independent digest of one session: the passages most distinctive *within* it, chosen from the stored embeddings with no query at all. This is the only read that tells you what a session contains when you do not already know what you are looking for — `recall` needs a query, `scan` needs a literal, `get` needs coordinates. Use it to judge a session against open-ended criteria: is this worth publishing, does it reveal anything internal, what was actually accomplished here. The material that disqualifies a session is usually the material that does not belong in it, which is what a distinctiveness selector surfaces and a summary drops. DO NOT READ THE WHOLE SESSION INSTEAD. Sessions run to thousands of turns; `get`-ing one end to end costs more than every other call together, overflows the reply, and leaves you paging a transcript by line number. A sketch is a handful of places and a few thousand characters, and every one carries a `→ get` line for when you want the surrounding turns verbatim. Sketch to find out what is there, `scan` to establish how often a term you found actually occurs, `get` to read the evidence. A sketch samples: it states what it selected, so it can never show that something is *absent* — that is `scan`, and only for the literal you pass."
+    )]
+    async fn sketch(
+        &self,
+        Parameters(SketchRequest {
+            session_id,
+            units,
+            max_chars,
+            from,
+            to,
+            memory,
+        }): Parameters<SketchRequest>,
+    ) -> String {
+        match super::sketch::run(self.memory(memory), session_id, from, to, units, max_chars).await {
+            Ok(s) if !s.is_empty() => s,
+            Ok(_) => "no results".to_string(),
+            Err(e) => format!("sketch error: {e}"),
+        }
+    }
+
+    #[tool(
         description = "Show funes memory status: chunk and session counts, pending local indexing, and — for a remote memory — last push plus this host's pending push coverage."
     )]
     async fn status(&self, Parameters(StatusRequest { memory }): Parameters<StatusRequest>) -> String {
@@ -270,7 +315,7 @@ impl ServerHandler for Funes {
             .with_protocol_version(ProtocolVersion::V_2024_11_05)
             .with_instructions(
                 "Read the user's past AI agent sessions, stored verbatim (hybrid search + \
-                 cross-encoder rerank + recency). Four verbs, and which one depends on the shape of \
+                 cross-encoder rerank + recency). Five verbs, and which one depends on the shape of \
                  the question.\n\n\
                  `recall` — a natural-language query, when you need prior decisions, rationale, or \
                  context. Call it before asserting the history of anything (that it was never \
@@ -291,6 +336,11 @@ impl ServerHandler for Funes {
                  `scan` — a literal string in every block of one session. Exhaustive where recall \
                  is ranked and partial, so this is what settles whether a session mentions \
                  something at all; a zero is the clearance recall cannot give.\n\n\
+                 `sketch` — what one session contains, with no query at all: the passages most \
+                 distinctive within it. The read for when you do not know what to look for, which is \
+                 every open-ended judgement about a session — is this worth publishing, does it \
+                 reveal anything internal, what happened here. Reach for it instead of reading a \
+                 session end to end, which costs more than everything else together.\n\n\
                  Every verb takes an optional `memory`, to read a different memory for one call."
                     .to_string(),
             )

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -31,10 +31,12 @@ pub struct RecallRequest {
 pub struct GetRequest {
     #[schemars(description = "Session id from a recall hit's `→ get` line")]
     pub session_id: String,
-    #[schemars(description = "Turn uuid from a recall hit's `→ get` line")]
-    pub turn_uuid: String,
-    #[schemars(description = "Turns within this seq window of the target are included (default 3)")]
-    pub window: Option<i64>,
+    #[schemars(
+        description = "First turn to read, as the session's own seq — a dense counter over its turns, which a hit's `→ get` line gives you. Defaults to the session's start."
+    )]
+    pub from: Option<i64>,
+    #[schemars(description = "Last turn to read, as the session's own seq. Defaults to 20 turns from `from`.")]
+    pub to: Option<i64>,
     #[schemars(
         description = "Memory to read for this call — the one the recall hit's `→ get` line names. Defaults to the server's memory."
     )]
@@ -74,7 +76,7 @@ impl Funes {
     }
 
     #[tool(
-        description = "Recall decisions, rationale, and context from the user's past AI agent sessions. Returns ranked passages with provenance (timestamp, session, block type) plus surrounding neighbor chunks. Each hit carries a `→ get <session_id> <turn_uuid>` line — call `get` with those to read the full surrounding turns. Use when the user references earlier work, or when you lack context that may exist in a prior session. Recall subject-matter, not only decisions: before re-deriving how an API, library, or system behaves — or anything a past session already investigated — query the topic itself; research subagents accumulate exactly these findings and recall surfaces them, often as the top hit, so check before re-investigating from scratch. Also recall before asserting the history of anything — that it was never built, was dropped, is out of scope, or was never discussed; a confident claim about a past decision is the cue you're missing context this holds. To recall from a different memory than the server's default (e.g. a shared `<org>/<repo>` dataset on the HF Hub), pass `memory` — no CLI needed."
+        description = "Recall decisions, rationale, and context from the user's past AI agent sessions. Returns ranked passages with provenance (timestamp, session, block type) plus surrounding neighbor chunks. Each hit carries a `→ get <session_id> --from <seq> --to <seq>` line — call `get` with exactly those to read the full surrounding turns. Use when the user references earlier work, or when you lack context that may exist in a prior session. Recall subject-matter, not only decisions: before re-deriving how an API, library, or system behaves — or anything a past session already investigated — query the topic itself; research subagents accumulate exactly these findings and recall surfaces them, often as the top hit, so check before re-investigating from scratch. Also recall before asserting the history of anything — that it was never built, was dropped, is out of scope, or was never discussed; a confident claim about a past decision is the cue you're missing context this holds. To recall from a different memory than the server's default (e.g. a shared `<org>/<repo>` dataset on the HF Hub), pass `memory` — no CLI needed."
     )]
     async fn recall(
         &self,
@@ -105,18 +107,19 @@ impl Funes {
     }
 
     #[tool(
-        description = "Drill down on a recall hit: fetch the named turn plus the turns within `window` of it, each reassembled into readable text. Pass the `session_id` and `turn_uuid` from a recall hit's `→ get` line — and the `memory` it names."
+        description = "Read a range of one session's turns, each reassembled into readable text. Turns are addressed by `seq`, the session's own dense counter — a recall or scan hit's `→ get` line hands you the session, the range around the hit, and the memory to pass, so drilling into a hit is running what it printed. A session id on its own reads from the start, which is how you read a session you picked from `sessions` rather than found by searching. Widen or move by editing `from`/`to`; every reply closes with the range it covered and the session's size, so the next range is obvious."
     )]
     async fn get(
         &self,
         Parameters(GetRequest {
             session_id,
-            turn_uuid,
-            window,
+            from,
+            to,
             memory,
         }): Parameters<GetRequest>,
     ) -> String {
-        match recall::get(self.memory(memory), session_id, turn_uuid, window.unwrap_or(3)).await {
+        let range = recall::TurnRange { from, to };
+        match recall::get(self.memory(memory), session_id, range).await {
             Ok(s) if !s.is_empty() => s,
             Ok(_) => "no results".to_string(),
             Err(e) => format!("get error: {e}"),

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -56,6 +56,14 @@ pub struct GetRequest {
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct SessionsRequest {
+    #[schemars(
+        description = "Memory to list — `<org>/<repo>`, an `hf://…` URI, a local path, or `local`. Defaults to the server's memory."
+    )]
+    pub memory: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct StatusRequest {
     #[schemars(
         description = "Memory to inspect — `<org>/<repo>`, an `hf://…` URI, a local path, or `local`. Defaults to the server's memory."
@@ -138,6 +146,17 @@ impl Funes {
             Ok(s) if !s.is_empty() => s,
             Ok(_) => "no results".to_string(),
             Err(e) => format!("get error: {e}"),
+        }
+    }
+
+    #[tool(
+        description = "List every session in a memory, oldest first: first timestamp, harness, workdir, full session id, and how many turns it holds, closed by the total. `recall` is ranked retrieval — it surfaces what a query reaches and says nothing about the rest, so it can never tell you how much a memory holds or how much of it you have looked at. Call this whenever coverage is the question: sizing a memory before a sweep, reporting how many sessions you actually examined, or checking whether a session you heard about by id is in there at all."
+    )]
+    async fn sessions(&self, Parameters(SessionsRequest { memory }): Parameters<SessionsRequest>) -> String {
+        match recall::sessions(self.memory(memory)).await {
+            Ok(s) if !s.is_empty() => s,
+            Ok(_) => "no results".to_string(),
+            Err(e) => format!("sessions error: {e}"),
         }
     }
 

--- a/src/commands/recall.rs
+++ b/src/commands/recall.rs
@@ -1,7 +1,7 @@
-//! The read surface: `recall`, `get`, `status` over the existing index.
+//! The read surface: `recall`, `get`, `sessions`, `status` over the existing index.
 //! Recall pipeline: hybrid (vector + BM25, fused by reciprocal rank) → cross-encoder rerank →
-//! recency reweight → neighbor expansion. `recall`/`get` return results rendered in the agent
-//! format; `recall_hits`/`get_turns` return the structured results for other renderings
+//! recency reweight → neighbor expansion. `recall`/`get`/`sessions` return results rendered in the
+//! agent format; `recall_hits`/`get_turns` return the structured results for other renderings
 //! (see `render`).
 
 use super::curate;
@@ -57,6 +57,17 @@ pub struct Hit {
     pub block_type: String,
     pub harness: String,
     pub neighbors: Vec<Neighbor>,
+}
+
+/// One session in a memory's listing: where and when it started, and how much it holds.
+pub struct Session {
+    pub session_id: String,
+    /// First timestamp in the session.
+    pub ts: String,
+    pub workdir: String,
+    pub harness: String,
+    /// Distinct turns, not rows: chunking is an indexing artifact, a turn is what `get` reads.
+    pub turns: usize,
 }
 
 /// One reassembled turn from `get`: its blocks in order, splits stitched back together.
@@ -592,6 +603,71 @@ pub async fn get(memory: Memory, session_id: String, range: TurnRange) -> Result
         ));
     }
     Ok(crate::ui::render::get_agent(&note, &turns, total))
+}
+
+/// Every session in a memory, oldest first, rendered in the agent format. Ranked retrieval reaches
+/// what a query reaches and says nothing about the rest, so enumeration is the only thing that
+/// answers what a memory holds and how much of it a pass has covered.
+pub async fn sessions(memory: Memory) -> Result<String> {
+    let read = open_read(&memory).await?;
+    let note = read.note.clone().unwrap_or_default();
+    let label = read.memory_label.clone().unwrap_or_else(|| memory.label());
+    let sessions = scan_sessions(&read.ds).await?;
+    if sessions.is_empty() {
+        return Ok(format!("{note}no sessions in {label}\n"));
+    }
+    Ok(crate::ui::render::sessions_agent(&note, &sessions))
+}
+
+/// Fold every row into its session: earliest timestamp, provenance, and distinct turn count.
+async fn scan_sessions(ds: &Dataset) -> Result<Vec<Session>> {
+    let mut cols = vec!["session_id", "ts", "workdir", "turn_uuid"];
+    if has_harness_col(ds) {
+        cols.push("harness");
+    }
+    let batches = dataset::scan_rows(ds, &cols, None, None).await?;
+
+    let mut by_id: HashMap<String, (Session, HashSet<String>)> = HashMap::new();
+    for batch in &batches {
+        let (sid, ts, wd, turn, harness) = (
+            scol(batch, "session_id"),
+            scol(batch, "ts"),
+            scol(batch, "workdir"),
+            scol(batch, "turn_uuid"),
+            scol(batch, "harness"),
+        );
+        for i in 0..batch.num_rows() {
+            let id = sval(sid, i);
+            let (session, turns) = by_id.entry(id.clone()).or_insert_with(|| {
+                (
+                    Session {
+                        session_id: id,
+                        ts: sval(ts, i),
+                        workdir: sval(wd, i),
+                        harness: sval(harness, i),
+                        turns: 0,
+                    },
+                    HashSet::new(),
+                )
+            });
+            // Rows arrive in scan order, not time order, so the first one seen isn't the earliest.
+            let row_ts = sval(ts, i);
+            if row_ts < session.ts {
+                session.ts = row_ts;
+            }
+            turns.insert(sval(turn, i));
+        }
+    }
+
+    let mut out: Vec<Session> = by_id
+        .into_values()
+        .map(|(session, turns)| Session {
+            turns: turns.len(),
+            ..session
+        })
+        .collect();
+    out.sort_by(|a, b| (&a.ts, &a.session_id).cmp(&(&b.ts, &b.session_id)));
+    Ok(out)
 }
 
 /// The turns behind `get`, each reassembled (blocks in order, splits de-overlapped). Returns the

--- a/src/commands/recall.rs
+++ b/src/commands/recall.rs
@@ -10,7 +10,7 @@ use crate::inference::{self, Embedder, Reranker};
 use crate::memory::dataset;
 use crate::memory::{Memory, MemoryState};
 use crate::traces::harness::Harness;
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use arrow_array::{Float32Array, Int64Array, RecordBatch, StringArray, UInt64Array};
 use chrono::{DateTime, Utc};
 use futures::TryStreamExt;
@@ -567,25 +567,37 @@ async fn attach_neighbors(ds: &Dataset, hits: &mut [&mut Hit], window: i64) -> R
     Ok(())
 }
 
-/// Drill down on a recall hit: the named turn plus the turns within `window` of it, rendered in
-/// the agent format.
-pub async fn get(memory: Memory, session_id: String, turn_uuid: String, window: i64) -> Result<String> {
-    let (note, turns) = get_turns(memory, session_id.clone(), turn_uuid.clone(), window).await?;
-    if turns.is_empty() {
-        return Ok(format!("{note}turn {turn_uuid} not found in session {session_id}\n"));
-    }
-    Ok(crate::ui::render::get_agent(&note, &turns))
+/// Which turns of a session to read. `seq` is a session's own coordinate — a dense counter over its
+/// turns — so a range is exactly "turns n through m", and it is the only way to address a turn.
+#[derive(Default)]
+pub struct TurnRange {
+    /// First seq to read. Defaults to the session's start.
+    pub from: Option<i64>,
+    /// Last seq to read. Defaults to [`DEFAULT_SPAN`] turns from `from`.
+    pub to: Option<i64>,
 }
 
-/// The turns behind `get`: the named one plus those within `window` of it, each reassembled
-/// (blocks in order, splits de-overlapped). Returns the degradation note and the turns — empty
-/// when the turn isn't in the session; rendering is the caller's choice.
-pub async fn get_turns(
-    memory: Memory,
-    session_id: String,
-    turn_uuid: String,
-    window: i64,
-) -> Result<(String, Vec<Turn>)> {
+/// Turns a coordinate read covers when only a start is given — enough to see what a stretch of a
+/// session is doing, without committing to a session that runs to thousands of turns.
+const DEFAULT_SPAN: i64 = 20;
+
+/// Read a range of a session's turns, rendered in the agent format. A hit's `→ get` line carries
+/// the range it sits in, and a session id alone reads from the start — so choosing a session and
+/// reading it are the same act, addressed the same way.
+pub async fn get(memory: Memory, session_id: String, range: TurnRange) -> Result<String> {
+    let (note, turns, total) = get_turns(memory, session_id.clone(), range).await?;
+    if turns.is_empty() {
+        return Ok(format!(
+            "{note}no turns in that range of session {session_id} (it holds {total})\n"
+        ));
+    }
+    Ok(crate::ui::render::get_agent(&note, &turns, total))
+}
+
+/// The turns behind `get`, each reassembled (blocks in order, splits de-overlapped). Returns the
+/// degradation note, the turns — empty when the range holds none — and how many turns the session
+/// holds in total, so a partial read can say what it is part of.
+pub async fn get_turns(memory: Memory, session_id: String, range: TurnRange) -> Result<(String, Vec<Turn>, usize)> {
     let read = open_read(&memory).await?;
     let note = read.note.clone().unwrap_or_default();
     let ds = &read.ds;
@@ -621,14 +633,13 @@ pub async fn get_turns(
         }
     }
 
-    let center = match rows.iter().find(|r| r.1 == turn_uuid) {
-        Some(r) => r.0,
-        None => return Ok((note, Vec::new())),
-    };
-    Ok((
-        note,
-        turns_from_rows(rows.iter().filter(|r| (r.0 - center).abs() <= window)),
-    ))
+    let total = rows.iter().map(|r| (r.0, &r.1)).collect::<HashSet<_>>().len();
+    let from = range
+        .from
+        .unwrap_or_else(|| rows.iter().map(|r| r.0).min().unwrap_or(0));
+    let to = range.to.unwrap_or(from + DEFAULT_SPAN - 1);
+    let kept = rows.iter().filter(|r| r.0 >= from && r.0 <= to);
+    Ok((note, turns_from_rows(kept), total))
 }
 
 /// Reassemble rows into turns: group by (seq, turn_uuid), order blocks by (block_idx, split_idx),

--- a/src/commands/recall.rs
+++ b/src/commands/recall.rs
@@ -113,7 +113,9 @@ pub struct Session {
     pub harness: String,
     /// The session's source repo(s) as `owner/name`, space-joined; empty when unresolvable.
     pub repo: String,
-    /// Distinct turns, not rows: chunking is an indexing artifact, a turn is what `get` reads.
+    /// Distinct turns, not rows: chunking is an indexing artifact, and a turn is what `get` reads —
+    /// so this counts (seq, turn_uuid) pairs, the same unit `get` renders and `--from`/`--to` index.
+    /// A uuid alone would undercount: a compacted transcript replays turns under the same uuid.
     pub turns: usize,
     /// The opening real prompt, scaffolding skipped — what the session was for, in one line.
     pub first_prompt: String,
@@ -811,7 +813,7 @@ async fn first_prompts(ds: &Dataset, ids: &[String]) -> Result<HashMap<String, S
 /// metadata only — the opening prompts cost a `text` read, so they are fetched separately for the
 /// rows that survive the filter.
 async fn scan_sessions(ds: &Dataset) -> Result<Vec<Session>> {
-    let mut cols = vec!["session_id", "ts", "workdir", "turn_uuid"];
+    let mut cols = vec!["session_id", "ts", "workdir", "turn_uuid", "seq"];
     if has_harness_col(ds) {
         cols.push("harness");
     }
@@ -820,7 +822,7 @@ async fn scan_sessions(ds: &Dataset) -> Result<Vec<Session>> {
     }
     let batches = dataset::scan_rows(ds, &cols, None, None).await?;
 
-    let mut by_id: HashMap<String, (Session, HashSet<String>)> = HashMap::new();
+    let mut by_id: HashMap<String, (Session, HashSet<(i64, String)>)> = HashMap::new();
     for batch in &batches {
         let (sid, ts, wd, turn, harness, repo) = (
             scol(batch, "session_id"),
@@ -830,6 +832,7 @@ async fn scan_sessions(ds: &Dataset) -> Result<Vec<Session>> {
             scol(batch, "harness"),
             scol(batch, "repo"),
         );
+        let seq = icol(batch, "seq");
         for i in 0..batch.num_rows() {
             let id = sval(sid, i);
             let (session, turns) = by_id.entry(id.clone()).or_insert_with(|| {
@@ -851,7 +854,7 @@ async fn scan_sessions(ds: &Dataset) -> Result<Vec<Session>> {
             if row_ts < session.ts {
                 session.ts = row_ts;
             }
-            turns.insert(sval(turn, i));
+            turns.insert((ival(seq, i), sval(turn, i)));
         }
     }
 
@@ -876,9 +879,11 @@ struct Block {
     text: String,
 }
 
-/// Blocks under assembly, keyed by (turn_uuid, block_idx): each one's facets, and the split rows
-/// still to be stitched into its `text`.
-type BlockParts = HashMap<(String, i64), (Block, Vec<(i64, String)>)>;
+/// Blocks under assembly, keyed by (seq, turn_uuid, block_idx): each one's facets, and the split
+/// rows still to be stitched into its `text`. The seq is part of the key because a turn uuid can
+/// recur at different positions in a session — a compacted transcript replays turns — and two
+/// blocks that merely share a uuid are two blocks, not one.
+type BlockParts = HashMap<(i64, String, i64), (Block, Vec<(i64, String)>)>;
 
 /// Find `needle` in every block of one session, rendered in the agent format. Where recall ranks
 /// and can only show what is present, this is exhaustive over the session: a needle that returns
@@ -949,7 +954,7 @@ async fn reassembled_blocks(ds: &Dataset, session_id: &str, from: Option<i64>, t
         );
         let (seq, bi, si) = (icol(batch, "seq"), icol(batch, "block_idx"), icol(batch, "split_idx"));
         for i in 0..batch.num_rows() {
-            let key = (sval(turn, i), ival(bi, i));
+            let key = (ival(seq, i), sval(turn, i), ival(bi, i));
             let entry = blocks.entry(key).or_insert_with(|| {
                 (
                     Block {

--- a/src/commands/recall.rs
+++ b/src/commands/recall.rs
@@ -103,16 +103,43 @@ pub struct ScanResult {
     pub to: Option<i64>,
 }
 
-/// One session in a memory's listing: where and when it started, and how much it holds.
+/// One session in a memory's listing: when and where it started, how much it holds, and the prompt
+/// it opened with.
 pub struct Session {
     pub session_id: String,
     /// First timestamp in the session.
     pub ts: String,
     pub workdir: String,
     pub harness: String,
+    /// The session's source repo(s) as `owner/name`, space-joined; empty when unresolvable.
+    pub repo: String,
     /// Distinct turns, not rows: chunking is an indexing artifact, a turn is what `get` reads.
     pub turns: usize,
+    /// The opening real prompt, scaffolding skipped — what the session was for, in one line.
+    pub first_prompt: String,
 }
+
+impl Session {
+    /// The `YYYY-MM-DD` the session started.
+    pub fn date(&self) -> &str {
+        self.ts.get(..10).unwrap_or(&self.ts)
+    }
+
+    /// Best available provenance: the repo when the checkout resolved, else the working directory.
+    pub fn origin(&self) -> &str {
+        self.repo.split_whitespace().next().unwrap_or(&self.workdir)
+    }
+}
+
+/// How many sessions a listing renders before it elides the rest. A row carries an opening prompt
+/// now, so a memory of a few hundred sessions would otherwise answer past any tool-result ceiling —
+/// the very failure the filters exist to avoid.
+const SESSIONS_LIMIT: usize = 50;
+
+/// The most rows one listing will render, whatever `limit` asks for. Past this the reply is larger
+/// than a tool result can carry, so a higher `limit` would only produce an answer nobody receives:
+/// walking with `offset` is the way to see more.
+const SESSIONS_LIMIT_MAX: usize = 200;
 
 /// One reassembled turn from `get`: its blocks in order, splits stitched back together.
 pub struct Turn {
@@ -471,9 +498,13 @@ async fn fts_candidates(ds: &Dataset, query: &str, limit: usize, filter: Option<
 /// Whether the memory carries the `harness` column — false for one built before the facet existed
 /// (an un-migrated memory).
 fn has_harness_col(ds: &Dataset) -> bool {
-    arrow_schema::Schema::from(ds.schema())
-        .column_with_name("harness")
-        .is_some()
+    has_col(ds, "harness")
+}
+
+/// Whether the dataset carries `name`. Projecting a column a memory predates errors, so every
+/// migrated column is asked for before it is read.
+fn has_col(ds: &Dataset, name: &str) -> bool {
+    arrow_schema::Schema::from(ds.schema()).column_with_name(name).is_some()
 }
 
 /// `HIT_COLS`, minus `harness` on an un-migrated memory: projecting a column the dataset lacks errors,
@@ -649,36 +680,155 @@ pub async fn get(memory: Memory, session_id: String, range: TurnRange) -> Result
     Ok(crate::ui::render::get_agent(&note, &turns, total))
 }
 
-/// Every session in a memory, oldest first, rendered in the agent format. Ranked retrieval reaches
-/// what a query reaches and says nothing about the rest, so enumeration is the only thing that
-/// answers what a memory holds and how much of it a pass has covered.
-pub async fn sessions(memory: Memory) -> Result<String> {
+/// What narrows a listing: the population a criterion is about, before anything of it is read.
+#[derive(Default)]
+pub struct SessionFilter {
+    /// Keep sessions whose stored repo names this `owner/name`.
+    pub repo: Option<String>,
+    /// Keep sessions that started on or after this `YYYY-MM-DD`.
+    pub since: Option<String>,
+    /// Keep sessions that started on or before this `YYYY-MM-DD`.
+    pub until: Option<String>,
+    /// Rows to render; `None` takes [`SESSIONS_LIMIT`], and anything above [`SESSIONS_LIMIT_MAX`] is
+    /// clamped to it.
+    pub limit: Option<usize>,
+    /// Skip this many of the most recent matches before taking `limit` — how a listing is walked
+    /// back through time. Rows are ordered on (timestamp, session id), so a given offset always
+    /// names the same row: continuing neither repeats a session nor skips one.
+    pub offset: usize,
+}
+
+/// The sessions of a memory that `filter` keeps, oldest first, rendered in the agent format. Ranked
+/// retrieval reaches what a query reaches and says nothing about the rest, so enumeration is the
+/// only thing that answers what a memory holds and how much of it a pass has covered — which is why
+/// an elided row is always counted, never dropped quietly.
+///
+/// The prompts are read after the filter and the bound, so their cost follows the rows that will be
+/// rendered rather than the size of the memory.
+pub async fn sessions(memory: Memory, filter: SessionFilter) -> Result<String> {
+    // Zero once meant "every match", back when a listing had no ceiling. It now means an empty
+    // reply, which is never what a caller wants — so say so instead of returning nothing.
+    if filter.limit == Some(0) {
+        bail!("a limit of 0 would list nothing — omit it for {SESSIONS_LIMIT} rows, raise it to at most {SESSIONS_LIMIT_MAX}, and walk the rest with --offset");
+    }
     let read = open_read(&memory).await?;
     let note = read.note.clone().unwrap_or_default();
     let label = read.memory_label.clone().unwrap_or_else(|| memory.label());
-    let sessions = scan_sessions(&read.ds).await?;
-    if sessions.is_empty() {
+    let all = scan_sessions(&read.ds).await?;
+    if all.is_empty() {
         return Ok(format!("{note}no sessions in {label}\n"));
     }
-    Ok(crate::ui::render::sessions_agent(&note, &sessions))
+    let matched: Vec<Session> = all.into_iter().filter(|s| filter.keeps(s)).collect();
+    if matched.is_empty() {
+        return Ok(format!("{note}no session in {label} matches\n"));
+    }
+
+    // Oldest first is the reading order, but a page is taken from the *recent* end — the tail of a
+    // memory is what a pass is usually catching up on — and `offset` walks back from there.
+    let total = matched.len();
+    let limit = filter.limit.unwrap_or(SESSIONS_LIMIT).min(SESSIONS_LIMIT_MAX);
+    let end = total.saturating_sub(filter.offset);
+    let mut shown: Vec<Session> = matched.into_iter().take(end).skip(end.saturating_sub(limit)).collect();
+    if shown.is_empty() {
+        return Ok(format!(
+            "{note}offset {} is past the {total} session(s) in {label}\n",
+            filter.offset
+        ));
+    }
+    let ids: Vec<String> = shown.iter().map(|s| s.session_id.clone()).collect();
+    let mut prompts = first_prompts(&read.ds, &ids).await?;
+    for s in shown.iter_mut() {
+        s.first_prompt = prompts.remove(&s.session_id).unwrap_or_default();
+    }
+    Ok(crate::ui::render::sessions_agent(&note, &shown, total, filter.offset))
 }
 
-/// Fold every row into its session: earliest timestamp, provenance, and distinct turn count.
+impl SessionFilter {
+    /// Whether `s` survives every filter that was given.
+    fn keeps(&self, s: &Session) -> bool {
+        // A session's repo field can name several checkouts; any of them counts. Empty means the
+        // checkout didn't resolve at index time, which no `--repo` can claim.
+        if let Some(repo) = &self.repo {
+            if !s.repo.split_whitespace().any(|i| i == repo) {
+                return false;
+            }
+        }
+        if let Some(since) = &self.since {
+            if s.date() < since.as_str() {
+                return false;
+            }
+        }
+        if let Some(until) = &self.until {
+            if s.date() > until.as_str() {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+/// The opening real prompt of each session in `ids` — its earliest user text block that isn't
+/// injected scaffolding, collapsed to one line. A session whose user turns are all scaffolding is
+/// absent from the map.
+async fn first_prompts(ds: &Dataset, ids: &[String]) -> Result<HashMap<String, String>> {
+    if ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let list: Vec<String> = ids.iter().map(|id| format!("'{}'", esc(id))).collect();
+    // Split 0 only: `is_scaffolding` reads a block's start, and a later split begins mid-text.
+    let filter = format!(
+        "session_id IN ({}) AND role = 'user' AND block_type = 'text' AND split_idx = 0",
+        list.join(", ")
+    );
+    let cols = ["session_id", "seq", "block_idx", "text"];
+    let batches = dataset::scan_rows(ds, &cols, Some(&filter), None).await?;
+    let mut best: HashMap<String, ((i64, i64), String)> = HashMap::new();
+    for batch in &batches {
+        let (sid, text) = (scol(batch, "session_id"), scol(batch, "text"));
+        let (seq, bi) = (icol(batch, "seq"), icol(batch, "block_idx"));
+        for i in 0..batch.num_rows() {
+            let body = sval(text, i);
+            if crate::commands::curate::is_scaffolding(&body) {
+                continue;
+            }
+            let key = (ival(seq, i), ival(bi, i));
+            let entry = best.entry(sval(sid, i));
+            match entry {
+                std::collections::hash_map::Entry::Occupied(mut e) if key < e.get().0 => {
+                    e.insert((key, body));
+                }
+                std::collections::hash_map::Entry::Vacant(e) => {
+                    e.insert((key, body));
+                }
+                _ => {}
+            }
+        }
+    }
+    Ok(best.into_iter().map(|(id, (_, text))| (id, text)).collect())
+}
+
+/// Fold every row into its session: earliest timestamp, provenance, and distinct turn count. Reads
+/// metadata only — the opening prompts cost a `text` read, so they are fetched separately for the
+/// rows that survive the filter.
 async fn scan_sessions(ds: &Dataset) -> Result<Vec<Session>> {
     let mut cols = vec!["session_id", "ts", "workdir", "turn_uuid"];
     if has_harness_col(ds) {
         cols.push("harness");
     }
+    if has_col(ds, "repo") {
+        cols.push("repo");
+    }
     let batches = dataset::scan_rows(ds, &cols, None, None).await?;
 
     let mut by_id: HashMap<String, (Session, HashSet<String>)> = HashMap::new();
     for batch in &batches {
-        let (sid, ts, wd, turn, harness) = (
+        let (sid, ts, wd, turn, harness, repo) = (
             scol(batch, "session_id"),
             scol(batch, "ts"),
             scol(batch, "workdir"),
             scol(batch, "turn_uuid"),
             scol(batch, "harness"),
+            scol(batch, "repo"),
         );
         for i in 0..batch.num_rows() {
             let id = sval(sid, i);
@@ -689,7 +839,9 @@ async fn scan_sessions(ds: &Dataset) -> Result<Vec<Session>> {
                         ts: sval(ts, i),
                         workdir: sval(wd, i),
                         harness: sval(harness, i),
+                        repo: sval(repo, i),
                         turns: 0,
+                        first_prompt: String::new(),
                     },
                     HashSet::new(),
                 )

--- a/src/commands/recall.rs
+++ b/src/commands/recall.rs
@@ -1,8 +1,8 @@
-//! The read surface: `recall`, `get`, `sessions`, `status` over the existing index.
+//! The read surface: `recall`, `get`, `sessions`, `scan`, `status` over the existing index.
 //! Recall pipeline: hybrid (vector + BM25, fused by reciprocal rank) → cross-encoder rerank →
-//! recency reweight → neighbor expansion. `recall`/`get`/`sessions` return results rendered in the
-//! agent format; `recall_hits`/`get_turns` return the structured results for other renderings
-//! (see `render`).
+//! recency reweight → neighbor expansion. `recall`/`get`/`sessions`/`scan` return results rendered
+//! in the agent format; `recall_hits`/`get_turns` return the structured results for other
+//! renderings (see `render`).
 
 use super::curate;
 use crate::chunk;
@@ -57,6 +57,50 @@ pub struct Hit {
     pub block_type: String,
     pub harness: String,
     pub neighbors: Vec<Neighbor>,
+}
+
+/// Matching blocks `scan` lists before it stops. A session runs to thousands of turns, so a common
+/// word could still fill a reply; what the cap dropped is always reported.
+const SCAN_HIT_CAP: usize = 200;
+
+/// Why a `scan` listing stopped short, and what the caller can do about it.
+pub enum ScanCut {
+    /// Hits remain from this turn onward; a continuing scan starts exactly there. The page was cut
+    /// back to a turn boundary so that resuming neither repeats a hit nor skips one.
+    Resume(i64),
+    /// This one turn holds more matches than the cap by itself, so paging cannot step over it —
+    /// there is no coordinate that both makes progress and keeps every hit. Read the turn instead.
+    Crowded(i64),
+}
+
+/// One block of a session carrying a `scan` needle.
+pub struct ScanHit {
+    pub turn_uuid: String,
+    pub ts: String,
+    pub block_type: String,
+    pub seq: i64,
+    /// Byte offset of the match within `text`.
+    pub at: usize,
+    /// Chars the match spans — its own length, which case folding leaves unchanged.
+    pub len: usize,
+    /// The whole reassembled block, for the caller to excerpt around `at`.
+    pub text: String,
+}
+
+/// What a `scan` needle found in one session, or in the window of it that was scanned.
+pub struct ScanResult {
+    pub needle: String,
+    pub session_id: String,
+    /// Matching blocks in reading order, capped at [`SCAN_HIT_CAP`].
+    pub hits: Vec<ScanHit>,
+    /// Matching blocks past the cap, absent from `hits`.
+    pub dropped: usize,
+    /// Why the listing stopped, when it did — and where a continuing scan picks up.
+    pub cut: Option<ScanCut>,
+    /// The seq window scanned, when one was asked for. A zero over a window clears the window, not
+    /// the session, so the window rides with the result.
+    pub from: Option<i64>,
+    pub to: Option<i64>,
 }
 
 /// One session in a memory's listing: where and when it started, and how much it holds.
@@ -670,6 +714,215 @@ async fn scan_sessions(ds: &Dataset) -> Result<Vec<Session>> {
     Ok(out)
 }
 
+/// One block of a memory, its splits stitched back together, with the facets a `scan` hit prints.
+struct Block {
+    turn_uuid: String,
+    ts: String,
+    block_type: String,
+    seq: i64,
+    block_idx: i64,
+    text: String,
+}
+
+/// Blocks under assembly, keyed by (turn_uuid, block_idx): each one's facets, and the split rows
+/// still to be stitched into its `text`.
+type BlockParts = HashMap<(String, i64), (Block, Vec<(i64, String)>)>;
+
+/// Find `needle` in every block of one session, rendered in the agent format. Where recall ranks
+/// and can only show what is present, this is exhaustive over the session: a needle that returns
+/// nothing is absent from all of it. Literal, never a pattern — a regex that silently matches
+/// nothing would read as exactly that clearance.
+///
+/// A session that isn't in the memory is an error, not an empty result: a mistyped id would
+/// otherwise read as the clearance this verb exists to give.
+pub async fn scan(
+    memory: Memory,
+    needle: String,
+    session_id: String,
+    from: Option<i64>,
+    to: Option<i64>,
+    ignore_case: bool,
+    context: usize,
+) -> Result<String> {
+    let read = open_read(&memory).await?;
+    let note = read.note.clone().unwrap_or_default();
+    let label = read.memory_label.clone().unwrap_or_else(|| memory.label());
+    let blocks = reassembled_blocks(&read.ds, &session_id, from, to).await?;
+    if blocks.is_empty() {
+        // A window that holds nothing is not the same as a session that isn't there: only the
+        // unwindowed case can conclude the session is absent.
+        if from.is_some() || to.is_some() {
+            let scanned = reassembled_blocks(&read.ds, &session_id, None, None).await?;
+            if !scanned.is_empty() {
+                return Ok(format!(
+                    "{note}no turns in that range of session {session_id} (it holds {})\n",
+                    scanned.iter().map(|b| b.seq).collect::<HashSet<_>>().len()
+                ));
+            }
+        }
+        bail!("no session {session_id} in {label} — `funes sessions` lists the ones there are");
+    }
+    let result = find_needle(&blocks, &needle, &session_id, from, to, ignore_case);
+    Ok(crate::ui::render::scan_agent(
+        &note,
+        &memory_hint(read.memory_label.as_deref()),
+        &result,
+        context,
+    ))
+}
+
+/// Every block of one session, splits de-overlapped. Matching raw chunks would miss a needle that
+/// straddles a split boundary, so the session's rows are bucketed by block before anything is
+/// matched. Ordered by position in the session. Empty when the session isn't in the memory.
+async fn reassembled_blocks(ds: &Dataset, session_id: &str, from: Option<i64>, to: Option<i64>) -> Result<Vec<Block>> {
+    let cols = ["turn_uuid", "seq", "ts", "block_type", "block_idx", "split_idx", "text"];
+    let mut filter = format!("session_id = '{}'", esc(session_id));
+    if let Some(from) = from {
+        filter.push_str(&format!(" AND seq >= {from}"));
+    }
+    if let Some(to) = to {
+        filter.push_str(&format!(" AND seq <= {to}"));
+    }
+    let batches = dataset::scan_rows(ds, &cols, Some(filter.as_str()), None).await?;
+
+    // Splits of one block can land in different batches, so every row is bucketed before any of it
+    // is stitched.
+    let mut blocks: BlockParts = HashMap::new();
+    for batch in &batches {
+        let (turn, ts, bt, text) = (
+            scol(batch, "turn_uuid"),
+            scol(batch, "ts"),
+            scol(batch, "block_type"),
+            scol(batch, "text"),
+        );
+        let (seq, bi, si) = (icol(batch, "seq"), icol(batch, "block_idx"), icol(batch, "split_idx"));
+        for i in 0..batch.num_rows() {
+            let key = (sval(turn, i), ival(bi, i));
+            let entry = blocks.entry(key).or_insert_with(|| {
+                (
+                    Block {
+                        turn_uuid: sval(turn, i),
+                        ts: sval(ts, i),
+                        block_type: sval(bt, i),
+                        seq: ival(seq, i),
+                        block_idx: ival(bi, i),
+                        text: String::new(),
+                    },
+                    Vec::new(),
+                )
+            });
+            entry.1.push((ival(si, i), sval(text, i)));
+        }
+    }
+    drop(batches);
+
+    let mut out: Vec<Block> = blocks
+        .into_values()
+        .map(|(mut block, mut splits)| {
+            splits.sort_by_key(|(si, _)| *si);
+            let mut pieces = splits.into_iter().map(|(_, t)| t);
+            block.text = pieces.next().unwrap_or_default();
+            for piece in pieces {
+                block.text = chunk::stitch(&block.text, &piece);
+            }
+            block
+        })
+        .collect();
+    out.sort_by_key(|b| (b.seq, b.block_idx));
+    Ok(out)
+}
+
+/// Every block of the scanned window carrying `needle`, in reading order, capped at
+/// [`SCAN_HIT_CAP`] — with the coordinate a continuing scan resumes from when the cap bites.
+fn find_needle(
+    blocks: &[Block],
+    needle: &str,
+    session_id: &str,
+    from: Option<i64>,
+    to: Option<i64>,
+    ignore_case: bool,
+) -> ScanResult {
+    let folded: Vec<char> = if ignore_case {
+        needle.chars().map(fold).collect()
+    } else {
+        Vec::new()
+    };
+    let mut hits: Vec<ScanHit> = Vec::new();
+    for b in blocks {
+        let at = if ignore_case {
+            find_folded(&b.text, &folded)
+        } else {
+            b.text.find(needle)
+        };
+        let Some(at) = at else { continue };
+        hits.push(ScanHit {
+            turn_uuid: b.turn_uuid.clone(),
+            ts: b.ts.clone(),
+            block_type: b.block_type.clone(),
+            seq: b.seq,
+            at,
+            len: needle.chars().count(),
+            text: b.text.clone(),
+        });
+    }
+
+    // Cut at a turn boundary. Hits are in reading order, so dropping the trailing hits that share
+    // the first dropped hit's turn leaves a page a caller can continue from exactly: everything
+    // rendered lies before that turn. Cutting mid-turn instead would force a resume that either
+    // repeats the turn's earlier hits or skips its later ones.
+    let found = hits.len();
+    let cut = hits.get(SCAN_HIT_CAP).map(|h| h.seq).map(|boundary| {
+        match hits[..SCAN_HIT_CAP].iter().rposition(|h| h.seq < boundary) {
+            Some(last) => {
+                hits.truncate(last + 1);
+                ScanCut::Resume(boundary)
+            }
+            // The cap falls inside a single turn's own matches: no boundary to cut at.
+            None => {
+                hits.truncate(SCAN_HIT_CAP);
+                ScanCut::Crowded(boundary)
+            }
+        }
+    });
+    ScanResult {
+        needle: needle.to_string(),
+        session_id: session_id.to_string(),
+        dropped: found - hits.len(),
+        hits,
+        cut,
+        from,
+        to,
+    }
+}
+
+/// Byte offset of the first case-folded occurrence of `needle` (already folded) in `text`. Folding
+/// is per char, so the offset stays an offset into the original.
+fn find_folded(text: &str, needle: &[char]) -> Option<usize> {
+    if needle.is_empty() {
+        return None;
+    }
+    let hay: Vec<(usize, char)> = text.char_indices().collect();
+    if hay.len() < needle.len() {
+        return None;
+    }
+    hay.windows(needle.len()).find_map(|w| {
+        w.iter()
+            .zip(needle)
+            .all(|(&(_, c), &want)| fold(c) == want)
+            .then_some(w[0].0)
+    })
+}
+
+/// Lowercase `c` when that is a single char — which covers the case variation `--ignore-case` is
+/// for. A char whose lowercase is several (`İ`) stays as it is and simply won't fold-match.
+fn fold(c: char) -> char {
+    let mut lower = c.to_lowercase();
+    match (lower.next(), lower.next()) {
+        (Some(l), None) => l,
+        _ => c,
+    }
+}
+
 /// The turns behind `get`, each reassembled (blocks in order, splits de-overlapped). Returns the
 /// degradation note, the turns — empty when the range holds none — and how many turns the session
 /// holds in total, so a partial read can say what it is part of.
@@ -1047,6 +1300,30 @@ mod tests {
         );
         // values are escaped against filter-string injection.
         assert_eq!(build_where(None, Some("a'b")).as_deref(), Some("harness = 'a''b'"));
+    }
+
+    #[test]
+    fn find_folded_matches_case_insensitively_at_original_offsets() {
+        let folded = |n: &str| -> Vec<char> { n.chars().map(fold).collect() };
+        let text = "the Cache is Pinned to a Commit";
+        // The offset indexes the original text, not a lowercased copy.
+        assert_eq!(find_folded(text, &folded("PINNED")), Some(13));
+        assert_eq!(&text[13..19], "Pinned");
+        assert_eq!(find_folded(text, &folded("cache")), Some(4));
+        assert_eq!(find_folded(text, &folded("absent")), None);
+        // An empty needle never matches, so it can't report the whole memory as a hit.
+        assert_eq!(find_folded(text, &[]), None);
+        // A needle longer than the text is not a match rather than a panic.
+        assert_eq!(find_folded("ab", &folded("abc")), None);
+    }
+
+    #[test]
+    fn fold_lowercases_only_one_to_one_mappings() {
+        assert_eq!(fold('A'), 'a');
+        assert_eq!(fold('É'), 'é');
+        assert_eq!(fold('a'), 'a');
+        // `İ` lowercases to two chars, which would break offset arithmetic — left as it is.
+        assert_eq!(fold('İ'), 'İ');
     }
 
     #[test]

--- a/src/commands/sketch.rs
+++ b/src/commands/sketch.rs
@@ -1,0 +1,62 @@
+//! `funes sketch`: what a session contains, without being told what to look for.
+//!
+//! Every other read needs a question — `recall` a query, `scan` a literal, `get` coordinates. This
+//! one asks the session instead, selecting the passages most distinctive within it from the vectors
+//! already stored. That is the read for judging a session against criteria which cannot be turned
+//! into queries, because the material that disqualifies a session is usually the material that does
+//! not belong in it.
+//!
+//! It samples, so it never establishes absence: [`super::scan`] does that, for one literal at a time.
+
+use crate::memory::Memory;
+use crate::session_sketch::{self, SketchOptions};
+use anyhow::{bail, Result};
+
+/// Places a sketch shows when the caller doesn't say.
+const DEFAULT_UNITS: usize = 8;
+
+/// Characters a sketch renders when the caller doesn't say — cheap by default, since a caller can
+/// always ask for more and an over-fetch is paid for by whoever reads the reply.
+const DEFAULT_CHARS: usize = 8_000;
+
+/// Digest one session, rendered in the agent format. `units` and `max_chars` are requests: both are
+/// clamped to what a reply can carry, and any narrowing is reported rather than applied quietly.
+pub async fn run(
+    memory: Memory,
+    session_id: String,
+    from: Option<i64>,
+    to: Option<i64>,
+    units: Option<usize>,
+    max_chars: Option<usize>,
+) -> Result<String> {
+    let asked = SketchOptions {
+        budget: units.unwrap_or(DEFAULT_UNITS),
+        char_budget: max_chars.unwrap_or(DEFAULT_CHARS),
+    };
+    let (options, clamped) = asked.clamp();
+    // A whole-session digest is deterministic in the session's content, so it is worth caching: a
+    // second pass over the same candidate costs nothing. A window is not cached — a cache entry
+    // keyed on the session would otherwise answer for a stretch of it.
+    let sketch = if from.is_none() && to.is_none() {
+        let mut batch =
+            session_sketch::generate_many_cached(&memory, std::slice::from_ref(&session_id), options).await?;
+        if let Some(error) = batch.failures.remove(&session_id) {
+            bail!("sketching session {session_id}: {error}");
+        }
+        match batch.sketches.remove(&session_id) {
+            Some(sketch) => sketch,
+            None => bail!("session {session_id} has no stored chunks"),
+        }
+    } else {
+        session_sketch::generate(&memory, &session_id, from, to, options).await?
+    };
+    if sketch.evidence.is_empty() {
+        bail!("nothing to sketch in session {session_id} — it holds no text worth selecting");
+    }
+    Ok(crate::ui::render::sketch_agent(
+        "",
+        &super::recall::memory_hint(Some(&memory.label())),
+        &sketch,
+        clamped,
+    ))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,5 +37,6 @@ pub mod hub;
 pub mod inference;
 pub mod memory;
 pub mod scan;
+pub mod session_sketch;
 pub mod traces;
 pub mod ui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,6 +72,22 @@ enum Cmd {
     },
     /// List a memory's sessions, oldest first.
     Sessions {
+        /// Keep only sessions whose checkout resolved to this repo (`owner/name`).
+        #[arg(long, value_name = "OWNER/NAME")]
+        repo: Option<String>,
+        /// Keep only sessions that started on or after this date (`YYYY-MM-DD`).
+        #[arg(long, value_name = "DATE")]
+        since: Option<String>,
+        /// Keep only sessions that started on or before this date (`YYYY-MM-DD`).
+        #[arg(long, value_name = "DATE")]
+        until: Option<String>,
+        /// Rows to list, keeping the most recent. Capped at 200 — walk with --offset for more.
+        /// Zero is an error.
+        #[arg(long, value_name = "N")]
+        limit: Option<usize>,
+        /// Skip this many of the most recent matches before taking --limit, to walk back in time.
+        #[arg(long, value_name = "N", default_value_t = 0)]
+        offset: usize,
         #[command(flatten)]
         memory: MemoryOpts,
     },
@@ -362,8 +378,22 @@ async fn main() -> Result<()> {
             print!("{}", recall::get(memory.resolve(), session_id, range).await?);
             Ok(())
         }
-        Cmd::Sessions { memory } => {
-            print!("{}", recall::sessions(memory.resolve()).await?);
+        Cmd::Sessions {
+            repo,
+            since,
+            until,
+            limit,
+            offset,
+            memory,
+        } => {
+            let filter = recall::SessionFilter {
+                repo,
+                since,
+                until,
+                limit,
+                offset,
+            };
+            print!("{}", recall::sessions(memory.resolve(), filter).await?);
             Ok(())
         }
         Cmd::Scan {

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,9 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
+/// Characters shown each side of a `scan` match when no context is given.
+const DEFAULT_CONTEXT: usize = 100;
+
 #[derive(Parser)]
 #[command(name = "funes", version, about = "Recall over your past AI agent sessions.")]
 struct Cli {
@@ -69,6 +72,29 @@ enum Cmd {
     },
     /// List a memory's sessions, oldest first.
     Sessions {
+        #[command(flatten)]
+        memory: MemoryOpts,
+    },
+    /// Find a literal string everywhere in one session — exhaustive, unranked.
+    Scan {
+        /// The literal to find. Not a regex.
+        #[arg(value_name = "NEEDLE")]
+        needle: String,
+        /// The session to scan (from a `sessions` row or a recall hit's `→ get` line).
+        #[arg(value_name = "SESSION_ID")]
+        session_id: String,
+        /// First turn to scan, as the session's own seq. Defaults to the session's start.
+        #[arg(long, value_name = "SEQ")]
+        from: Option<i64>,
+        /// Last turn to scan, as the session's own seq. Defaults to the session's end.
+        #[arg(long, value_name = "SEQ")]
+        to: Option<i64>,
+        /// Match regardless of case.
+        #[arg(short, long)]
+        ignore_case: bool,
+        /// Characters of surrounding text to show on each side of a match.
+        #[arg(long, default_value_t = DEFAULT_CONTEXT)]
+        context: usize,
         #[command(flatten)]
         memory: MemoryOpts,
     },
@@ -338,6 +364,21 @@ async fn main() -> Result<()> {
         }
         Cmd::Sessions { memory } => {
             print!("{}", recall::sessions(memory.resolve()).await?);
+            Ok(())
+        }
+        Cmd::Scan {
+            needle,
+            session_id,
+            from,
+            to,
+            ignore_case,
+            context,
+            memory,
+        } => {
+            print!(
+                "{}",
+                recall::scan(memory.resolve(), needle, session_id, from, to, ignore_case, context).await?
+            );
             Ok(())
         }
         Cmd::Ask { agent } => match agent {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@
 //! `$FUNES_HOME` or `~/.funes`.
 
 use funes::agents::{claude, codex, hermes, pi};
-use funes::commands::{ask, curate, index, mcp, push, recall, scrub, update};
+use funes::commands::{ask, curate, index, mcp, push, recall, scrub, sketch, update};
 use funes::hub;
 use funes::memory;
 use funes::scan;
@@ -88,6 +88,25 @@ enum Cmd {
         /// Skip this many of the most recent matches before taking --limit, to walk back in time.
         #[arg(long, value_name = "N", default_value_t = 0)]
         offset: usize,
+        #[command(flatten)]
+        memory: MemoryOpts,
+    },
+    /// Digest one session: the passages most distinctive within it, chosen without a query.
+    Sketch {
+        /// Session to digest (from a `sessions` row or a hit's `→ get` line).
+        session_id: String,
+        /// How many distinct places to show. Clamped to 40, and to what --max-chars can render.
+        #[arg(long, value_name = "N")]
+        units: Option<usize>,
+        /// Total characters to render. Clamped to 40000.
+        #[arg(long, value_name = "N")]
+        max_chars: Option<usize>,
+        /// First turn to digest, as the session's own seq. Defaults to the session's start.
+        #[arg(long, value_name = "SEQ")]
+        from: Option<i64>,
+        /// Last turn to digest, as the session's own seq. Defaults to the session's end.
+        #[arg(long, value_name = "SEQ")]
+        to: Option<i64>,
         #[command(flatten)]
         memory: MemoryOpts,
     },
@@ -394,6 +413,20 @@ async fn main() -> Result<()> {
                 offset,
             };
             print!("{}", recall::sessions(memory.resolve(), filter).await?);
+            Ok(())
+        }
+        Cmd::Sketch {
+            session_id,
+            units,
+            max_chars,
+            from,
+            to,
+            memory,
+        } => {
+            print!(
+                "{}",
+                sketch::run(memory.resolve(), session_id, from, to, units, max_chars).await?
+            );
             Ok(())
         }
         Cmd::Scan {

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,6 +67,11 @@ enum Cmd {
         #[command(flatten)]
         memory: MemoryOpts,
     },
+    /// List a memory's sessions, oldest first.
+    Sessions {
+        #[command(flatten)]
+        memory: MemoryOpts,
+    },
     /// Ask a coding agent one question, grounded in a memory — nothing installed.
     ///
     /// Borrows the agent for a single answer: funes recalls from the memory and hands the agent
@@ -329,6 +334,10 @@ async fn main() -> Result<()> {
         } => {
             let range = recall::TurnRange { from, to };
             print!("{}", recall::get(memory.resolve(), session_id, range).await?);
+            Ok(())
+        }
+        Cmd::Sessions { memory } => {
+            print!("{}", recall::sessions(memory.resolve()).await?);
             Ok(())
         }
         Cmd::Ask { agent } => match agent {

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,14 +13,11 @@ use funes::traces::harness::Harness;
 use funes::ui::render;
 
 use anyhow::{anyhow, Context, Result};
-use clap::{Args, Parser, Subcommand, ValueEnum};
+use clap::{Args, Parser, Subcommand};
 use std::io::{IsTerminal, Write};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-
-/// Turns around a `get` target when no window is given.
-const DEFAULT_WINDOW: i64 = 3;
 
 #[derive(Parser)]
 #[command(name = "funes", version, about = "Recall over your past AI agent sessions.")]
@@ -57,21 +54,16 @@ enum Cmd {
         #[command(flatten)]
         memory: MemoryOpts,
     },
-    /// Drill down on a recall hit: a turn plus the turns around it, reassembled.
+    /// Read a range of a session's turns, addressed by the session's own seq.
     Get {
-        /// Session id (from a recall hit's `→ get` line).
+        /// Session id (from a `sessions` row or a hit's `→ get` line).
         session_id: String,
-        /// Turn uuid (from a recall hit's `→ get` line).
-        turn_uuid: String,
-        /// Turns within this seq window of the target are included.
-        #[arg(long, default_value_t = DEFAULT_WINDOW)]
-        window: i64,
-        /// Output format. Default: human in a terminal, agent when piped.
-        #[arg(long, value_enum)]
-        format: Option<OutputFormat>,
-        /// Highlight this text in the human rendering (matched whitespace-insensitively).
-        #[arg(long)]
-        highlight: Option<String>,
+        /// First turn to read, as the session's own seq. Defaults to the session's start.
+        #[arg(long, value_name = "SEQ")]
+        from: Option<i64>,
+        /// Last turn to read, as the session's own seq. Defaults to 20 turns from --from.
+        #[arg(long, value_name = "SEQ")]
+        to: Option<i64>,
         #[command(flatten)]
         memory: MemoryOpts,
     },
@@ -281,29 +273,6 @@ impl MemoryOpts {
     }
 }
 
-/// The two output layouts for `get`.
-#[derive(Clone, Copy, ValueEnum)]
-enum OutputFormat {
-    /// A numbered list with a hit selector.
-    Human,
-    /// The stable agent layout: multi-line hits with provenance, previews, and neighbors.
-    Agent,
-}
-
-impl OutputFormat {
-    /// Resolve the effective format: an explicit flag wins; otherwise human when both stdin and
-    /// stdout are terminals (the hit selector needs both), agent when piped or scripted.
-    fn resolve(flag: Option<OutputFormat>) -> OutputFormat {
-        flag.unwrap_or_else(|| {
-            if std::io::stdin().is_terminal() && std::io::stdout().is_terminal() {
-                OutputFormat::Human
-            } else {
-                OutputFormat::Agent
-            }
-        })
-    }
-}
-
 /// Color and width for the human renderings: color needs a terminal and no `NO_COLOR`; width
 /// follows `$COLUMNS` when exported, else 100.
 fn human_io() -> (bool, usize) {
@@ -354,27 +323,12 @@ async fn main() -> Result<()> {
         }
         Cmd::Get {
             session_id,
-            turn_uuid,
-            window,
-            format,
-            highlight,
+            from,
+            to,
             memory,
         } => {
-            let format = OutputFormat::resolve(format);
-            let (note, turns) =
-                recall::get_turns(memory.resolve(), session_id.clone(), turn_uuid.clone(), window).await?;
-            if turns.is_empty() {
-                print!("{note}");
-                println!("turn {turn_uuid} not found in session {session_id}");
-            } else if matches!(format, OutputFormat::Human) {
-                let (color, width) = human_io();
-                print!(
-                    "{}",
-                    render::get_human(&note, &turns, color, width, highlight.as_deref())
-                );
-            } else {
-                print!("{}", render::get_agent(&note, &turns));
-            }
+            let range = recall::TurnRange { from, to };
+            print!("{}", recall::get(memory.resolve(), session_id, range).await?);
             Ok(())
         }
         Cmd::Ask { agent } => match agent {

--- a/src/session_sketch.rs
+++ b/src/session_sketch.rs
@@ -1,0 +1,1742 @@
+//! Deterministic session-sketch selection for guided curation.
+//!
+//! The structured sketch API powers the alternate preview in `funes curate`. Constructing a sketch
+//! never writes memory or curation state; the cached entry is a derived local artifact.
+
+use crate::chunk::OVERLAP;
+use crate::commands::curate;
+use crate::memory::dataset;
+use crate::memory::Memory;
+use anyhow::{bail, Context, Result};
+use arrow_array::{Array, FixedSizeListArray, Float32Array, Int64Array, RecordBatch, StringArray};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::cmp::Ordering;
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+// Initial host validation found that 8/16k retained the complete arc of focused sessions while the
+// earlier 12/24k draft mostly admitted secondary transitions. Both remain experimental CLI knobs.
+const DEFAULT_BUDGET: usize = 8;
+const DEFAULT_CHAR_BUDGET: usize = 16_000;
+const TOOL_RESULT_PREVIEW: usize = 2_000;
+
+/// The fewest characters a selected passage renders, whatever the budget divided by the unit count
+/// works out to. Below this a passage is not evidence, just a fragment.
+const MIN_UNIT_CHARS: usize = 240;
+const NEAR_DUPLICATE: f32 = 0.97;
+const VECTOR_EPSILON: f32 = 1e-7;
+// Exact all-pairs grouping preserves the original selector on ordinary sessions. Beyond this size,
+// deterministic random-hyperplane bands generate a bounded candidate set. At cosine 0.97, eight
+// independent 10-bit bands have about a 99% chance of sharing at least one band under the usual
+// SimHash model; a chronological window also catches locally repeated harness traffic.
+const EXACT_DUPLICATE_MAX_UNITS: usize = 3_000;
+const DUPLICATE_LSH_BANDS: usize = 8;
+const DUPLICATE_LSH_BITS: usize = 10;
+const DUPLICATE_BUCKET_HEAD: usize = 8;
+const DUPLICATE_BUCKET_RECENT: usize = 40;
+const DUPLICATE_TEMPORAL_WINDOW: usize = 16;
+const SKETCH_SCHEMA_VERSION: u32 = 1;
+const SELECTOR_VERSION: &str = "session-sketch-v2-experimental";
+
+#[derive(Clone)]
+struct RawRow {
+    session_id: String,
+    id: String,
+    text: String,
+    turn_uuid: String,
+    seq: i64,
+    ts: String,
+    role: String,
+    block_type: String,
+    tool_name: String,
+    block_idx: i64,
+    split_idx: i64,
+    vector: Option<Vec<f32>>,
+}
+
+#[derive(Clone)]
+struct Unit {
+    id: String,
+    text: String,
+    turn_uuid: String,
+    seq: i64,
+    ts: String,
+    role: String,
+    block_type: String,
+    tool_name: String,
+    block_idx: i64,
+    vector: Option<Vec<f32>>,
+    quality: f32,
+    mass: f32,
+}
+
+#[derive(Default)]
+struct Candidate {
+    reasons: BTreeSet<String>,
+    mandatory: bool,
+    transition: f32,
+}
+
+struct CandidatePool {
+    by_unit: HashMap<usize, Candidate>,
+    order: Vec<usize>,
+}
+
+impl CandidatePool {
+    fn new() -> Self {
+        Self {
+            by_unit: HashMap::new(),
+            order: Vec::new(),
+        }
+    }
+
+    fn add(&mut self, unit: usize, reason: impl Into<String>, mandatory: bool, transition: f32) {
+        if !self.by_unit.contains_key(&unit) {
+            self.order.push(unit);
+        }
+        let c = self.by_unit.entry(unit).or_default();
+        c.reasons.insert(reason.into());
+        c.mandatory |= mandatory;
+        c.transition = c.transition.max(transition);
+    }
+
+    fn retain_first(&mut self, limit: usize) {
+        if self.order.len() <= limit {
+            return;
+        }
+        let keep: HashSet<usize> = self.order.iter().copied().take(limit).collect();
+        self.order.truncate(limit);
+        self.by_unit.retain(|i, _| keep.contains(i));
+    }
+}
+
+/// Stable inputs to the deterministic selector. Context neighbors do not count against `budget`.
+#[derive(Clone, Copy, Debug)]
+pub struct SketchOptions {
+    pub budget: usize,
+    pub char_budget: usize,
+}
+
+impl Default for SketchOptions {
+    fn default() -> Self {
+        Self {
+            budget: DEFAULT_BUDGET,
+            char_budget: DEFAULT_CHAR_BUDGET,
+        }
+    }
+}
+
+/// Per-session results from one shared memory scan. One malformed session does not hide sketches
+/// for the others; its error is recorded in `failures` instead.
+#[derive(Default)]
+pub struct SketchBatch {
+    pub sketches: HashMap<String, SessionSketch>,
+    pub failures: HashMap<String, String>,
+    pub cache_outcomes: HashMap<String, CacheOutcome>,
+}
+
+/// What one cached generation did. This lets a future detached hook report whether it did useful
+/// work without coupling the selector to hook installation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CacheOutcome {
+    /// No prior cache file existed.
+    Created,
+    /// The source and selector keys matched; the existing sketch was reused.
+    Reused,
+    /// A prior entry existed but session growth, a rewrite, or selector inputs made it stale.
+    Refreshed,
+    /// Generation succeeded but the best-effort cache write did not.
+    NotStored,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SessionSketch {
+    pub schema_version: u32,
+    pub selector_version: String,
+    pub memory: String,
+    pub session_id: String,
+    pub source_fingerprint: String,
+    pub embedding_fingerprint: String,
+    pub source_chunks: usize,
+    pub eligible_units: usize,
+    pub selected_units: Vec<SelectedUnit>,
+    pub evidence: Vec<Evidence>,
+    pub diagnostics: Diagnostics,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SelectedUnit {
+    pub id: String,
+    pub turn_uuid: String,
+    pub seq: i64,
+    pub block_idx: i64,
+    pub reasons: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Evidence {
+    pub id: String,
+    pub turn_uuid: String,
+    pub seq: i64,
+    pub block_idx: i64,
+    pub ts: String,
+    pub role: String,
+    pub block_type: String,
+    pub tool_name: Option<String>,
+    pub selected: bool,
+    pub reasons: Vec<String>,
+    pub truncated: bool,
+    pub text: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Diagnostics {
+    pub axes: usize,
+    pub transitions: usize,
+    pub near_duplicate_groups: usize,
+    pub duplicate_strategy: String,
+    pub duplicate_vector_comparisons: usize,
+    pub candidates: usize,
+    pub rendered_characters: usize,
+    pub budget: usize,
+    pub char_budget: usize,
+    pub elapsed_ms: u128,
+    pub fallback: Option<String>,
+}
+
+#[derive(Clone)]
+struct TurnInfo {
+    units: Vec<usize>,
+    vector: Option<Vec<f32>>,
+}
+
+#[derive(Clone, Copy)]
+struct Boundary {
+    after_turn: usize,
+    score: f32,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct DuplicateStats {
+    groups: usize,
+    strategy: &'static str,
+    vector_comparisons: usize,
+}
+
+/// Build one sketch of a session, or of the `from`..`to` window of it. Reads the memory and nothing
+/// else. `options` is taken as asked: clamp it with [`SketchOptions::clamp`] first if it came from a
+/// caller, so the narrowing can be reported.
+pub async fn generate(
+    memory: &Memory,
+    session_id: &str,
+    from: Option<i64>,
+    to: Option<i64>,
+    options: SketchOptions,
+) -> Result<SessionSketch> {
+    let ds = memory.open().await?;
+    let rows = read_window(&ds, session_id, from, to).await?;
+    if rows.is_empty() {
+        bail!("session {session_id} has no stored chunks");
+    }
+    build_sketch(
+        memory.label(),
+        session_id.to_string(),
+        rows,
+        embedding_fingerprint(&ds),
+        options.budget,
+        options.char_budget,
+        Instant::now(),
+    )
+}
+
+/// Build sketches for several exact session ids from one dataset scan. Session-local selector
+/// failures are isolated in the returned batch; opening or scanning the memory still fails the
+/// whole operation.
+pub async fn generate_many(memory: &Memory, session_ids: &[String], options: SketchOptions) -> Result<SketchBatch> {
+    generate_many_inner(memory, session_ids, options, None).await
+}
+
+/// Build or reuse sketches for a picker. Cache entries live under the funes home and are accepted
+/// only when the complete source/embedding fingerprints, selector version, schema, and budgets
+/// match. A corrupt or unwritable cache quietly degrades to deterministic generation.
+pub async fn generate_many_cached(
+    memory: &Memory,
+    session_ids: &[String],
+    options: SketchOptions,
+) -> Result<SketchBatch> {
+    let cache = dataset::funes_dir().join("cache/session-sketch");
+    generate_many_inner(memory, session_ids, options, Some(&cache)).await
+}
+
+async fn generate_many_inner(
+    memory: &Memory,
+    session_ids: &[String],
+    options: SketchOptions,
+    cache_root: Option<&Path>,
+) -> Result<SketchBatch> {
+    let (options, _) = options.clamp();
+    if session_ids.is_empty() {
+        return Ok(SketchBatch::default());
+    }
+
+    let ds = memory.open().await?;
+    let embedding_fingerprint = embedding_fingerprint(&ds);
+    let rows = read_sessions(&ds, session_ids).await?;
+    let mut by_session: HashMap<String, Vec<RawRow>> = HashMap::new();
+    for row in rows {
+        by_session.entry(row.session_id.clone()).or_default().push(row);
+    }
+
+    let mut batch = SketchBatch::default();
+    let memory_label = memory.label();
+    for session_id in session_ids {
+        let Some(rows) = by_session.remove(session_id) else {
+            batch
+                .failures
+                .insert(session_id.clone(), "session has no stored chunks".to_string());
+            continue;
+        };
+
+        let source_fingerprint = fingerprint(&rows);
+        let cache_path = cache_root.map(|root| cache_path(root, &memory_label, session_id));
+        let had_cache = cache_path.as_deref().is_some_and(Path::exists);
+        if let Some(sketch) = cache_path.as_deref().and_then(|path| {
+            load_cached_sketch(
+                path,
+                &memory_label,
+                session_id,
+                &source_fingerprint,
+                &embedding_fingerprint,
+                options,
+            )
+        }) {
+            batch.sketches.insert(session_id.clone(), sketch);
+            batch.cache_outcomes.insert(session_id.clone(), CacheOutcome::Reused);
+            continue;
+        }
+
+        match build_sketch(
+            memory_label.clone(),
+            session_id.clone(),
+            rows,
+            embedding_fingerprint.clone(),
+            options.budget,
+            options.char_budget,
+            Instant::now(),
+        ) {
+            Ok(sketch) => {
+                if let Some(path) = cache_path.as_deref() {
+                    let outcome = if store_cached_sketch(path, &sketch).is_err() {
+                        CacheOutcome::NotStored
+                    } else if had_cache {
+                        CacheOutcome::Refreshed
+                    } else {
+                        CacheOutcome::Created
+                    };
+                    batch.cache_outcomes.insert(session_id.clone(), outcome);
+                }
+                batch.sketches.insert(session_id.clone(), sketch);
+            }
+            Err(error) => {
+                batch.failures.insert(session_id.clone(), format!("{error:#}"));
+            }
+        }
+    }
+    Ok(batch)
+}
+
+fn cache_path(root: &Path, memory: &str, session_id: &str) -> PathBuf {
+    let mut hash = Sha256::new();
+    hash.update(memory.as_bytes());
+    hash.update([0]);
+    hash.update(session_id.as_bytes());
+    root.join(format!("{}.json", hex::encode(hash.finalize())))
+}
+
+fn load_cached_sketch(
+    path: &Path,
+    memory: &str,
+    session_id: &str,
+    source_fingerprint: &str,
+    embedding_fingerprint: &str,
+    options: SketchOptions,
+) -> Option<SessionSketch> {
+    let file = std::fs::File::open(path).ok()?;
+    let sketch: SessionSketch = serde_json::from_reader(file).ok()?;
+    cache_matches(
+        &sketch,
+        memory,
+        session_id,
+        source_fingerprint,
+        embedding_fingerprint,
+        options,
+    )
+    .then_some(sketch)
+}
+
+fn cache_matches(
+    sketch: &SessionSketch,
+    memory: &str,
+    session_id: &str,
+    source_fingerprint: &str,
+    embedding_fingerprint: &str,
+    options: SketchOptions,
+) -> bool {
+    sketch.schema_version == SKETCH_SCHEMA_VERSION
+        && sketch.selector_version == SELECTOR_VERSION
+        && sketch.memory == memory
+        && sketch.session_id == session_id
+        && sketch.source_fingerprint == source_fingerprint
+        && sketch.embedding_fingerprint == embedding_fingerprint
+        && sketch.diagnostics.budget == options.budget
+        && sketch.diagnostics.char_budget == options.char_budget
+}
+
+fn store_cached_sketch(path: &Path, sketch: &SessionSketch) -> Result<()> {
+    let parent = path.parent().context("session-sketch cache path has no parent")?;
+    std::fs::create_dir_all(parent)
+        .with_context(|| format!("creating session-sketch cache at {}", parent.display()))?;
+    let mut staged = tempfile::NamedTempFile::new_in(parent)
+        .with_context(|| format!("staging session-sketch cache in {}", parent.display()))?;
+    serde_json::to_writer(&mut staged, sketch).context("serializing session-sketch cache")?;
+    staged.flush().context("flushing session-sketch cache")?;
+    staged
+        .persist(path)
+        .map_err(|error| error.error)
+        .with_context(|| format!("replacing session-sketch cache at {}", path.display()))?;
+    Ok(())
+}
+
+/// The widest and cheapest a sketch may be asked to be. The upper bounds are a reply ceiling, not a
+/// preference: past them the answer is one no caller receives, so a larger request is clamped rather
+/// than honoured — and the clamp is reported.
+pub const UNITS_MAX: usize = 40;
+pub const CHARS_MAX: usize = 40_000;
+pub const CHARS_MIN: usize = 1_000;
+
+/// What a request was narrowed to, and why — so a caller that asked for more learns it did not get
+/// it. An agent that believes it saw the whole digest is the failure this guards.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Clamped {
+    pub units: Option<usize>,
+    pub chars: Option<usize>,
+}
+
+impl SketchOptions {
+    /// Bring a request inside the bounds, reporting each value that moved. `units` is additionally
+    /// held to what the character budget can render at [`MIN_UNIT_CHARS`] apiece: asking for forty
+    /// places inside a thousand characters would return slivers, not evidence.
+    pub fn clamp(self) -> (Self, Clamped) {
+        let chars = self.char_budget.clamp(CHARS_MIN, CHARS_MAX);
+        let fits = (chars / MIN_UNIT_CHARS).max(1);
+        let units = self.budget.clamp(1, UNITS_MAX.min(fits));
+        (
+            SketchOptions {
+                budget: units,
+                char_budget: chars,
+            },
+            Clamped {
+                units: (units != self.budget).then_some(units),
+                chars: (chars != self.char_budget).then_some(chars),
+            },
+        )
+    }
+}
+
+/// One session's rows, or the `from`..`to` seq window of them. A window makes a long session
+/// digestible in stretches: a fixed number of places over ten thousand turns is thin, where the same
+/// number over each two thousand is proportional.
+async fn read_window(ds: &lance::Dataset, session: &str, from: Option<i64>, to: Option<i64>) -> Result<Vec<RawRow>> {
+    let rows = read_sessions(ds, &[session.to_string()]).await?;
+    Ok(rows
+        .into_iter()
+        .filter(|r| from.is_none_or(|f| r.seq >= f) && to.is_none_or(|t| r.seq <= t))
+        .collect())
+}
+
+async fn read_sessions(ds: &lance::Dataset, sessions: &[String]) -> Result<Vec<RawRow>> {
+    let columns = [
+        "session_id",
+        "id",
+        "text",
+        "turn_uuid",
+        "seq",
+        "ts",
+        "role",
+        "block_type",
+        "tool_name",
+        "block_idx",
+        "split_idx",
+        "vector",
+    ];
+    let quoted = sessions
+        .iter()
+        .map(|session| format!("'{}'", session.replace('\'', "''")))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let filter = format!("session_id IN ({quoted})");
+    let batches = dataset::scan_rows(ds, &columns, Some(&filter), None).await?;
+    let mut rows = Vec::new();
+    for batch in &batches {
+        let session_id = str_col(batch, "session_id")?;
+        let id = str_col(batch, "id")?;
+        let text = str_col(batch, "text")?;
+        let turn = str_col(batch, "turn_uuid")?;
+        let seq = int_col(batch, "seq")?;
+        let ts = str_col(batch, "ts")?;
+        let role = str_col(batch, "role")?;
+        let block_type = str_col(batch, "block_type")?;
+        let tool_name = str_col(batch, "tool_name")?;
+        let block_idx = int_col(batch, "block_idx")?;
+        let split_idx = int_col(batch, "split_idx")?;
+        let vectors = batch
+            .column_by_name("vector")
+            .context("memory has no `vector` column")?
+            .as_any()
+            .downcast_ref::<FixedSizeListArray>()
+            .context("`vector` column is not a fixed-size list")?;
+        for i in 0..batch.num_rows() {
+            rows.push(RawRow {
+                session_id: str_value(session_id, i),
+                id: str_value(id, i),
+                text: str_value(text, i),
+                turn_uuid: str_value(turn, i),
+                seq: int_value(seq, i),
+                ts: str_value(ts, i),
+                role: str_value(role, i),
+                block_type: str_value(block_type, i),
+                tool_name: str_value(tool_name, i),
+                block_idx: int_value(block_idx, i),
+                split_idx: int_value(split_idx, i),
+                vector: vector_value(vectors, i)?,
+            });
+        }
+    }
+    rows.sort_by(|a, b| {
+        (&a.session_id, a.seq, &a.turn_uuid, a.block_idx, a.split_idx, &a.id).cmp(&(
+            &b.session_id,
+            b.seq,
+            &b.turn_uuid,
+            b.block_idx,
+            b.split_idx,
+            &b.id,
+        ))
+    });
+    Ok(rows)
+}
+
+fn str_col<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a StringArray> {
+    batch
+        .column_by_name(name)
+        .with_context(|| format!("memory has no `{name}` column"))?
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .with_context(|| format!("`{name}` column is not utf8"))
+}
+
+fn int_col<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a Int64Array> {
+    batch
+        .column_by_name(name)
+        .with_context(|| format!("memory has no `{name}` column"))?
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .with_context(|| format!("`{name}` column is not int64"))
+}
+
+fn str_value(col: &StringArray, i: usize) -> String {
+    if col.is_null(i) {
+        String::new()
+    } else {
+        col.value(i).to_string()
+    }
+}
+
+fn int_value(col: &Int64Array, i: usize) -> i64 {
+    if col.is_null(i) {
+        0
+    } else {
+        col.value(i)
+    }
+}
+
+fn vector_value(col: &FixedSizeListArray, i: usize) -> Result<Option<Vec<f32>>> {
+    if col.is_null(i) {
+        return Ok(None);
+    }
+    let value = col.value(i);
+    let floats = value
+        .as_any()
+        .downcast_ref::<Float32Array>()
+        .context("`vector` items are not float32")?;
+    if floats.null_count() > 0 {
+        return Ok(None);
+    }
+    Ok(Some((0..floats.len()).map(|j| floats.value(j)).collect()))
+}
+
+fn embedding_fingerprint(ds: &lance::Dataset) -> String {
+    let schema = arrow_schema::Schema::from(ds.schema());
+    for key in ["embedding_fingerprint", "embedding_model"] {
+        if let Some(value) = schema.metadata().get(key) {
+            return format!("{key}:{value}");
+        }
+    }
+    "unrecorded".to_string()
+}
+
+fn build_sketch(
+    memory: String,
+    session_id: String,
+    rows: Vec<RawRow>,
+    embedding_fingerprint: String,
+    budget: usize,
+    char_budget: usize,
+    started: Instant,
+) -> Result<SessionSketch> {
+    let source_chunks = rows.len();
+    let source_fingerprint = fingerprint(&rows);
+    let mut units = reconstruct_units(&rows)?;
+    if units.is_empty() {
+        bail!("session contains no eligible blocks after dropping thinking and scaffolding");
+    }
+    let duplicate_stats = assign_duplicate_mass(&mut units);
+    let turns = build_turns(&units);
+
+    let all_indices: Vec<usize> = (0..units.len()).collect();
+    let all_chars = context_chars(&units, all_indices.iter().copied(), per_unit_cap(budget, char_budget));
+    let (selected, pool, axes, transitions, fallback) = if units.len() <= budget && all_chars <= char_budget {
+        let mut pool = CandidatePool::new();
+        for i in 0..units.len() {
+            pool.add(i, "all_evidence", true, 0.0);
+        }
+        (
+            all_indices,
+            pool,
+            0,
+            0,
+            Some("session fits the evidence budgets".to_string()),
+        )
+    } else {
+        let mut pool = CandidatePool::new();
+        add_anchors(&units, &mut pool);
+        let anchor_count = pool.by_unit.values().filter(|c| c.mandatory).count();
+        let axes = discover_axes(&units, budget, anchor_count, &mut pool);
+        let transitions = add_transitions(&units, &turns, budget, &mut pool);
+        pool.retain_first(budget.saturating_mul(4));
+        let selected = select_final(&units, &pool, budget, char_budget);
+        (selected, pool, axes, transitions, None)
+    };
+
+    // Selected units only. The picker rendered unselected neighbours around each one and did not
+    // count them against the budget; an agent gets a `→ get` coordinate per item instead, so
+    // reading around one is a follow-up call whose cost is visible.
+    let mut selected_sorted = selected.clone();
+    selected_sorted.sort_by_key(|&i| unit_key(&units[i]));
+    let unit_cap = per_unit_cap(budget, char_budget);
+    let rendered_characters = context_chars(&units, selected_sorted.iter().copied(), unit_cap);
+    let selected_units = selected_sorted
+        .iter()
+        .map(|&i| {
+            let candidate = pool.by_unit.get(&i);
+            SelectedUnit {
+                id: units[i].id.clone(),
+                turn_uuid: units[i].turn_uuid.clone(),
+                seq: units[i].seq,
+                block_idx: units[i].block_idx,
+                reasons: candidate
+                    .map(|c| c.reasons.iter().cloned().collect())
+                    .unwrap_or_else(|| vec!["selected".to_string()]),
+            }
+        })
+        .collect();
+    let evidence = selected_sorted
+        .iter()
+        .map(|&i| {
+            let (text, truncated) = display_text(&units[i], unit_cap);
+            let reasons = pool
+                .by_unit
+                .get(&i)
+                .map(|c| c.reasons.iter().cloned().collect())
+                .unwrap_or_default();
+            Evidence {
+                id: units[i].id.clone(),
+                turn_uuid: units[i].turn_uuid.clone(),
+                seq: units[i].seq,
+                block_idx: units[i].block_idx,
+                ts: units[i].ts.clone(),
+                role: units[i].role.clone(),
+                block_type: units[i].block_type.clone(),
+                tool_name: (!units[i].tool_name.is_empty()).then(|| units[i].tool_name.clone()),
+                selected: true,
+                reasons,
+                truncated,
+                text,
+            }
+        })
+        .collect();
+
+    Ok(SessionSketch {
+        schema_version: SKETCH_SCHEMA_VERSION,
+        selector_version: SELECTOR_VERSION.to_string(),
+        memory,
+        session_id,
+        source_fingerprint,
+        embedding_fingerprint,
+        source_chunks,
+        eligible_units: units.len(),
+        selected_units,
+        evidence,
+        diagnostics: Diagnostics {
+            axes,
+            transitions,
+            near_duplicate_groups: duplicate_stats.groups,
+            duplicate_strategy: duplicate_stats.strategy.to_string(),
+            duplicate_vector_comparisons: duplicate_stats.vector_comparisons,
+            candidates: pool.order.len(),
+            rendered_characters,
+            budget,
+            char_budget,
+            elapsed_ms: started.elapsed().as_millis(),
+            fallback,
+        },
+    })
+}
+
+fn fingerprint(rows: &[RawRow]) -> String {
+    let mut hash = Sha256::new();
+    for row in rows {
+        for field in [
+            row.id.as_str(),
+            row.text.as_str(),
+            row.turn_uuid.as_str(),
+            row.ts.as_str(),
+            row.role.as_str(),
+            row.block_type.as_str(),
+            row.tool_name.as_str(),
+        ] {
+            hash.update((field.len() as u64).to_le_bytes());
+            hash.update(field.as_bytes());
+        }
+        hash.update(row.seq.to_le_bytes());
+        hash.update(row.block_idx.to_le_bytes());
+        hash.update(row.split_idx.to_le_bytes());
+        match &row.vector {
+            Some(vector) => {
+                hash.update([1]);
+                for value in vector {
+                    hash.update(value.to_le_bytes());
+                }
+            }
+            None => hash.update([0]),
+        }
+    }
+    format!("sha256:{}", hex::encode(hash.finalize()))
+}
+
+fn reconstruct_units(rows: &[RawRow]) -> Result<Vec<Unit>> {
+    let mut groups: BTreeMap<(i64, String, i64), Vec<&RawRow>> = BTreeMap::new();
+    for row in rows {
+        groups
+            .entry((row.seq, row.turn_uuid.clone(), row.block_idx))
+            .or_default()
+            .push(row);
+    }
+    let mut units = Vec::new();
+    for ((_seq, _turn, _block), mut pieces) in groups {
+        pieces.sort_by_key(|row| row.split_idx);
+        let head = pieces[0];
+        let mut text = String::new();
+        let dim = pieces.iter().find_map(|r| r.vector.as_ref().map(Vec::len));
+        let mut aggregate = dim.map(|d| vec![0.0f32; d]);
+        let mut total_weight = 0.0f32;
+        for piece in &pieces {
+            let overlap = if text.is_empty() {
+                0
+            } else {
+                overlap_len(&text, &piece.text)
+            };
+            let weight = piece.text.chars().count().saturating_sub(overlap).max(1) as f32;
+            if let (Some(sum), Some(vector)) = (&mut aggregate, &piece.vector) {
+                if sum.len() != vector.len() {
+                    bail!("inconsistent vector dimensions inside block {}", head.id);
+                }
+                for (dst, src) in sum.iter_mut().zip(vector) {
+                    *dst += weight * src;
+                }
+                total_weight += weight;
+            }
+            text = if text.is_empty() {
+                piece.text.clone()
+            } else {
+                stitch(&text, &piece.text)
+            };
+        }
+        let vector = aggregate.and_then(|mut vector| {
+            if total_weight > 0.0 {
+                for value in &mut vector {
+                    *value /= total_weight;
+                }
+            }
+            normalize(vector)
+        });
+        let text = text.trim().to_string();
+        if text.is_empty() || head.block_type == "thinking" {
+            continue;
+        }
+        if head.role == "user" && head.block_type == "text" && curate::is_scaffolding(&text) {
+            continue;
+        }
+        if head.block_type == "text" && is_harness_noise(&text) {
+            continue;
+        }
+        let Some(type_weight) = type_weight(&head.block_type) else {
+            continue;
+        };
+        let chars = text.chars().count() as f32;
+        let length_factor = (chars / 200.0).sqrt().clamp(0.25, 1.0);
+        units.push(Unit {
+            id: head.id.clone(),
+            text,
+            turn_uuid: head.turn_uuid.clone(),
+            seq: head.seq,
+            ts: head.ts.clone(),
+            role: head.role.clone(),
+            block_type: head.block_type.clone(),
+            tool_name: head.tool_name.clone(),
+            block_idx: head.block_idx,
+            vector,
+            quality: type_weight * length_factor,
+            mass: type_weight,
+        });
+    }
+    units.sort_by(|a, b| {
+        a.seq
+            .cmp(&b.seq)
+            .then_with(|| a.turn_uuid.cmp(&b.turn_uuid))
+            .then_with(|| a.block_idx.cmp(&b.block_idx))
+            .then_with(|| a.id.cmp(&b.id))
+    });
+    Ok(units)
+}
+
+fn type_weight(block_type: &str) -> Option<f32> {
+    match block_type {
+        "text" => Some(1.0),
+        "tool_use" => Some(0.35),
+        "tool_result" => Some(0.20),
+        "thinking" => None,
+        _ => None,
+    }
+}
+
+fn is_harness_noise(text: &str) -> bool {
+    matches!(
+        text.trim(),
+        "[Request interrupted by user]" | "[Request interrupted by user for tool use]"
+    )
+}
+
+fn overlap_len(left: &str, right: &str) -> usize {
+    let left: Vec<char> = left.chars().collect();
+    let right: Vec<char> = right.chars().collect();
+    let max = left.len().min(right.len()).min(OVERLAP);
+    (1..=max)
+        .rev()
+        .find(|&n| left[left.len() - n..] == right[..n])
+        .unwrap_or(0)
+}
+
+fn stitch(left: &str, right: &str) -> String {
+    let overlap = overlap_len(left, right);
+    let suffix: String = right.chars().skip(overlap).collect();
+    format!("{left}{suffix}")
+}
+
+fn normalize(mut vector: Vec<f32>) -> Option<Vec<f32>> {
+    let norm = vector.iter().map(|v| v * v).sum::<f32>().sqrt();
+    if !norm.is_finite() || norm <= VECTOR_EPSILON {
+        return None;
+    }
+    for value in &mut vector {
+        *value /= norm;
+    }
+    Some(vector)
+}
+
+fn dot(left: &[f32], right: &[f32]) -> f32 {
+    left.iter().zip(right).map(|(a, b)| a * b).sum()
+}
+
+fn unit_key(unit: &Unit) -> (i64, &str, i64, &str) {
+    (unit.seq, &unit.turn_uuid, unit.block_idx, &unit.id)
+}
+
+fn assign_duplicate_mass(units: &mut [Unit]) -> DuplicateStats {
+    assign_duplicate_mass_with_limit(units, EXACT_DUPLICATE_MAX_UNITS)
+}
+
+fn assign_duplicate_mass_with_limit(units: &mut [Unit], exact_limit: usize) -> DuplicateStats {
+    let mut dsu = DisjointSet::new(units.len());
+
+    // Text equality is exact, cheap, and must also work for rows without stored embeddings.
+    {
+        let mut by_text: HashMap<&str, usize> = HashMap::new();
+        for (i, unit) in units.iter().enumerate() {
+            if let Some(previous) = by_text.insert(&unit.text, i) {
+                dsu.union(previous, i);
+            }
+        }
+    }
+
+    let vector_count = units.iter().filter(|unit| unit.vector.is_some()).count();
+    let (strategy, vector_comparisons) = if vector_count <= exact_limit {
+        ("exact-all-pairs", group_near_duplicates_exact(units, &mut dsu))
+    } else {
+        ("simhash-8x10-bounded", group_near_duplicates_bounded(units, &mut dsu))
+    };
+
+    let mut sizes: HashMap<usize, usize> = HashMap::new();
+    for i in 0..units.len() {
+        let root = dsu.find(i);
+        *sizes.entry(root).or_default() += 1;
+    }
+    for (i, unit) in units.iter_mut().enumerate() {
+        let root = dsu.find(i);
+        unit.mass /= sizes[&root] as f32;
+    }
+    DuplicateStats {
+        groups: sizes.values().filter(|&&size| size > 1).count(),
+        strategy,
+        vector_comparisons,
+    }
+}
+
+fn group_near_duplicates_exact(units: &[Unit], dsu: &mut DisjointSet) -> usize {
+    let mut comparisons = 0;
+    for i in 0..units.len() {
+        let Some(left) = units[i].vector.as_deref() else {
+            continue;
+        };
+        for (j, unit) in units.iter().enumerate().skip(i + 1) {
+            let Some(right) = unit.vector.as_deref() else {
+                continue;
+            };
+            if dsu.find(i) == dsu.find(j) {
+                continue;
+            }
+            comparisons += 1;
+            if left.len() == right.len() && dot(left, right) >= NEAR_DUPLICATE {
+                dsu.union(i, j);
+            }
+        }
+    }
+    comparisons
+}
+
+fn group_near_duplicates_bounded(units: &[Unit], dsu: &mut DisjointSet) -> usize {
+    let mut planes_by_dimension: HashMap<usize, Vec<Vec<f32>>> = HashMap::new();
+    let mut buckets: HashMap<(usize, usize, u16), Vec<usize>> = HashMap::new();
+    let mut history_by_dimension: HashMap<usize, Vec<usize>> = HashMap::new();
+    let mut comparisons = 0;
+
+    for (i, unit) in units.iter().enumerate() {
+        let Some(vector) = unit.vector.as_deref() else {
+            continue;
+        };
+        let dimension = vector.len();
+        let keys = {
+            let planes = planes_by_dimension
+                .entry(dimension)
+                .or_insert_with(|| duplicate_hyperplanes(dimension));
+            duplicate_band_keys(vector, planes)
+        };
+
+        let mut candidates = BTreeSet::new();
+        if let Some(history) = history_by_dimension.get(&dimension) {
+            candidates.extend(history.iter().rev().take(DUPLICATE_TEMPORAL_WINDOW));
+        }
+        for (band, &key) in keys.iter().enumerate() {
+            if let Some(bucket) = buckets.get(&(dimension, band, key)) {
+                candidates.extend(bucket.iter().take(DUPLICATE_BUCKET_HEAD));
+                candidates.extend(bucket.iter().rev().take(DUPLICATE_BUCKET_RECENT));
+            }
+        }
+
+        for j in candidates {
+            if dsu.find(i) == dsu.find(j) {
+                continue;
+            }
+            let Some(other) = units[j].vector.as_deref() else {
+                continue;
+            };
+            comparisons += 1;
+            if dot(vector, other) >= NEAR_DUPLICATE {
+                dsu.union(i, j);
+            }
+        }
+
+        for (band, key) in keys.into_iter().enumerate() {
+            buckets.entry((dimension, band, key)).or_default().push(i);
+        }
+        history_by_dimension.entry(dimension).or_default().push(i);
+    }
+    comparisons
+}
+
+fn duplicate_hyperplanes(dimension: usize) -> Vec<Vec<f32>> {
+    (0..DUPLICATE_LSH_BANDS * DUPLICATE_LSH_BITS)
+        .map(|plane| {
+            (0..dimension)
+                .map(|component| {
+                    let seed = (plane as u64)
+                        .wrapping_mul(0x9e37_79b9_7f4a_7c15)
+                        .wrapping_add(component as u64)
+                        .wrapping_add(0x6a09_e667_f3bc_c909);
+                    if splitmix64(seed) & 1 == 0 {
+                        -1.0
+                    } else {
+                        1.0
+                    }
+                })
+                .collect()
+        })
+        .collect()
+}
+
+fn duplicate_band_keys(vector: &[f32], planes: &[Vec<f32>]) -> [u16; DUPLICATE_LSH_BANDS] {
+    let mut keys = [0u16; DUPLICATE_LSH_BANDS];
+    for (plane_idx, plane) in planes.iter().enumerate() {
+        if dot(vector, plane) >= 0.0 {
+            let band = plane_idx / DUPLICATE_LSH_BITS;
+            let bit = plane_idx % DUPLICATE_LSH_BITS;
+            keys[band] |= 1 << bit;
+        }
+    }
+    keys
+}
+
+fn splitmix64(mut value: u64) -> u64 {
+    value = value.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    value ^ (value >> 31)
+}
+
+struct DisjointSet {
+    parent: Vec<usize>,
+    rank: Vec<u8>,
+}
+
+impl DisjointSet {
+    fn new(len: usize) -> Self {
+        Self {
+            parent: (0..len).collect(),
+            rank: vec![0; len],
+        }
+    }
+
+    fn find(&mut self, i: usize) -> usize {
+        if self.parent[i] != i {
+            self.parent[i] = self.find(self.parent[i]);
+        }
+        self.parent[i]
+    }
+
+    fn union(&mut self, left: usize, right: usize) {
+        let mut left = self.find(left);
+        let mut right = self.find(right);
+        if left == right {
+            return;
+        }
+        if self.rank[left] < self.rank[right] {
+            std::mem::swap(&mut left, &mut right);
+        }
+        self.parent[right] = left;
+        if self.rank[left] == self.rank[right] {
+            self.rank[left] += 1;
+        }
+    }
+}
+
+fn build_turns(units: &[Unit]) -> Vec<TurnInfo> {
+    let mut grouped: BTreeMap<(i64, String), Vec<usize>> = BTreeMap::new();
+    for (i, unit) in units.iter().enumerate() {
+        grouped.entry((unit.seq, unit.turn_uuid.clone())).or_default().push(i);
+    }
+    grouped
+        .into_iter()
+        .map(|((_seq, _turn_uuid), indices)| {
+            let vector = weighted_mean(
+                indices
+                    .iter()
+                    .filter_map(|&i| units[i].vector.as_deref().map(|v| (units[i].mass, v))),
+            );
+            TurnInfo { units: indices, vector }
+        })
+        .collect()
+}
+
+fn weighted_mean<'a>(values: impl Iterator<Item = (f32, &'a [f32])>) -> Option<Vec<f32>> {
+    let mut aggregate: Option<Vec<f32>> = None;
+    let mut total = 0.0f32;
+    for (weight, vector) in values {
+        let sum = aggregate.get_or_insert_with(|| vec![0.0; vector.len()]);
+        if sum.len() != vector.len() {
+            continue;
+        }
+        for (dst, src) in sum.iter_mut().zip(vector) {
+            *dst += weight * src;
+        }
+        total += weight;
+    }
+    aggregate.and_then(|mut vector| {
+        if total > 0.0 {
+            for value in &mut vector {
+                *value /= total;
+            }
+        }
+        normalize(vector)
+    })
+}
+
+fn centroid(units: &[Unit]) -> Option<Vec<f32>> {
+    let mut aggregate: Option<Vec<f32>> = None;
+    let mut total = 0.0f32;
+    for unit in units {
+        let Some(vector) = unit.vector.as_deref() else {
+            continue;
+        };
+        let sum = aggregate.get_or_insert_with(|| vec![0.0; vector.len()]);
+        for (dst, src) in sum.iter_mut().zip(vector) {
+            *dst += unit.mass * src;
+        }
+        total += unit.mass;
+    }
+    aggregate.map(|mut vector| {
+        if total > 0.0 {
+            for value in &mut vector {
+                *value /= total;
+            }
+        }
+        vector
+    })
+}
+
+fn add_anchors(units: &[Unit], pool: &mut CandidatePool) {
+    if let Some((i, _)) = units
+        .iter()
+        .enumerate()
+        .find(|(_, unit)| unit.role == "user" && unit.block_type == "text")
+    {
+        pool.add(i, "opening_user", true, 0.0);
+    }
+    if let Some((i, _)) = units
+        .iter()
+        .enumerate()
+        .rev()
+        .find(|(_, unit)| unit.role == "assistant" && unit.block_type == "text")
+    {
+        pool.add(i, "closing_assistant", true, 0.0);
+    }
+    if let Some(mu) = centroid(units).and_then(normalize) {
+        let mut best: Option<(usize, f32)> = None;
+        for (i, unit) in units.iter().enumerate() {
+            if unit.block_type != "text" {
+                continue;
+            }
+            let Some(vector) = unit.vector.as_deref() else {
+                continue;
+            };
+            let score = unit.quality * dot(&mu, vector).max(0.0);
+            if best.is_none_or(|(_, current)| score > current) {
+                best = Some((i, score));
+            }
+        }
+        if let Some((i, _)) = best {
+            pool.add(i, "centroid_medoid", true, 0.0);
+        }
+    }
+}
+
+fn discover_axes(units: &[Unit], budget: usize, anchors: usize, pool: &mut CandidatePool) -> usize {
+    let Some(mu) = centroid(units) else {
+        return 0;
+    };
+    let geometric: Vec<usize> = units
+        .iter()
+        .enumerate()
+        .filter_map(|(i, unit)| unit.vector.as_ref().map(|_| i))
+        .collect();
+    if geometric.is_empty() {
+        return 0;
+    }
+    let wanted = ((budget.saturating_sub(anchors)) / 2).clamp(1, 6);
+    let mut basis: Vec<Vec<f32>> = Vec::new();
+    for axis in 0..wanted {
+        let mut pivot: Option<(usize, Vec<f32>, f32)> = None;
+        for &i in &geometric {
+            let vector = units[i].vector.as_deref().unwrap();
+            let mut residual: Vec<f32> = vector.iter().zip(&mu).map(|(x, mean)| x - mean).collect();
+            for q in &basis {
+                let projection = dot(&residual, q);
+                for (value, direction) in residual.iter_mut().zip(q) {
+                    *value -= projection * direction;
+                }
+            }
+            let norm = residual.iter().map(|v| v * v).sum::<f32>().sqrt();
+            let score = units[i].quality * norm;
+            if pivot.as_ref().is_none_or(|(_, _, current)| score > *current) {
+                pivot = Some((i, residual, score));
+            }
+        }
+        let Some((_pivot_idx, residual, score)) = pivot else {
+            break;
+        };
+        if !score.is_finite() || score <= VECTOR_EPSILON {
+            break;
+        }
+        let Some(direction) = normalize(residual) else {
+            break;
+        };
+        let positive = extreme(units, &geometric, &mu, &direction, 1.0);
+        let negative = extreme(units, &geometric, &mu, &direction, -1.0);
+        if let Some(i) = positive {
+            pool.add(i, format!("axis_{}_positive", axis + 1), false, 0.0);
+        }
+        if let Some(i) = negative {
+            pool.add(i, format!("axis_{}_negative", axis + 1), false, 0.0);
+        }
+        basis.push(direction);
+    }
+    basis.len()
+}
+
+fn extreme(units: &[Unit], geometric: &[usize], mu: &[f32], direction: &[f32], sign: f32) -> Option<usize> {
+    let mut best: Option<(usize, f32)> = None;
+    for &i in geometric {
+        let vector = units[i].vector.as_deref().unwrap();
+        let projection: f32 = vector
+            .iter()
+            .zip(mu)
+            .zip(direction)
+            .map(|((x, mean), q)| (x - mean) * q)
+            .sum();
+        let score = units[i].quality * (sign * projection).max(0.0);
+        if best.is_none_or(|(_, current)| score > current) {
+            best = Some((i, score));
+        }
+    }
+    best.and_then(|(i, score)| (score > 0.0).then_some(i))
+}
+
+fn add_transitions(units: &[Unit], turns: &[TurnInfo], budget: usize, pool: &mut CandidatePool) -> usize {
+    if turns.len() < 2 {
+        return 0;
+    }
+    let mut boundaries = Vec::new();
+    for after in 0..turns.len() - 1 {
+        let left_start = after.saturating_sub(1);
+        let right_end = (after + 3).min(turns.len());
+        let left = mean_vectors(
+            turns[left_start..=after]
+                .iter()
+                .filter_map(|turn| turn.vector.as_deref()),
+        );
+        let right = mean_vectors(
+            turns[after + 1..right_end]
+                .iter()
+                .filter_map(|turn| turn.vector.as_deref()),
+        );
+        if let (Some(left), Some(right)) = (left, right) {
+            boundaries.push(Boundary {
+                after_turn: after,
+                score: (1.0 - dot(&left, &right)).max(0.0),
+            });
+        }
+    }
+    boundaries.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(Ordering::Equal)
+            .then_with(|| a.after_turn.cmp(&b.after_turn))
+    });
+    let wanted = (budget / 2).clamp(1, 6);
+    let mut chosen: Vec<Boundary> = Vec::new();
+    for boundary in boundaries {
+        if chosen
+            .iter()
+            .any(|other| other.after_turn.abs_diff(boundary.after_turn) <= 2)
+        {
+            continue;
+        }
+        chosen.push(boundary);
+        if chosen.len() == wanted {
+            break;
+        }
+    }
+    for (rank, boundary) in chosen.iter().enumerate() {
+        if let Some(i) = text_before(units, turns, boundary.after_turn) {
+            pool.add(i, format!("transition_{}_left", rank + 1), false, boundary.score);
+        }
+        if let Some(i) = text_after(units, turns, boundary.after_turn + 1) {
+            pool.add(i, format!("transition_{}_right", rank + 1), false, boundary.score);
+        }
+    }
+    chosen.len()
+}
+
+fn mean_vectors<'a>(vectors: impl Iterator<Item = &'a [f32]>) -> Option<Vec<f32>> {
+    weighted_mean(vectors.map(|vector| (1.0, vector)))
+}
+
+fn text_before(units: &[Unit], turns: &[TurnInfo], turn: usize) -> Option<usize> {
+    turns[..=turn]
+        .iter()
+        .rev()
+        .flat_map(|t| t.units.iter().rev())
+        .copied()
+        .find(|&i| units[i].block_type == "text")
+}
+
+fn text_after(units: &[Unit], turns: &[TurnInfo], turn: usize) -> Option<usize> {
+    turns[turn..]
+        .iter()
+        .flat_map(|t| &t.units)
+        .copied()
+        .find(|&i| units[i].block_type == "text")
+}
+
+fn select_final(units: &[Unit], pool: &CandidatePool, budget: usize, char_budget: usize) -> Vec<usize> {
+    let mut selected: Vec<usize> = pool
+        .order
+        .iter()
+        .copied()
+        .filter(|i| pool.by_unit[i].mandatory)
+        .collect();
+    selected.dedup();
+    let mut selected_set: HashSet<usize> = selected.iter().copied().collect();
+    // The budget counts what is rendered, and only selected units are. Costing the surrounding
+    // turn as well — as this did when a picker displayed that context — would spend the caller's
+    // budget on text it never receives.
+    let unit_cap = per_unit_cap(budget, char_budget);
+    let mut chars = context_chars(units, selected.iter().copied(), unit_cap);
+    let mut covered = vec![0.0f32; units.len()];
+    for &i in &selected {
+        update_coverage(units, i, &mut covered);
+    }
+    let total_mass: f32 = units.iter().map(|unit| unit.mass).sum();
+    let average_mass = total_mass / budget as f32;
+    // `budget` is a ceiling, not a target. A weak candidate must explain at least a quarter of an
+    // average selection slot; a strong chronological pivot can satisfy this via its bonus.
+    let minimum_gain = 0.25 * average_mass;
+    let max_transition = pool
+        .by_unit
+        .values()
+        .map(|candidate| candidate.transition)
+        .fold(0.0f32, f32::max);
+
+    while selected.len() < budget {
+        let mut best: Option<(usize, f32, f32, usize)> = None;
+        for &candidate_idx in &pool.order {
+            if selected_set.contains(&candidate_idx) {
+                continue;
+            }
+            let marginal_chars = context_chars(units, std::iter::once(candidate_idx), unit_cap);
+            if chars.saturating_add(marginal_chars) > char_budget {
+                continue;
+            }
+            let Some(vector) = units[candidate_idx].vector.as_deref() else {
+                continue;
+            };
+            let mut gain = 0.0f32;
+            for (i, unit) in units.iter().enumerate() {
+                let Some(other) = unit.vector.as_deref() else {
+                    continue;
+                };
+                let similarity = dot(vector, other).max(0.0);
+                gain += unit.mass * (similarity - covered[i]).max(0.0);
+            }
+            let transition = if max_transition > 0.0 {
+                pool.by_unit[&candidate_idx].transition / max_transition
+            } else {
+                0.0
+            };
+            let transition_bonus = 0.5 * average_mass * transition;
+            let substantive_gain = gain + transition_bonus;
+            let cost = (1.0 + marginal_chars as f32 / 4000.0).sqrt();
+            let score = substantive_gain / cost;
+            if best.as_ref().is_none_or(|(_, current, _, _)| score > *current) {
+                best = Some((candidate_idx, score, substantive_gain, marginal_chars));
+            }
+        }
+        let Some((chosen, score, substantive_gain, marginal_chars)) = best else {
+            break;
+        };
+        if !score.is_finite() || substantive_gain < minimum_gain {
+            break;
+        }
+        selected.push(chosen);
+        selected_set.insert(chosen);
+        chars += marginal_chars;
+        update_coverage(units, chosen, &mut covered);
+    }
+    selected
+}
+
+fn update_coverage(units: &[Unit], selected: usize, covered: &mut [f32]) {
+    let Some(vector) = units[selected].vector.as_deref() else {
+        return;
+    };
+    for (i, unit) in units.iter().enumerate() {
+        if let Some(other) = unit.vector.as_deref() {
+            covered[i] = covered[i].max(dot(vector, other).max(0.0));
+        }
+    }
+}
+
+fn context_chars(units: &[Unit], indices: impl Iterator<Item = usize>, unit_cap: usize) -> usize {
+    indices
+        .map(|i| {
+            let (text, _) = display_text(&units[i], unit_cap);
+            text.chars().count() + 96
+        })
+        .sum()
+}
+
+/// The characters one unit may render: an equal share of the budget, floored so that a wide
+/// selection still shows something of each place rather than a sliver of many.
+fn per_unit_cap(budget: usize, char_budget: usize) -> usize {
+    (char_budget / budget.max(1)).max(MIN_UNIT_CHARS)
+}
+
+/// A passage as it is rendered, and whether it was shortened. `cap` is the share of the character
+/// budget one unit may take: without it a single turn carrying a file would spend the whole digest,
+/// and unlike `get` — a verbatim read, where a turn must arrive whole — a sketch is a sample, so
+/// shortening a passage is the honest thing rather than a loss.
+fn display_text(unit: &Unit, cap: usize) -> (String, bool) {
+    // A tool result is the least dense text in a session, so it is held to the tighter of the two
+    // bounds even when the per-unit cap would allow more.
+    let limit = if unit.block_type == "tool_result" {
+        cap.min(TOOL_RESULT_PREVIEW)
+    } else {
+        cap
+    };
+    if unit.text.chars().count() <= limit {
+        return (unit.text.clone(), false);
+    }
+    let head_len = limit * 7 / 10;
+    let tail_len = limit.saturating_sub(head_len);
+    let head: String = unit.text.chars().take(head_len).collect();
+    let mut tail: Vec<char> = unit.text.chars().rev().take(tail_len).collect();
+    tail.reverse();
+    let tail: String = tail.into_iter().collect();
+    (format!("{head}\n\n[… shortened by session-sketch …]\n\n{tail}"), true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn raw_row(seq: i64, text: &str) -> RawRow {
+        RawRow {
+            session_id: "session".into(),
+            id: format!("id-{seq}"),
+            text: text.into(),
+            turn_uuid: format!("turn-{seq}"),
+            seq,
+            ts: "2026-07-22T00:00:00Z".into(),
+            role: "user".into(),
+            block_type: "text".into(),
+            tool_name: String::new(),
+            block_idx: 0,
+            split_idx: 0,
+            vector: Some(vec![1.0, 0.0]),
+        }
+    }
+
+    fn cached_sketch_fixture() -> SessionSketch {
+        SessionSketch {
+            schema_version: SKETCH_SCHEMA_VERSION,
+            selector_version: SELECTOR_VERSION.into(),
+            memory: "local-memory".into(),
+            session_id: "session".into(),
+            source_fingerprint: "source".into(),
+            embedding_fingerprint: "embedding".into(),
+            source_chunks: 1,
+            eligible_units: 1,
+            selected_units: Vec::new(),
+            evidence: Vec::new(),
+            diagnostics: Diagnostics {
+                axes: 0,
+                transitions: 0,
+                near_duplicate_groups: 0,
+                duplicate_strategy: "exact".into(),
+                duplicate_vector_comparisons: 0,
+                candidates: 0,
+                rendered_characters: 0,
+                budget: DEFAULT_BUDGET,
+                char_budget: DEFAULT_CHAR_BUDGET,
+                elapsed_ms: 1,
+                fallback: None,
+            },
+        }
+    }
+
+    fn unit(seq: i64, role: &str, vector: &[f32], text: &str) -> Unit {
+        Unit {
+            id: format!("id-{seq}-{role}"),
+            text: text.to_string(),
+            turn_uuid: format!("turn-{seq}"),
+            seq,
+            ts: String::new(),
+            role: role.to_string(),
+            block_type: "text".to_string(),
+            tool_name: String::new(),
+            block_idx: 0,
+            vector: normalize(vector.to_vec()),
+            quality: 1.0,
+            mass: 1.0,
+        }
+    }
+
+    #[test]
+    fn overlap_is_reassembled_once() {
+        assert_eq!(overlap_len("abcdef", "defghi"), 3);
+        assert_eq!(stitch("abcdef", "defghi"), "abcdefghi");
+        assert_eq!(stitch("abc", "xyz"), "abcxyz");
+    }
+
+    #[test]
+    fn source_fingerprint_invalidates_growth_and_same_count_rewrites() {
+        let original = vec![raw_row(1, "original")];
+        let original_fingerprint = fingerprint(&original);
+
+        let mut grown = original.clone();
+        grown.push(raw_row(2, "new turn"));
+        assert_ne!(fingerprint(&grown), original_fingerprint);
+
+        let mut rewritten = original;
+        rewritten[0].text = "rewritten".into();
+        assert_ne!(fingerprint(&rewritten), original_fingerprint);
+    }
+
+    #[test]
+    fn sketch_cache_round_trips_and_rejects_stale_keys() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = cache_path(temp.path(), "local-memory", "session");
+        let sketch = cached_sketch_fixture();
+        let options = SketchOptions::default();
+        store_cached_sketch(&path, &sketch).unwrap();
+
+        assert!(load_cached_sketch(&path, "local-memory", "session", "source", "embedding", options,).is_some());
+        assert!(load_cached_sketch(
+            &path,
+            "local-memory",
+            "session",
+            "rewritten-source",
+            "embedding",
+            options,
+        )
+        .is_none());
+        assert!(load_cached_sketch(
+            &path,
+            "local-memory",
+            "session",
+            "source",
+            "embedding",
+            SketchOptions {
+                budget: options.budget + 1,
+                ..options
+            },
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn tool_result_preview_is_unicode_safe() {
+        let mut u = unit(1, "user", &[1.0, 0.0], &"🦀".repeat(2_100));
+        u.block_type = "tool_result".to_string();
+        let (text, truncated) = display_text(&u, 8_000);
+        assert!(
+            truncated,
+            "a tool result is held to its own bound, not the per-unit cap"
+        );
+        assert!(text.contains("shortened"));
+        assert!(text.is_char_boundary(text.len()));
+    }
+
+    #[test]
+    fn a_passage_cannot_spend_the_whole_budget() {
+        // Prose is bounded by its share of the budget: without that, one turn carrying a file
+        // renders as the entire digest.
+        let u = unit(1, "user", &[1.0, 0.0], &"x".repeat(50_000));
+        let (text, truncated) = display_text(&u, 1_000);
+        assert!(truncated);
+        assert!(
+            text.chars().count() < 1_100,
+            "capped near its share, got {} chars",
+            text.chars().count()
+        );
+        // A short passage is untouched.
+        let short = unit(2, "user", &[1.0, 0.0], "brief");
+        assert_eq!(display_text(&short, 1_000), ("brief".to_string(), false));
+    }
+
+    #[test]
+    fn a_unit_always_gets_a_floor_of_the_budget() {
+        // Dividing a small budget among many units would leave slivers; the floor holds instead,
+        // and the caller is told the unit count was clamped.
+        assert_eq!(per_unit_cap(40, 1_000), MIN_UNIT_CHARS);
+        assert_eq!(per_unit_cap(8, 8_000), 1_000);
+        assert_eq!(
+            per_unit_cap(0, 8_000),
+            8_000,
+            "a zero unit count must not divide by zero"
+        );
+    }
+
+    #[test]
+    fn axes_include_both_ends_of_a_contrast() {
+        let units = vec![
+            unit(0, "user", &[1.0, 0.0], "east"),
+            unit(1, "assistant", &[-1.0, 0.0], "west"),
+            unit(2, "assistant", &[0.0, 1.0], "north"),
+            unit(3, "assistant", &[0.0, -1.0], "south"),
+        ];
+        let mut pool = CandidatePool::new();
+        let axes = discover_axes(&units, 7, 3, &mut pool);
+        assert_eq!(axes, 2);
+        assert!(pool.order.len() >= 4, "pool={:?}", pool.order);
+    }
+
+    #[test]
+    fn transition_finds_a_strong_semantic_boundary() {
+        let units = vec![
+            unit(0, "user", &[1.0, 0.0], "a0"),
+            unit(1, "assistant", &[1.0, 0.0], "a1"),
+            unit(2, "user", &[-1.0, 0.0], "b0"),
+            unit(3, "assistant", &[-1.0, 0.0], "b1"),
+        ];
+        let turns = build_turns(&units);
+        let mut pool = CandidatePool::new();
+        let count = add_transitions(&units, &turns, 6, &mut pool);
+        assert_eq!(count, 1);
+        assert!(pool.by_unit.values().any(|c| c.transition > 1.5));
+    }
+
+    #[test]
+    fn coverage_adds_the_unrepresented_cluster() {
+        let units = vec![
+            unit(0, "user", &[1.0, 0.0], "cluster a opening"),
+            unit(1, "assistant", &[0.99, 0.01], "cluster a repeat"),
+            unit(2, "assistant", &[0.0, 1.0], "cluster b"),
+        ];
+        let mut pool = CandidatePool::new();
+        pool.add(0, "opening_user", true, 0.0);
+        pool.add(1, "candidate_a", false, 0.0);
+        pool.add(2, "candidate_b", false, 0.0);
+        let selected = select_final(&units, &pool, 3, 20_000);
+        assert!(selected.contains(&2), "selected={selected:?}");
+    }
+
+    #[test]
+    fn duplicate_groups_share_mass() {
+        let mut units = vec![
+            unit(0, "user", &[1.0, 0.0], "same"),
+            unit(1, "assistant", &[1.0, 0.0], "same"),
+            unit(2, "assistant", &[0.0, 1.0], "different"),
+        ];
+        let stats = assign_duplicate_mass(&mut units);
+        assert_eq!(stats.groups, 1);
+        assert_eq!(stats.strategy, "exact-all-pairs");
+        assert!((units[0].mass - 0.5).abs() < 1e-6);
+        assert!((units[1].mass - 0.5).abs() < 1e-6);
+        assert!((units[2].mass - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn exact_text_duplicates_without_vectors_share_mass() {
+        let mut units = vec![
+            unit(0, "user", &[1.0, 0.0], "same unembedded text"),
+            unit(1, "assistant", &[0.0, 1.0], "same unembedded text"),
+        ];
+        units[0].vector = None;
+        units[1].vector = None;
+        let stats = assign_duplicate_mass(&mut units);
+        assert_eq!(stats.groups, 1);
+        assert_eq!(stats.vector_comparisons, 0);
+        assert!((units[0].mass - 0.5).abs() < 1e-6);
+        assert!((units[1].mass - 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn bounded_duplicate_search_avoids_quadratic_comparisons() {
+        let mut units: Vec<Unit> = (0..400)
+            .map(|seq| unit(seq, "assistant", &[1.0, 0.0], &format!("repeat {seq}")))
+            .collect();
+        let stats = assign_duplicate_mass_with_limit(&mut units, 0);
+        assert_eq!(stats.strategy, "simhash-8x10-bounded");
+        assert_eq!(stats.groups, 1);
+        assert!(
+            stats.vector_comparisons < units.len() * 64,
+            "comparisons={}",
+            stats.vector_comparisons
+        );
+        for unit in units {
+            assert!((unit.mass - 1.0 / 400.0).abs() < 1e-6);
+        }
+    }
+
+    #[test]
+    fn bounded_duplicate_search_finds_a_distant_near_neighbor() {
+        let dimension = 128;
+        let mut first = vec![0.0; dimension];
+        first[0] = 1.0;
+        let mut units = vec![unit(0, "assistant", &first, "first")];
+        for component in 2..82 {
+            let mut filler = vec![0.0; dimension];
+            filler[component] = 1.0;
+            units.push(unit(
+                component as i64,
+                "assistant",
+                &filler,
+                &format!("filler {component}"),
+            ));
+        }
+        let mut near = vec![0.0; dimension];
+        near[0] = 0.98;
+        near[1] = (1.0f32 - 0.98f32.powi(2)).sqrt();
+        units.push(unit(100, "assistant", &near, "near first"));
+
+        let stats = assign_duplicate_mass_with_limit(&mut units, 0);
+        assert_eq!(stats.groups, 1);
+        assert!((units[0].mass - 0.5).abs() < 1e-6);
+        assert!((units.last().unwrap().mass - 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn centroid_anchor_prefers_text_over_tool_output() {
+        let text = unit(0, "assistant", &[1.0, 0.0], "explanation");
+        let mut tool = unit(1, "user", &[1.0, 0.0], "large output");
+        tool.block_type = "tool_result".to_string();
+        tool.quality = 0.2;
+        tool.mass = 0.2;
+        let mut pool = CandidatePool::new();
+        add_anchors(&[text, tool], &mut pool);
+        let medoid = pool
+            .by_unit
+            .iter()
+            .find(|(_, candidate)| candidate.reasons.contains("centroid_medoid"))
+            .map(|(&i, _)| i);
+        assert_eq!(medoid, Some(0));
+    }
+
+    #[test]
+    fn harness_interruption_is_noise() {
+        assert!(is_harness_noise("[Request interrupted by user]"));
+        assert!(!is_harness_noise("the user interrupted the request intentionally"));
+    }
+}

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -6,6 +6,7 @@
 //! one-liner, prose wrapped, marks highlighted.
 
 use crate::commands::recall::{Hit, ScanCut, ScanResult, Session, Turn};
+use crate::session_sketch::{Clamped, SessionSketch};
 use std::fmt::Write as _;
 
 /// Turns each side of a hit that a `→ get` line reaches for. A hint is meant to be run as it
@@ -158,6 +159,56 @@ pub fn scan_agent(note: &str, memory_arg: &str, r: &ScanResult, context: usize) 
         None => {}
     }
     let _ = writeln!(out, "---");
+    out
+}
+
+/// The agent `sketch` format: a header stating what the digest covers and cost, then each selected
+/// passage with the `→ get` that reads the turns around it verbatim. What was asked for and not
+/// given — a clamped request, a selection the budget cut short — is stated, never silently applied.
+/// Byte-stable.
+pub fn sketch_agent(note: &str, memory_arg: &str, sketch: &SessionSketch, clamped: Clamped) -> String {
+    let mut out = note.to_string();
+    let d = &sketch.diagnostics;
+    let _ = writeln!(
+        out,
+        "sketch {} — {} of {} places · {} of {} chars · {} eligible units",
+        sketch.session_id,
+        sketch.evidence.len(),
+        d.budget,
+        d.rendered_characters,
+        d.char_budget,
+        sketch.eligible_units
+    );
+    if let Some(units) = clamped.units {
+        let _ = writeln!(out, "  (units clamped to {units})");
+    }
+    if let Some(chars) = clamped.chars {
+        let _ = writeln!(out, "  (max-chars clamped to {chars})");
+    }
+    if let Some(note) = &d.fallback {
+        let _ = writeln!(out, "  ({note})");
+    }
+    for e in &sketch.evidence {
+        let kind = match &e.tool_name {
+            Some(tool) => format!("{} ({tool})", e.block_type),
+            None => e.block_type.clone(),
+        };
+        let _ = writeln!(
+            out,
+            "[{}] {} {} seq{}{}",
+            e.ts,
+            e.role,
+            kind,
+            e.seq,
+            if e.truncated { " · shortened" } else { "" }
+        );
+        let _ = writeln!(out, "  → get {}{}{}", sketch.session_id, hint_range(e.seq), memory_arg);
+        let _ = writeln!(out, "{}", e.text);
+    }
+    let _ = writeln!(
+        out,
+        "---\na sketch samples: it shows what it selected, so it cannot show that anything is absent — scan a literal for that"
+    );
     out
 }
 

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -1,11 +1,11 @@
 //! Rendering for the read commands, over `recall`'s structured results.
 //!
-//! [`recall_agent`]/[`get_agent`]/[`sessions_agent`] are the machine format — byte-stable, its
-//! layout is a published contract (the `→ get` lines are parsed) and must not change.
-//! [`get_human`] renders a turn for a terminal: tool chunks compressed to a deterministic
+//! [`recall_agent`]/[`get_agent`]/[`sessions_agent`]/[`scan_agent`] are the machine format —
+//! byte-stable, its layout is a published contract (the `→ get` lines are parsed) and must not
+//! change. [`get_human`] renders a turn for a terminal: tool chunks compressed to a deterministic
 //! one-liner, prose wrapped, marks highlighted.
 
-use crate::commands::recall::{Hit, Session, Turn};
+use crate::commands::recall::{Hit, ScanCut, ScanResult, Session, Turn};
 use std::fmt::Write as _;
 
 /// Turns each side of a hit that a `→ get` line reaches for. A hint is meant to be run as it
@@ -70,6 +70,71 @@ pub fn sessions_agent(note: &str, sessions: &[Session]) -> String {
 /// wide range would otherwise answer past any tool-result ceiling; what the budget left out is
 /// always stated, with the coordinates to ask for it.
 const GET_BUDGET: usize = 40_000;
+
+/// The agent `scan` format: a header echoing the needle and what it was cleared against — the
+/// session, and the window when one was asked for, since a zero over a window clears only the
+/// window — then one line per carrying block with the `→ get` that reads it. A cap is stated with
+/// the coordinate that continues past it, never silent. Byte-stable.
+pub fn scan_agent(note: &str, memory_arg: &str, r: &ScanResult, context: usize) -> String {
+    let mut out = note.to_string();
+    let scanned = match (r.from, r.to) {
+        (None, None) => String::new(),
+        (Some(a), Some(b)) => format!(" turns {a}-{b}"),
+        (Some(a), None) => format!(" turns {a} on"),
+        (None, Some(b)) => format!(" turns up to {b}"),
+    };
+    if r.hits.is_empty() {
+        let _ = writeln!(out, "no matches for {:?} in {}{scanned}\n---", r.needle, r.session_id);
+        return out;
+    }
+    let _ = writeln!(
+        out,
+        "scan {:?} in {}{scanned} — {} hits",
+        r.needle,
+        r.session_id,
+        r.hits.len() + r.dropped
+    );
+    for h in &r.hits {
+        let _ = writeln!(out, "[{}] {} seq{}", h.ts, h.block_type, h.seq);
+        let _ = writeln!(out, "  → get {}{}{}", r.session_id, hint_range(h.seq), memory_arg);
+        let _ = writeln!(out, "  {}", excerpt(&h.text, h.at, h.len, context));
+    }
+    match &r.cut {
+        Some(ScanCut::Resume(seq)) => {
+            let _ = writeln!(out, "{} more hits not shown — continue with --from {seq}", r.dropped);
+        }
+        Some(ScanCut::Crowded(seq)) => {
+            let _ = writeln!(
+                out,
+                "{} more hits not shown, all in turn {seq} — read it with --from {seq} --to {seq}",
+                r.dropped
+            );
+        }
+        None => {}
+    }
+    let _ = writeln!(out, "---");
+    out
+}
+
+/// `context` chars of the block on each side of the match, whitespace-collapsed onto one line so a
+/// section stays scannable. A `…` marks each end the block runs past.
+fn excerpt(text: &str, at: usize, len: usize, context: usize) -> String {
+    let start = text[..at]
+        .char_indices()
+        .rev()
+        .nth(context.saturating_sub(1))
+        .map_or(0, |(j, _)| j);
+    let end = text[at..]
+        .char_indices()
+        .nth(len + context)
+        .map_or(text.len(), |(j, _)| at + j);
+    format!(
+        "{}{}{}",
+        if start > 0 { "… " } else { "" },
+        text[start..end].split_whitespace().collect::<Vec<_>>().join(" "),
+        if end < text.len() { " …" } else { "" }
+    )
+}
 
 /// The agent `get` format: `[ts] role seqN turn=…` headers over reassembled blocks, closed by the
 /// coordinates read and the session's size — so a partial read says what it is part of, and the
@@ -420,7 +485,19 @@ fn write_wrapped(out: &mut String, line: &str, width: usize, indent: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::commands::recall::Neighbor;
+    use crate::commands::recall::{Neighbor, ScanHit};
+
+    fn scan_hit() -> ScanHit {
+        ScanHit {
+            turn_uuid: "aaaa-bbbb".to_string(),
+            ts: "2026-06-19T01:29:59.000Z".to_string(),
+            block_type: "tool_result".to_string(),
+            seq: 7,
+            at: 6,
+            len: 9,
+            text: "?? ../acme-internal/README.md".to_string(),
+        }
+    }
 
     fn hit(ts: &str, block_type: &str, text: &str) -> Hit {
         Hit {
@@ -520,6 +597,139 @@ mod tests {
         assert_eq!(word_span(text, "nope delta"), None);
         // A long mark cut mid-word at its start still anchors via the skip.
         assert_eq!(word_span(text, "pha beta gamma delta epsilon zeta eta"), Some(1..7));
+    }
+
+    #[test]
+    fn sessions_agent_is_byte_stable() {
+        let s = Session {
+            session_id: "0123456789abcdef".to_string(),
+            ts: "2026-06-19T01:29:59.000Z".to_string(),
+            workdir: "-home-u-funes".to_string(),
+            harness: "claude_code".to_string(),
+            turns: 47,
+        };
+        assert_eq!(
+            sessions_agent("", &[s]),
+            "[2026-06-19T01:29:59.000Z] claude_code -home-u-funes/0123456789abcdef 47 turns\n\
+             ---\n\
+             1 sessions\n"
+        );
+        // An empty listing still closes with its total.
+        assert_eq!(sessions_agent("", &[]), "---\n0 sessions\n");
+    }
+
+    #[test]
+    fn scan_agent_is_byte_stable() {
+        let r = ScanResult {
+            needle: "acme-internal".to_string(),
+            session_id: "0123456789abcdef".to_string(),
+            hits: vec![scan_hit()],
+            dropped: 0,
+            cut: None,
+            from: None,
+            to: None,
+        };
+        assert_eq!(
+            scan_agent("", " --memory local", &r, 40),
+            "scan \"acme-internal\" in 0123456789abcdef — 1 hits\n\
+             [2026-06-19T01:29:59.000Z] tool_result seq7\n\
+             \x20 → get 0123456789abcdef --from 4 --to 10 --memory local\n\
+             \x20 ?? ../acme-internal/README.md\n\
+             ---\n"
+        );
+    }
+
+    #[test]
+    fn scan_agent_states_a_zero_and_a_cap() {
+        let empty = ScanResult {
+            needle: "Acme Corp".to_string(),
+            session_id: "0123456789abcdef".to_string(),
+            hits: vec![],
+            dropped: 0,
+            cut: None,
+            from: None,
+            to: None,
+        };
+        assert_eq!(
+            scan_agent("", "", &empty, 40),
+            "no matches for \"Acme Corp\" in 0123456789abcdef\n---\n"
+        );
+        // A zero over a window clears the window, not the session — so the window is named in it.
+        let windowed = ScanResult {
+            from: Some(500),
+            to: Some(999),
+            ..empty
+        };
+        assert_eq!(
+            scan_agent("", "", &windowed, 40),
+            "no matches for \"Acme Corp\" in 0123456789abcdef turns 500-999\n---\n"
+        );
+        // An open-ended window says which end is open, so the claim it clears stays readable.
+        let onward = ScanResult {
+            needle: "Acme Corp".to_string(),
+            session_id: "0123456789abcdef".to_string(),
+            hits: vec![],
+            dropped: 0,
+            cut: None,
+            from: Some(500),
+            to: None,
+        };
+        assert!(
+            scan_agent("", "", &onward, 40)
+                .starts_with("no matches for \"Acme Corp\" in 0123456789abcdef turns 500 on"),
+            "got: {}",
+            scan_agent("", "", &onward, 40)
+        );
+        // A cap is stated, never silent — and the header counts what was found, not what is listed.
+        let capped = ScanResult {
+            needle: "the".to_string(),
+            session_id: "0123456789abcdef".to_string(),
+            hits: vec![scan_hit()],
+            dropped: 12,
+            cut: Some(ScanCut::Resume(41)),
+            from: None,
+            to: None,
+        };
+        let out = scan_agent("", "", &capped, 40);
+        assert!(
+            out.starts_with("scan \"the\" in 0123456789abcdef — 13 hits\n"),
+            "got: {out}"
+        );
+        // A cap the caller cannot walk past is a dead end: the elision names where to resume.
+        assert!(
+            out.contains("\n12 more hits not shown — continue with --from 41\n"),
+            "got: {out}"
+        );
+        // One turn holding more matches than the cap has no coordinate that both progresses and
+        // keeps every hit, so the reply says so instead of offering a resume that would loop.
+        let crowded = ScanResult {
+            needle: "the".to_string(),
+            session_id: "0123456789abcdef".to_string(),
+            hits: vec![scan_hit()],
+            dropped: 99,
+            cut: Some(ScanCut::Crowded(7)),
+            from: None,
+            to: None,
+        };
+        let out = scan_agent("", "", &crowded, 40);
+        assert!(
+            out.contains("99 more hits not shown, all in turn 7 — read it with --from 7 --to 7"),
+            "got: {out}"
+        );
+    }
+
+    #[test]
+    fn excerpt_windows_the_match_and_marks_the_cuts() {
+        let text = "alpha ".repeat(20) + "NEEDLE" + &" omega".repeat(20);
+        let at = text.find("NEEDLE").unwrap();
+        let e = excerpt(&text, at, 6, 12);
+        assert!(e.starts_with("… "), "a cut head is marked: {e}");
+        assert!(e.ends_with(" …"), "a cut tail is marked: {e}");
+        assert!(e.contains("NEEDLE"), "the match is in the window: {e}");
+        // A block shorter than the window is shown whole, with no ellipses.
+        assert_eq!(excerpt("a NEEDLE b", 2, 6, 40), "a NEEDLE b");
+        // Newlines collapse, so a hit stays one line.
+        assert_eq!(excerpt("a\n\nNEEDLE\tb", 3, 6, 40), "a NEEDLE b");
     }
 
     #[test]

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -8,6 +8,17 @@
 use crate::commands::recall::{Hit, Turn};
 use std::fmt::Write as _;
 
+/// Turns each side of a hit that a `→ get` line reaches for. A hint is meant to be run as it
+/// stands, so it carries the range rather than a coordinate the caller would have to widen by hand.
+const HINT_WINDOW: i64 = 3;
+
+/// The `--from a --to b` a `→ get` line carries for a hit at `seq`: the turns around it, clamped at
+/// the session's start. Turns are addressed by seq alone — the turn uuid is provenance, not an
+/// address, and a hit already knows where it sits.
+fn hint_range(seq: i64) -> String {
+    format!(" --from {} --to {}", (seq - HINT_WINDOW).max(0), seq + HINT_WINDOW)
+}
+
 /// Longest scent ever built — beyond any line budget, so final truncation is [`ellipsize`]'s job.
 const SCENT_CAP: usize = 240;
 
@@ -28,7 +39,7 @@ pub fn recall_agent(note: &str, memory_arg: &str, hits: &[(Hit, f64)]) -> String
             "[{}] {} {}/{} {}  score={:.3}",
             h.ts, h.harness, h.workdir, s8, h.block_type, score
         );
-        let _ = writeln!(out, "  → get {} {}{}", h.session_id, h.turn_uuid, memory_arg);
+        let _ = writeln!(out, "  → get {}{}{}", h.session_id, hint_range(h.seq), memory_arg);
         let _ = writeln!(out, "{}", h.text);
         for n in &h.neighbors {
             let np: String = n.text.chars().take(160).collect();
@@ -39,13 +50,35 @@ pub fn recall_agent(note: &str, memory_arg: &str, hits: &[(Hit, f64)]) -> String
     out
 }
 
-/// The agent `get` format: `[ts] role seqN turn=…` headers over reassembled blocks. Byte-stable.
-pub fn get_agent(note: &str, turns: &[Turn]) -> String {
+/// Characters of turns a `get` renders before it stops. A single turn can carry a whole file, so a
+/// wide range would otherwise answer past any tool-result ceiling; what the budget left out is
+/// always stated, with the coordinates to ask for it.
+const GET_BUDGET: usize = 40_000;
+
+/// The agent `get` format: `[ts] role seqN turn=…` headers over reassembled blocks, closed by the
+/// coordinates read and the session's size — so a partial read says what it is part of, and the
+/// next range is obvious. Byte-stable.
+pub fn get_agent(note: &str, turns: &[Turn], total: usize) -> String {
     let mut out = note.to_string();
+    let mut shown = 0;
     for t in turns {
+        if shown > 0 && out.len() >= GET_BUDGET {
+            break;
+        }
         let _ = writeln!(out, "[{}] {} seq{} turn={}", t.ts, t.role, t.seq, t.turn_uuid);
         let _ = writeln!(out, "{}", t.blocks.join("\n\n"));
         let _ = writeln!(out, "---");
+        shown += 1;
+    }
+    let (first, last) = (turns[0].seq, turns[shown - 1].seq);
+    let _ = writeln!(out, "turns {first}-{last} of {total}");
+    if shown < turns.len() {
+        let _ = writeln!(
+            out,
+            "{} more turn(s) in range not shown — read them with --from {}",
+            turns.len() - shown,
+            last + 1
+        );
     }
     out
 }
@@ -402,14 +435,25 @@ mod tests {
         assert_eq!(
             out,
             "[2026-06-19T01:29:59.000Z] claude_code -home-u-funes/01234567 text  score=0.578\n\
-             \x20 → get 0123456789abcdef aaaa-bbbb --memory hf://datasets/acme/kb\n\
+             \x20 → get 0123456789abcdef --from 4 --to 10 --memory hf://datasets/acme/kb\n\
              the decision was made\n\
              \x20 ~ [assistant text seq5] hello\n\
              ---\n"
         );
         // The built-in guide has no memory to name: an empty suffix keeps the hint bare.
         let bare = recall_agent("", "", &[(hit("2026-06-19T01:29:59.000Z", "text", "x"), 0.5)]);
-        assert!(bare.contains("  → get 0123456789abcdef aaaa-bbbb\n"), "got: {bare}");
+        assert!(
+            bare.contains("  → get 0123456789abcdef --from 4 --to 10\n"),
+            "got: {bare}"
+        );
+    }
+
+    #[test]
+    fn a_hint_range_never_reaches_before_the_session() {
+        // seq 0 has no turns behind it; the hint must stay runnable rather than ask for -3.
+        assert_eq!(hint_range(0), " --from 0 --to 3");
+        assert_eq!(hint_range(2), " --from 0 --to 5");
+        assert_eq!(hint_range(9), " --from 6 --to 12");
     }
 
     #[test]
@@ -472,8 +516,52 @@ mod tests {
             blocks: vec!["first".to_string(), "second".to_string()],
         };
         assert_eq!(
-            get_agent("", &[t]),
-            "[2026-06-19T01:29:59.000Z] assistant seq3 turn=t-1\nfirst\n\nsecond\n---\n"
+            get_agent("", &[t], 70),
+            "[2026-06-19T01:29:59.000Z] assistant seq3 turn=t-1\nfirst\n\nsecond\n---\n\
+             turns 3-3 of 70\n"
+        );
+    }
+
+    fn turn_at(seq: i64, body: &str) -> Turn {
+        Turn {
+            seq,
+            turn_uuid: format!("t-{seq}"),
+            ts: "2026-06-19T01:29:59.000Z".to_string(),
+            role: "assistant".to_string(),
+            blocks: vec![body.to_string()],
+        }
+    }
+
+    #[test]
+    fn get_agent_bounds_a_wide_range_and_says_where_to_resume() {
+        // One turn can carry a whole file, so a range is bounded by rendered bytes rather than by
+        // a turn count — and what it left out is stated with the coordinate to ask for it.
+        let big = "x".repeat(GET_BUDGET / 2);
+        let turns: Vec<Turn> = (0..6).map(|i| turn_at(i, &big)).collect();
+        let out = get_agent("", &turns, 100);
+        assert!(
+            out.contains("\nturns 0-1 of 100\n"),
+            "states what it read: {}",
+            &out[out.len() - 120..]
+        );
+        assert!(
+            out.contains("4 more turn(s) in range not shown — read them with --from 2"),
+            "names the resume coordinate: {}",
+            &out[out.len() - 120..]
+        );
+    }
+
+    #[test]
+    fn get_agent_always_renders_one_turn() {
+        // A single turn past the budget still renders: the alternative is a read that answers
+        // nothing and cannot be narrowed any further.
+        let huge = "x".repeat(GET_BUDGET * 2);
+        let out = get_agent("", &[turn_at(4, &huge)], 9);
+        assert!(out.contains(&huge), "the turn is rendered whole");
+        assert!(
+            out.trim_end().ends_with("turns 4-4 of 9"),
+            "got: {}",
+            &out[out.len() - 60..]
         );
     }
 

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -50,20 +50,65 @@ pub fn recall_agent(note: &str, memory_arg: &str, hits: &[(Hit, f64)]) -> String
     out
 }
 
-/// The agent `sessions` format: one line per session, oldest first, closed by the total. The
-/// session id is printed whole — it is the payload here, not a pointer into a longer hint line.
-/// Byte-stable.
-pub fn sessions_agent(note: &str, sessions: &[Session]) -> String {
+/// Chars of a session's opening prompt a row carries. Enough to tell sessions apart; the whole
+/// prompt is a `get` away.
+const PROMPT_CHARS: usize = 120;
+
+/// Characters of rows a `sessions` listing renders before it stops. The row bound and this one are
+/// two sides of the same ceiling: 200 rows carrying prompts is about this many characters, so
+/// neither can be raised into a reply nobody receives.
+const SESSIONS_BUDGET: usize = 40_000;
+
+/// The agent `sessions` format: a row per session, oldest first, each carrying the prompt it opened
+/// with on an indented second line, closed by the total. The session id is printed whole — it is the
+/// payload here, not a pointer into a longer hint line. `total` is every session the filter matched
+/// and `offset` where this page started, so an elided row is not just stated but reachable — the
+/// trailer names the offset that continues. Byte-stable.
+pub fn sessions_agent(note: &str, sessions: &[Session], total: usize, offset: usize) -> String {
     let mut out = note.to_string();
+    let mut shown = 0;
     for s in sessions {
+        if shown > 0 && out.len() >= SESSIONS_BUDGET {
+            break;
+        }
         let _ = writeln!(
             out,
-            "[{}] {} {}/{} {} turns",
-            s.ts, s.harness, s.workdir, s.session_id, s.turns
+            "[{}] {} {} {} turns {}",
+            s.date(),
+            s.harness,
+            s.origin(),
+            s.turns,
+            s.session_id
+        );
+        if !s.first_prompt.is_empty() {
+            let _ = writeln!(out, "  {}", one_line(&s.first_prompt, PROMPT_CHARS));
+        }
+        shown += 1;
+    }
+    // What is left is older than this page: `offset + shown` names the row it starts at, and the
+    // ordering is total, so that offset is the same row on every call.
+    let remaining = total.saturating_sub(offset + shown);
+    if remaining == 0 && offset == 0 {
+        let _ = writeln!(out, "---\n{total} sessions");
+    } else if remaining == 0 {
+        let _ = writeln!(out, "---\n{shown} of {total} sessions — the oldest match reached");
+    } else {
+        let _ = writeln!(
+            out,
+            "---\n{shown} of {total} sessions — {remaining} older: continue with --offset {}, or narrow with --repo/--since/--until",
+            offset + shown
         );
     }
-    let _ = writeln!(out, "---\n{} sessions", sessions.len());
     out
+}
+
+/// `s` collapsed onto one line and cut to `max` chars, `…` marking the cut.
+fn one_line(s: &str, max: usize) -> String {
+    let flat = s.split_whitespace().collect::<Vec<_>>().join(" ");
+    match flat.char_indices().nth(max) {
+        Some((i, _)) => format!("{}…", &flat[..i]),
+        None => flat,
+    }
 }
 
 /// Characters of turns a `get` renders before it stops. A single turn can carry a whole file, so a
@@ -599,23 +644,93 @@ mod tests {
         assert_eq!(word_span(text, "pha beta gamma delta epsilon zeta eta"), Some(1..7));
     }
 
-    #[test]
-    fn sessions_agent_is_byte_stable() {
-        let s = Session {
+    fn session(repo: &str, prompt: &str) -> Session {
+        Session {
             session_id: "0123456789abcdef".to_string(),
             ts: "2026-06-19T01:29:59.000Z".to_string(),
             workdir: "-home-u-funes".to_string(),
             harness: "claude_code".to_string(),
+            repo: repo.to_string(),
             turns: 47,
-        };
+            first_prompt: prompt.to_string(),
+        }
+    }
+
+    #[test]
+    fn sessions_agent_is_byte_stable() {
+        let s = session("huggingface/funes", "why is\n  rerank slow");
         assert_eq!(
-            sessions_agent("", &[s]),
-            "[2026-06-19T01:29:59.000Z] claude_code -home-u-funes/0123456789abcdef 47 turns\n\
+            sessions_agent("", &[s], 1, 0),
+            "[2026-06-19] claude_code huggingface/funes 47 turns 0123456789abcdef\n\
+             \x20 why is rerank slow\n\
              ---\n\
              1 sessions\n"
         );
         // An empty listing still closes with its total.
-        assert_eq!(sessions_agent("", &[]), "---\n0 sessions\n");
+        assert_eq!(sessions_agent("", &[], 0, 0), "---\n0 sessions\n");
+    }
+
+    #[test]
+    fn sessions_agent_falls_back_to_workdir_and_states_what_it_elided() {
+        // No repo resolved at index time: the workdir is the only provenance there is.
+        let out = sessions_agent("", &[session("", "x")], 1, 0);
+        assert!(
+            out.starts_with("[2026-06-19] claude_code -home-u-funes 47 turns"),
+            "got: {out}"
+        );
+        // A bounded listing says so, and says how many matched — a dropped row is never silent.
+        let capped = sessions_agent("", &[session("acme/kb", "x")], 723, 0);
+        assert!(
+            capped.contains("---\n1 of 723 sessions — 722 older: continue with --offset 1, or narrow with"),
+            "got: {capped}"
+        );
+    }
+
+    #[test]
+    fn a_bounded_listing_names_the_offset_that_continues_it() {
+        // A page in the middle of a walk states where it sits and where the next one starts, so the
+        // caller never has to guess and never re-reads a row.
+        let page = sessions_agent("", &[session("acme/kb", "x"), session("acme/kb", "y")], 10, 4);
+        assert!(
+            page.contains("---\n2 of 10 sessions — 4 older: continue with --offset 6"),
+            "got: {page}"
+        );
+        // The oldest page says so rather than offering an offset that would return nothing.
+        let last = sessions_agent("", &[session("acme/kb", "x")], 10, 9);
+        assert!(
+            last.contains("---\n1 of 10 sessions — the oldest match reached"),
+            "got: {last}"
+        );
+    }
+
+    #[test]
+    fn a_listing_stops_at_its_byte_budget() {
+        // The row cap and the byte budget are the same ceiling from two sides: a page of rows whose
+        // prompts are long stops on bytes, and still hands back a usable offset.
+        let long = "word ".repeat(40);
+        let rows: Vec<Session> = (0..400).map(|_| session("acme/kb", &long)).collect();
+        let out = sessions_agent("", &rows, 400, 0);
+        assert!(
+            out.len() < SESSIONS_BUDGET + 400,
+            "the budget holds: {} bytes",
+            out.len()
+        );
+        let shown = out.lines().filter(|l| l.starts_with('[')).count();
+        assert!(shown < 400, "not every row was rendered: {shown}");
+        assert!(
+            out.contains(&format!("continue with --offset {shown}")),
+            "the offset must resume where rendering stopped: {}",
+            out.lines().last().unwrap()
+        );
+    }
+
+    #[test]
+    fn a_prompt_row_is_one_line_and_bounded() {
+        let long = "word ".repeat(60);
+        let out = sessions_agent("", &[session("acme/kb", &long)], 1, 0);
+        let prompt = out.lines().nth(1).unwrap();
+        assert!(prompt.ends_with('…'), "a cut prompt is marked: {prompt}");
+        assert!(prompt.chars().count() <= PROMPT_CHARS + 4, "bounded: {prompt}");
     }
 
     #[test]

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -1,11 +1,11 @@
 //! Rendering for the read commands, over `recall`'s structured results.
 //!
-//! [`recall_agent`]/[`get_agent`] are the machine format — byte-stable, its layout is a published
-//! contract (the `→ get` lines are parsed) and must not change. [`get_human`] renders a turn for
-//! a terminal: tool chunks compressed to a deterministic one-liner, prose wrapped, marks
-//! highlighted.
+//! [`recall_agent`]/[`get_agent`]/[`sessions_agent`] are the machine format — byte-stable, its
+//! layout is a published contract (the `→ get` lines are parsed) and must not change.
+//! [`get_human`] renders a turn for a terminal: tool chunks compressed to a deterministic
+//! one-liner, prose wrapped, marks highlighted.
 
-use crate::commands::recall::{Hit, Turn};
+use crate::commands::recall::{Hit, Session, Turn};
 use std::fmt::Write as _;
 
 /// Turns each side of a hit that a `→ get` line reaches for. A hint is meant to be run as it
@@ -47,6 +47,22 @@ pub fn recall_agent(note: &str, memory_arg: &str, hits: &[(Hit, f64)]) -> String
         }
         let _ = writeln!(out, "---");
     }
+    out
+}
+
+/// The agent `sessions` format: one line per session, oldest first, closed by the total. The
+/// session id is printed whole — it is the payload here, not a pointer into a longer hint line.
+/// Byte-stable.
+pub fn sessions_agent(note: &str, sessions: &[Session]) -> String {
+    let mut out = note.to_string();
+    for s in sessions {
+        let _ = writeln!(
+            out,
+            "[{}] {} {}/{} {} turns",
+            s.ts, s.harness, s.workdir, s.session_id, s.turns
+        );
+    }
+    let _ = writeln!(out, "---\n{} sessions", sessions.len());
     out
 }
 

--- a/tests/index_recall.rs
+++ b/tests/index_recall.rs
@@ -21,6 +21,11 @@ fn write_transcript(source: &std::path::Path) -> (String, String) {
             r#"{{"type":"assistant","uuid":"t4","parentUuid":"t3","timestamp":"2026-01-01T00:00:15Z","message":{{"role":"assistant","content":[{{"type":"text","text":"{}"}}]}}}}"#,
             seam_block()
         ),
+        // A compacted transcript replays turns under a uuid it has already used. Real sessions do
+        // this — one 10,000-turn session holds ~3,300 such repeats — and it is the case that breaks
+        // any code treating a turn uuid as a session-unique key.
+        r#"{"type":"assistant","uuid":"replay","parentUuid":"t4","timestamp":"2026-01-01T00:00:20Z","message":{"role":"assistant","content":[{"type":"text","text":"first REPLAYEDMARKER occurrence"}]}}"#,
+        r#"{"type":"assistant","uuid":"replay","parentUuid":"t4","timestamp":"2026-01-01T00:00:25Z","message":{"role":"assistant","content":[{"type":"text","text":"second REPLAYEDMARKER occurrence"}]}}"#,
     ];
     for l in lines {
         writeln!(f, "{l}").unwrap();
@@ -109,7 +114,7 @@ async fn index_then_read_surface() {
         .await
         .unwrap();
     assert!(
-        listed.contains(&format!("{workdir} 4 turns {session}")),
+        listed.contains(&format!("{workdir} 6 turns {session}")),
         "sessions should list the session with its distinct turn count: {listed}"
     );
     assert!(
@@ -289,6 +294,68 @@ async fn index_then_read_surface() {
     assert!(
         outside.contains("no turns in that range"),
         "an empty window must not read as absence: {outside}"
+    );
+
+    // `sessions` and `get` must report the same size, or neither number can be trusted: the
+    // addressable unit is what `--from`/`--to` index, which is what `get` renders.
+    let sized = funes::commands::recall::get(
+        funes::memory::Memory::local(),
+        session.clone(),
+        funes::commands::recall::TurnRange {
+            from: Some(0),
+            to: Some(0),
+        },
+    )
+    .await
+    .unwrap();
+    assert!(
+        sized.contains("of 6"),
+        "get must count the turns sessions listed: {sized}"
+    );
+
+    // A turn uuid recurring at two positions is two turns, not one. Both verbs have to agree with
+    // that, and with each other: `sessions` counts what `get` renders, and a scan of the whole
+    // session finds exactly what its windows find between them.
+    let replayed = funes::commands::recall::scan(
+        funes::memory::Memory::local(),
+        "REPLAYEDMARKER".into(),
+        session.clone(),
+        None,
+        None,
+        false,
+        40,
+    )
+    .await
+    .unwrap();
+    assert!(
+        replayed.contains("— 2 hits"),
+        "a replayed uuid must not merge two blocks into one hit: {replayed}"
+    );
+    let first_half = funes::commands::recall::scan(
+        funes::memory::Memory::local(),
+        "REPLAYEDMARKER".into(),
+        session.clone(),
+        None,
+        Some(4),
+        false,
+        40,
+    )
+    .await
+    .unwrap();
+    let second_half = funes::commands::recall::scan(
+        funes::memory::Memory::local(),
+        "REPLAYEDMARKER".into(),
+        session.clone(),
+        Some(5),
+        None,
+        false,
+        40,
+    )
+    .await
+    .unwrap();
+    assert!(
+        first_half.contains("— 1 hits") && second_half.contains("— 1 hits"),
+        "windows must partition the hits, not double-count or lose them: {first_half}{second_half}"
     );
 
     // A needle inside the region two chunks overlap is one hit, not one per chunk — splits are

--- a/tests/index_recall.rs
+++ b/tests/index_recall.rs
@@ -82,9 +82,13 @@ async fn index_then_read_surface() {
     assert!(tu.contains("tool_use"), "type filter should keep tool_use rows: {tu}");
 
     // get: reassemble the assistant turn by its uuid.
-    let got = funes::commands::recall::get(funes::memory::Memory::local(), session.clone(), "t2".into(), 3)
-        .await
-        .unwrap();
+    let got = funes::commands::recall::get(
+        funes::memory::Memory::local(),
+        session.clone(),
+        funes::commands::recall::TurnRange::default(),
+    )
+    .await
+    .unwrap();
     assert!(got.contains("typed blocks"), "get should return the turn text: {got}");
 
     // Every hit names the memory it was read from — the default memory and an explicit one alike.

--- a/tests/index_recall.rs
+++ b/tests/index_recall.rs
@@ -103,17 +103,90 @@ async fn index_then_read_surface() {
     .unwrap();
     assert!(got.contains("typed blocks"), "get should return the turn text: {got}");
 
-    // sessions: the memory enumerates to the one indexed session, counted in turns not rows.
-    let listed = funes::commands::recall::sessions(funes::memory::Memory::local())
+    // sessions: the memory enumerates to the one indexed session, counted in turns not rows, with
+    // the prompt it opened with — the cheapest triage there is.
+    let listed = funes::commands::recall::sessions(funes::memory::Memory::local(), Default::default())
         .await
         .unwrap();
     assert!(
-        listed.contains(&format!("{workdir}/{session} 4 turns")),
+        listed.contains(&format!("{workdir} 4 turns {session}")),
         "sessions should list the session with its distinct turn count: {listed}"
+    );
+    assert!(
+        listed.contains("how do we parse transcripts into turns"),
+        "a row should carry the opening prompt: {listed}"
     );
     assert!(
         listed.trim_end().ends_with("1 sessions"),
         "the listing should close with the total: {listed}"
+    );
+
+    // A limit of zero is an error, not an empty listing. It used to mean "every match", so a caller
+    // reaching for the old idiom must be told, not handed nothing.
+    let zero_limit = funes::commands::recall::sessions(
+        funes::memory::Memory::local(),
+        funes::commands::recall::SessionFilter {
+            limit: Some(0),
+            ..Default::default()
+        },
+    )
+    .await;
+    let err = zero_limit.expect_err("limit 0 must be an error").to_string();
+    assert!(
+        err.contains("would list nothing") && err.contains("--offset"),
+        "the error must say what to do instead: {err}"
+    );
+
+    // An offset past the matches says so rather than reporting an empty memory: the two are not
+    // the same claim, and only one of them means "nothing is there".
+    let past = funes::commands::recall::sessions(
+        funes::memory::Memory::local(),
+        funes::commands::recall::SessionFilter {
+            offset: 5,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    assert!(
+        past.contains("offset 5 is past the 1 session(s)"),
+        "an offset past the end must not read as an empty memory: {past}"
+    );
+
+    // The filters narrow the population before anything of it is read. This fixture has no
+    // resolvable checkout, so `--repo` can claim none of it, and a window that excludes its date
+    // keeps nothing.
+    let filtered = |f| funes::commands::recall::sessions(funes::memory::Memory::local(), f);
+    let by_repo = filtered(funes::commands::recall::SessionFilter {
+        repo: Some("acme/kb".into()),
+        ..Default::default()
+    })
+    .await
+    .unwrap();
+    assert!(
+        by_repo.contains("no session"),
+        "an unresolved checkout matches no repo: {by_repo}"
+    );
+    let before = filtered(funes::commands::recall::SessionFilter {
+        until: Some("2025-12-31".into()),
+        ..Default::default()
+    })
+    .await
+    .unwrap();
+    assert!(
+        before.contains("no session"),
+        "--until excludes a later session: {before}"
+    );
+    let window = filtered(funes::commands::recall::SessionFilter {
+        since: Some("2026-01-01".into()),
+        until: Some("2026-01-01".into()),
+        ..Default::default()
+    })
+    .await
+    .unwrap();
+    assert!(
+        window.contains(&session) && window.trim_end().ends_with("1 sessions"),
+        "an inclusive window keeps the session it brackets: {window}"
     );
 
     // scan: an exhaustive literal search of one session, and a zero that names the needle it

--- a/tests/index_recall.rs
+++ b/tests/index_recall.rs
@@ -358,6 +358,63 @@ async fn index_then_read_surface() {
         "windows must partition the hits, not double-count or lose them: {first_half}{second_half}"
     );
 
+    // sketch: what the session contains, asked without a query. It is bounded by construction and
+    // says what it left out, and every place it shows is addressable.
+    let sketched = funes::commands::sketch::run(
+        funes::memory::Memory::local(),
+        session.clone(),
+        None,
+        None,
+        Some(3),
+        Some(2_000),
+    )
+    .await
+    .unwrap();
+    assert!(
+        sketched.starts_with(&format!("sketch {session} — ")),
+        "a sketch names the session it digested: {sketched}"
+    );
+    assert!(
+        sketched.contains(&format!("→ get {session} --from 0 --to 3")),
+        "every place must be addressable, in the same coordinate as get: {sketched}"
+    );
+    assert!(
+        sketched.trim_end().ends_with("scan a literal for that"),
+        "a sketch must not read as a clearance: {sketched}"
+    );
+
+    // A request past the bounds is clamped and the clamp is reported — an agent that believes it
+    // saw the whole digest is the failure the bounds exist for.
+    let clamped = funes::commands::sketch::run(
+        funes::memory::Memory::local(),
+        session.clone(),
+        None,
+        None,
+        Some(40),
+        Some(1_000),
+    )
+    .await
+    .unwrap();
+    assert!(
+        clamped.contains("(units clamped to 4)"),
+        "a clamp must be stated, not applied quietly: {clamped}"
+    );
+
+    // An unknown session is an error, not an empty digest.
+    let missing = funes::commands::sketch::run(
+        funes::memory::Memory::local(),
+        "no-such-session".into(),
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
+    assert!(
+        missing.is_err_and(|e| e.to_string().contains("no-such-session")),
+        "a mistyped session must not read as an empty session"
+    );
+
     // A needle inside the region two chunks overlap is one hit, not one per chunk — splits are
     // stitched back into their block before anything is matched.
     let seam = funes::commands::recall::scan(

--- a/tests/index_recall.rs
+++ b/tests/index_recall.rs
@@ -91,6 +91,19 @@ async fn index_then_read_surface() {
     .unwrap();
     assert!(got.contains("typed blocks"), "get should return the turn text: {got}");
 
+    // sessions: the memory enumerates to the one indexed session, counted in turns not rows.
+    let listed = funes::commands::recall::sessions(funes::memory::Memory::local())
+        .await
+        .unwrap();
+    assert!(
+        listed.contains(&format!("{workdir}/{session} 3 turns")),
+        "sessions should list the session with its distinct turn count: {listed}"
+    );
+    assert!(
+        listed.trim_end().ends_with("1 sessions"),
+        "the listing should close with the total: {listed}"
+    );
+
     // Every hit names the memory it was read from — the default memory and an explicit one alike.
     let default_hint = format!("--memory {}", db_dir.path().join("memory").display());
     assert!(

--- a/tests/index_recall.rs
+++ b/tests/index_recall.rs
@@ -1,5 +1,5 @@
 //! End-to-end: build a real index from a tiny transcript in a temp dir, then exercise
-//! the read surface (recall / get / status). No mocking — this runs the real
+//! the read surface (recall / get / sessions / scan / status). No mocking — this runs the real
 //! BGE embedder + reranker (downloaded to the fastembed cache on first run) against a
 //! real Lance memory under a temp `$FUNES_HOME`.
 
@@ -17,11 +17,23 @@ fn write_transcript(source: &std::path::Path) -> (String, String) {
         r#"{"type":"user","uuid":"t1","timestamp":"2026-01-01T00:00:00Z","message":{"role":"user","content":"how do we parse transcripts into turns"}}"#,
         r#"{"type":"assistant","uuid":"t2","parentUuid":"t1","timestamp":"2026-01-01T00:00:05Z","message":{"role":"assistant","content":[{"type":"text","text":"We parse each JSONL line into a turn with typed blocks."},{"type":"tool_use","id":"c1","name":"Bash","input":{"command":"cargo test"}}]}}"#,
         r#"{"type":"user","uuid":"t3","parentUuid":"t2","timestamp":"2026-01-01T00:00:10Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"c1","content":[{"type":"text","text":"22 passed"}]}]}}"#,
+        &format!(
+            r#"{{"type":"assistant","uuid":"t4","parentUuid":"t3","timestamp":"2026-01-01T00:00:15Z","message":{{"role":"assistant","content":[{{"type":"text","text":"{}"}}]}}}}"#,
+            seam_block()
+        ),
     ];
     for l in lines {
         writeln!(f, "{l}").unwrap();
     }
     (session.to_string(), workdir.to_string())
+}
+
+/// A block long enough to split (over the 1200-char chunk cap), with `SPLITSEAMMARKER` placed in
+/// the 150-char region consecutive chunks overlap — so the marker is stored in two chunks. A scan
+/// that matched raw chunks would report it twice.
+fn seam_block() -> String {
+    let filler = |from: usize, to: usize| (from..to).map(|i| format!("w{i:03} ")).collect::<String>();
+    format!("{}SPLITSEAMMARKER {}", filler(0, 220), filler(220, 320))
 }
 
 #[tokio::test]
@@ -96,12 +108,161 @@ async fn index_then_read_surface() {
         .await
         .unwrap();
     assert!(
-        listed.contains(&format!("{workdir}/{session} 3 turns")),
+        listed.contains(&format!("{workdir}/{session} 4 turns")),
         "sessions should list the session with its distinct turn count: {listed}"
     );
     assert!(
         listed.trim_end().ends_with("1 sessions"),
         "the listing should close with the total: {listed}"
+    );
+
+    // scan: an exhaustive literal search of one session, and a zero that names the needle it
+    // cleared.
+    let scanned = funes::commands::recall::scan(
+        funes::memory::Memory::local(),
+        "typed blocks".into(),
+        session.clone(),
+        None,
+        None,
+        false,
+        40,
+    )
+    .await
+    .unwrap();
+    assert!(
+        scanned.contains(&format!("scan \"typed blocks\" in {session} — 1 hits")),
+        "scan should find the literal exactly once: {scanned}"
+    );
+    assert!(
+        scanned.contains(&format!("→ get {session} --from 0 --to 4")),
+        "a scan hit should carry a runnable range around its turn, clamped at the start: {scanned}"
+    );
+    let zero = funes::commands::recall::scan(
+        funes::memory::Memory::local(),
+        "nothing anywhere says this".into(),
+        session.clone(),
+        None,
+        None,
+        false,
+        40,
+    )
+    .await
+    .unwrap();
+    assert!(
+        zero.contains(&format!("no matches for \"nothing anywhere says this\" in {session}")),
+        "a zero should echo the needle and the session it cleared: {zero}"
+    );
+
+    // A session that isn't in the memory is an error, not a clearance — a mistyped id must never
+    // read as "the term is absent".
+    let unknown = funes::commands::recall::scan(
+        funes::memory::Memory::local(),
+        "typed blocks".into(),
+        "no-such-session".into(),
+        None,
+        None,
+        false,
+        40,
+    )
+    .await;
+    let err = unknown.expect_err("an unknown session must be an error").to_string();
+    assert!(err.contains("no session no-such-session"), "names the session: {err}");
+
+    // A window scopes what a zero clears: the same needle is present in the session and absent from
+    // a stretch that excludes it, and the reply says which stretch it cleared.
+    let windowed = funes::commands::recall::scan(
+        funes::memory::Memory::local(),
+        "typed blocks".into(),
+        session.clone(),
+        Some(2),
+        None,
+        false,
+        40,
+    )
+    .await
+    .unwrap();
+    assert!(
+        windowed.starts_with(&format!("no matches for \"typed blocks\" in {session} turns 2 on")),
+        "a window must scope the clearance it reports: {windowed}"
+    );
+    let covering = funes::commands::recall::scan(
+        funes::memory::Memory::local(),
+        "typed blocks".into(),
+        session.clone(),
+        Some(0),
+        Some(1),
+        false,
+        40,
+    )
+    .await
+    .unwrap();
+    assert!(
+        covering.contains("turns 0-1 — 1 hits"),
+        "a window that covers the hit still finds it: {covering}"
+    );
+
+    // A range outside the session is not a clearance — it reports the session's size instead.
+    let outside = funes::commands::recall::scan(
+        funes::memory::Memory::local(),
+        "typed blocks".into(),
+        session.clone(),
+        Some(900),
+        Some(910),
+        false,
+        40,
+    )
+    .await
+    .unwrap();
+    assert!(
+        outside.contains("no turns in that range"),
+        "an empty window must not read as absence: {outside}"
+    );
+
+    // A needle inside the region two chunks overlap is one hit, not one per chunk — splits are
+    // stitched back into their block before anything is matched.
+    let seam = funes::commands::recall::scan(
+        funes::memory::Memory::local(),
+        "SPLITSEAMMARKER".into(),
+        session.clone(),
+        None,
+        None,
+        false,
+        40,
+    )
+    .await
+    .unwrap();
+    assert!(
+        seam.contains("— 1 hits"),
+        "a split block should report one hit, not one per chunk: {seam}"
+    );
+
+    // --ignore-case covers case variation; the same needle misses without it.
+    let folded = funes::commands::recall::scan(
+        funes::memory::Memory::local(),
+        "TYPED BLOCKS".into(),
+        session.clone(),
+        None,
+        None,
+        true,
+        40,
+    )
+    .await
+    .unwrap();
+    assert!(folded.contains("— 1 hits"), "ignore_case should fold: {folded}");
+    let exact = funes::commands::recall::scan(
+        funes::memory::Memory::local(),
+        "TYPED BLOCKS".into(),
+        session.clone(),
+        None,
+        None,
+        false,
+        40,
+    )
+    .await
+    .unwrap();
+    assert!(
+        exact.starts_with("no matches for"),
+        "a literal scan is case-sensitive by default: {exact}"
     );
 
     // Every hit names the memory it was read from — the default memory and an explicit one alike.

--- a/tests/redact_on_index.rs
+++ b/tests/redact_on_index.rs
@@ -54,9 +54,13 @@ async fn planted_key_is_redacted_at_index_time() {
         .unwrap();
 
     // Read the stored turn back: the marker is present, the key body is gone.
-    let got = funes::commands::recall::get(funes::memory::Memory::local(), session.into(), "t1".into(), 3)
-        .await
-        .unwrap();
+    let got = funes::commands::recall::get(
+        funes::memory::Memory::local(),
+        session.into(),
+        funes::commands::recall::TurnRange::default(),
+    )
+    .await
+    .unwrap();
     assert!(
         got.contains("[REDACTED:PrivateKey]"),
         "expected a redaction marker, got: {got}"

--- a/tests/scrub.rs
+++ b/tests/scrub.rs
@@ -58,9 +58,13 @@ async fn scrub_redacts_an_existing_secret_in_place() {
     funes::commands::index::run_index(source.path(), false, None)
         .await
         .unwrap();
-    let dirty = funes::commands::recall::get(funes::memory::Memory::local(), session.into(), "t1".into(), 3)
-        .await
-        .unwrap();
+    let dirty = funes::commands::recall::get(
+        funes::memory::Memory::local(),
+        session.into(),
+        funes::commands::recall::TurnRange::default(),
+    )
+    .await
+    .unwrap();
     assert!(
         dirty.contains(&key_body),
         "setup: the key should be in the memory before scrub"
@@ -69,9 +73,13 @@ async fn scrub_redacts_an_existing_secret_in_place() {
     // Scrub with the real scanner: it must redact the key in place.
     std::env::remove_var("FUNES_TRUFFLEHOG");
     funes::commands::scrub::run().await.unwrap();
-    let clean = funes::commands::recall::get(funes::memory::Memory::local(), session.into(), "t1".into(), 3)
-        .await
-        .unwrap();
+    let clean = funes::commands::recall::get(
+        funes::memory::Memory::local(),
+        session.into(),
+        funes::commands::recall::TurnRange::default(),
+    )
+    .await
+    .unwrap();
     assert!(
         clean.contains("[REDACTED:PrivateKey]"),
         "expected a redaction marker after scrub: {clean}"

--- a/tests/scrub_drops_escaped_key.rs
+++ b/tests/scrub_drops_escaped_key.rs
@@ -66,9 +66,16 @@ async fn scrub_redacts_an_escaped_key_in_place() {
     funes::commands::index::run_index(source.path(), false, None)
         .await
         .unwrap();
-    let dirty = funes::commands::recall::get(funes::memory::Memory::local(), session.into(), "t2".into(), 0)
-        .await
-        .unwrap();
+    let dirty = funes::commands::recall::get(
+        funes::memory::Memory::local(),
+        session.into(),
+        funes::commands::recall::TurnRange {
+            from: Some(1),
+            to: Some(1),
+        },
+    )
+    .await
+    .unwrap();
     assert!(
         dirty.contains(&key_body),
         "setup: the escaped key should be in the memory before scrub"
@@ -78,9 +85,16 @@ async fn scrub_redacts_an_escaped_key_in_place() {
     std::env::remove_var("FUNES_TRUFFLEHOG");
     funes::commands::scrub::run().await.unwrap();
 
-    let after_key = funes::commands::recall::get(funes::memory::Memory::local(), session.into(), "t2".into(), 0)
-        .await
-        .unwrap_or_default();
+    let after_key = funes::commands::recall::get(
+        funes::memory::Memory::local(),
+        session.into(),
+        funes::commands::recall::TurnRange {
+            from: Some(1),
+            to: Some(1),
+        },
+    )
+    .await
+    .unwrap_or_default();
     assert!(
         !after_key.contains(&key_body),
         "escaped key survived scrub: {after_key}"
@@ -91,9 +105,16 @@ async fn scrub_redacts_an_escaped_key_in_place() {
     );
 
     // The clean turn is untouched.
-    let clean = funes::commands::recall::get(funes::memory::Memory::local(), session.into(), "t1".into(), 0)
-        .await
-        .unwrap();
+    let clean = funes::commands::recall::get(
+        funes::memory::Memory::local(),
+        session.into(),
+        funes::commands::recall::TurnRange {
+            from: Some(0),
+            to: Some(0),
+        },
+    )
+    .await
+    .unwrap();
     assert!(
         clean.contains("just chatting about parsers"),
         "clean turn was lost: {clean}"


### PR DESCRIPTION
This adds more verbs to funes to list sessions and scan them for "needle" terms.

The goal is to help looking for specific patterns in sessions, as opposed to the recall semantic search.