### PR TITLE
Add session listing and scanning capabilties

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,26 @@ fell back to).
 | `--harness` | — | restrict to `claude \| codex \| pi \| hermes` (the saved facet `claude_code` also parses) |
 | `--memory` | local memory | the memory to read — `<org>/<repo>`, an `hf://…` URI, a local path, or `local` |
 
+### sessions
+
+`funes sessions [--repo <owner/name>] [--since <date>] [--until <date>] [--limit <n>] [--offset <n>]
+[--memory <label>]` — every session a memory holds, oldest first, with the prompt each opened with.
+`--limit` keeps the most recent rows; `--offset` walks the listing back through time.
+
+Agent format, a row per session plus its opening prompt, closed by the total:
+
+```
+[<date>] <harness> <repo|workdir> <n> turns <session_id>
+  <the prompt it opened with, one line>
+---
+<shown> of <total> sessions — <n> older: continue with --offset <n>, or narrow with --repo/--since/--until
+```
+
+The session id is printed whole — it is what `get` takes. Turn counts are (seq, turn_uuid) pairs,
+the unit `get` renders, so the two agree on a session's size. A complete listing closes with
+`<total> sessions`; `no sessions in <label>` when the memory is empty, `no session in <label>
+matches` when a filter keeps nothing.
+
 ### get
 
 `funes get <session_id> [--from <seq>] [--to <seq>] [--memory <label>]` — a range of one session's

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ rank) → cross-encoder rerank → recency reweight → neighbor expansion. Agen
 
 ```
 [<ts>] <harness> <workdir>/<session8> <block_type>  score=<s.sss>
-  → get <session_id> <turn_uuid> --memory <label>
+  → get <session_id> --from <seq> --to <seq> --memory <label>
 <the full chunk text>
   ~ [<role> <block_type> seq<N>] <neighbor chunk, first 160 chars>
 ---
@@ -40,19 +40,37 @@ fell back to).
 
 ### get
 
-`funes get <session_id> <turn_uuid> [--window 3] [--memory <label>]` — the named turn plus turns
-within the seq window, splits reassembled into whole blocks. Pass the `--memory` a recall hint
-names so the drill-down reads the same memory the hit came from. `--highlight <text>` marks the
-text in the human rendering (matched whitespace-insensitively; no effect on the agent format).
-Agent format, per turn:
+`funes get <session_id> [--from <seq>] [--to <seq>] [--memory <label>]` — a range of one session's
+turns, splits reassembled into whole blocks. Pass the `--memory` a hint names so the drill-down reads
+the same memory the hit came from.
+
+Turns are addressed by `seq`, the session's own dense counter over its turns, so a range is turns n
+through m. A recall hit's `→ get` line carries the session, the range around the hit, and the memory.
+`--from` defaults to the session's start and `--to` to 20 turns on, so a session id alone is a valid
+read.
+
+The turn uuid is provenance, not an address: chunk ids are keyed on it and it is printed with every
+turn, but nothing takes it as input.
+
+Agent format, per turn, closed by the range read and the session's size:
 
 ```
 [<ts>] <role> seq<N> turn=<turn_uuid>
 <blocks, joined by blank lines>
 ---
+turns <first>-<last> of <total>
 ```
 
-`turn <uuid> not found in session <id>` when absent.
+A read renders 40,000 characters at most and names the coordinate to resume from:
+
+```
+turns 0-11 of 786
+9 more turn(s) in range not shown — read them with --from 12
+```
+
+A turn renders whole or not at all, so a single turn larger than that is the one thing that can
+exceed it. `no turns in that range of session <id> (it holds <n>)` when the coordinates land outside
+the session, `no session <id> in <label>` when the id is unknown.
 
 ### ask
 
@@ -88,10 +106,9 @@ A non-zero agent exit fails funes (exit 1, the child's code quoted).
 claude/codex/hermes also installs the automation hooks — see [docs/automation.md](docs/automation.md)). A
 positional `memory` binds the server to a memory; `funes add <agent> <memory>` bakes it into the
 registration. `funes remove <agent>` reverses that agent integration without deleting memories or
-transcripts. Tools: `recall` (query, k, block_type/harness filters, memory), `get`
-(session_id, turn_uuid, window, memory), `status` (memory) — each returns the corresponding
-agent-format string verbatim. A tool call's `memory` overrides the server's; with neither, it reads
-the local memory.
+transcripts. Tools: `recall` (query, k, block_type/harness filters, memory), `get` (session_id,
+from, to, memory), `status` (memory) — each returns the corresponding agent-format string verbatim.
+A tool call's `memory` overrides the server's; with neither, it reads the local memory.
 
 ## Working on the repo
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,9 +106,10 @@ A non-zero agent exit fails funes (exit 1, the child's code quoted).
 claude/codex/hermes also installs the automation hooks — see [docs/automation.md](docs/automation.md)). A
 positional `memory` binds the server to a memory; `funes add <agent> <memory>` bakes it into the
 registration. `funes remove <agent>` reverses that agent integration without deleting memories or
-transcripts. Tools: `recall` (query, k, block_type/harness filters, memory), `get` (session_id,
-from, to, memory), `status` (memory) — each returns the corresponding agent-format string verbatim.
-A tool call's `memory` overrides the server's; with neither, it reads the local memory.
+transcripts. Tools: `recall` (query, k, half_life, neighbors, candidates, block_type/harness
+filters, memory), `get` (session_id, from, to, memory), `status` (memory) — each returns the
+corresponding agent-format string verbatim. A tool call's `memory` overrides the server's; with
+neither, it reads the local memory.
 
 ## Working on the repo
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,27 @@ fell back to).
 | `--harness` | — | restrict to `claude \| codex \| pi \| hermes` (the saved facet `claude_code` also parses) |
 | `--memory` | local memory | the memory to read — `<org>/<repo>`, an `hf://…` URI, a local path, or `local` |
 
+### scan
+
+`funes scan <needle> <session_id> [--from <seq>] [--to <seq>] [-i] [--context <n>] [--memory <label>]`
+— every block of one session carrying a literal, in reading order. Splits are stitched back together
+before matching, so a needle straddling a chunk boundary is still found. `-i` matches regardless of
+case; `--from`/`--to` scan a stretch, and then a zero clears only that stretch.
+
+Agent format, a header then one line per carrying block:
+
+```
+scan "<needle>" in <session_id>[ turns <a>-<b>] — <n> hits
+[<ts>] <block_type> seq<N>
+  → get <session_id> --from <seq> --to <seq> --memory <label>
+  … <the match, with surrounding text on one line> …
+---
+```
+
+`no matches for "<needle>" in <session_id>` when nothing carries it — that zero is per session and
+per spelling. A capped listing is cut at a turn boundary and names the coordinate to continue from;
+when one turn holds more matches than the cap, it says so and names the turn.
+
 ### sessions
 
 `funes sessions [--repo <owner/name>] [--since <date>] [--until <date>] [--limit <n>] [--offset <n>]

--- a/docs/recall.md
+++ b/docs/recall.md
@@ -24,7 +24,7 @@ Each hit carries its provenance and a ready-to-run drill-down line:
 
 ```
 [<ts>] <harness> <workdir>/<session8> <block_type>  score=<s.sss>
-  → get <session_id> <turn_uuid> --memory <label>
+  → get <session_id> --from <seq> --to <seq> --memory <label>
 <the full chunk text>
   ~ [<role> <block_type> seq<N>] <neighbor chunk, first 160 chars>
 ---
@@ -46,18 +46,40 @@ from. `no results` prints when nothing matched. The exact shape is a contract �
 | `--harness` | — | restrict to `claude \| codex \| pi \| hermes` |
 | `--memory` | local | the memory to read (see below) |
 
-## Drilling in with `get`
+## Reading turns with `get`
 
 ```bash
-funes get <session_id> <turn_uuid> [--window 3] [--memory <label>] [--highlight <text>] [--format human|agent]
+funes get <session_id> [--from <seq>] [--to <seq>] [--memory <label>]
 ```
 
-`get` returns the named turn plus the turns within the seq window, with splits reassembled into whole
-blocks. Pass the same `--memory` the recall hint named, so the drill-down reads the memory the hit came
-from. Unlike `recall`, `get` has a **human** rendering in addition to the agent format — chosen when
-both stdin and stdout are terminals, overridable with `--format`. `--highlight` marks text in that
-human rendering (whitespace-insensitive; no effect on the agent format). It prints `turn <uuid> not
-found in session <id>` when the turn is absent.
+`get` returns a range of a session's turns, with their splits reassembled into whole blocks. Pass the
+same `--memory` the recall hint named, so the drill-down reads the memory the hit came from. The
+output is the agent format, the same in a terminal as when piped.
+
+Turns are addressed by `seq`, the session's own dense counter over its turns, so `--from 40 --to 60`
+is turns 40 through 60. A hit's `→ get` line hands you a ready-to-run range:
+
+```bash
+funes get 987a1e04-… --from 37 --to 43   # as printed by the hit
+funes get 987a1e04-… --from 40 --to 60   # move or widen
+funes get 987a1e04-…                     # from the start; --from alone reads 20 turns on
+```
+
+The turn uuid is provenance, not an address: it identifies a turn across re-indexing, and is printed
+with every turn, but nothing takes it as input.
+
+Every read closes with the range it covered and the session's size:
+
+```
+---
+turns 0-19 of 786
+```
+
+A read renders 40,000 characters at most, naming the coordinate to resume from — `9 more turn(s) in
+range not shown — read them with --from 12`. A turn renders whole or not at all, so a single turn
+larger than that is the one thing that can exceed it. It prints `no turns in that range of session
+<id>` when the coordinates land outside the session, and errors with `no session <id> in <label>`
+when the id is unknown.
 
 ## Reading a different memory
 

--- a/docs/recall.md
+++ b/docs/recall.md
@@ -49,6 +49,29 @@ from. `no results` prints when nothing matched. The exact shape is a contract �
 The MCP `recall` tool takes the same parameters and defaults, so an agent can widen a search —
 `half_life: 0` when the answer may be old.
 
+## Scanning a session
+
+```bash
+funes scan <needle> <session_id> [--from <seq>] [--to <seq>] [-i] [--context <n>] [--memory <label>]
+```
+
+`scan` finds a literal in every block of one session, in reading order, each hit carrying the `→ get`
+range that reads the turn around it. The needle is a literal, never a regex: a pattern that silently
+matched nothing would read as a clean result.
+
+| flag | default | effect |
+|---|---|---|
+| `--from` / `--to` | whole session | scan only this seq range |
+| `-i`, `--ignore-case` | off | match regardless of case |
+| `--context` | 100 | characters of surrounding text shown on each side of a match |
+| `--memory` | local | the memory to read |
+
+Splits are stitched back together before matching, so a needle that straddles a chunk boundary is
+found. A zero — `no matches for "<needle>" in <session_id>` — covers that session and that exact
+spelling, and a windowed scan says which stretch it covered. Listing stops at 200 hits, cut at a turn
+boundary, and names the `--from` that continues; if one turn holds more matches than that by itself,
+the reply names the turn to read instead.
+
 ## Listing sessions
 
 ```bash

--- a/docs/recall.md
+++ b/docs/recall.md
@@ -46,6 +46,9 @@ from. `no results` prints when nothing matched. The exact shape is a contract �
 | `--harness` | — | restrict to `claude \| codex \| pi \| hermes` |
 | `--memory` | local | the memory to read (see below) |
 
+The MCP `recall` tool takes the same parameters and defaults, so an agent can widen a search —
+`half_life: 0` when the answer may be old.
+
 ## Reading turns with `get`
 
 ```bash

--- a/docs/recall.md
+++ b/docs/recall.md
@@ -49,6 +49,26 @@ from. `no results` prints when nothing matched. The exact shape is a contract �
 The MCP `recall` tool takes the same parameters and defaults, so an agent can widen a search —
 `half_life: 0` when the answer may be old.
 
+## Listing sessions
+
+```bash
+funes sessions [--repo <owner/name>] [--since <date>] [--until <date>] [--limit <n>] [--offset <n>] [--memory <label>]
+```
+
+`sessions` lists what a memory holds, oldest first: date, harness, source repo (or the working
+directory when the checkout didn't resolve), turn count, session id, and the prompt the session
+opened with.
+
+| flag | default | effect |
+|---|---|---|
+| `--repo` | — | keep sessions whose checkout resolved to this `owner/name` |
+| `--since` / `--until` | — | keep sessions that started on or after / on or before a `YYYY-MM-DD` |
+| `--limit` | 50 | rows to list, keeping the most recent; capped at 200 |
+| `--offset` | 0 | skip this many of the most recent matches, to walk back in time |
+
+The trailer states the full match count and, when rows are elided, the offset that continues, so a
+listing never drops a session silently. A limit of 0 is an error rather than an empty reply.
+
 ## Reading turns with `get`
 
 ```bash

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -31,10 +31,14 @@ pub struct RecallRequest {
 pub struct GetRequest {
     #[schemars(description = "Session id from a recall hit's `→ get` line")]
     pub session_id: String,
-    #[schemars(description = "Turn uuid from a recall hit's `→ get` line")]
-    pub turn_uuid: String,
-    #[schemars(description = "Turns within this seq window of the target are included (default 3)")]
-    pub window: Option<i64>,
+    #[schemars(
+        description = "First turn to read, as the session's own seq, which a hit's `→ get` line gives you. Defaults to the session's start."
+    )]
+    pub from: Option<i64>,
+    #[schemars(
+        description = "Last turn to read, as the session's own seq. Omit it to read a fixed span from `from`; every reply names the range it covered."
+    )]
+    pub to: Option<i64>,
     #[schemars(
         description = "Memory to read for this call — the one the recall hit's `→ get` line names. Defaults to the server's memory."
     )]
@@ -74,7 +78,7 @@ impl Funes {
     }
 
     #[tool(
-        description = "Recall decisions, rationale, and context from the user's past AI agent sessions. Returns ranked passages with provenance (timestamp, session, block type) plus surrounding neighbor chunks. Each hit carries a `→ get <session_id> <turn_uuid>` line — call `get` with those to read the full surrounding turns. Use when the user references earlier work, or when you lack context that may exist in a prior session. Recall subject-matter, not only decisions: before re-deriving how an API, library, or system behaves — or anything a past session already investigated — query the topic itself; research subagents accumulate exactly these findings and recall surfaces them, often as the top hit, so check before re-investigating from scratch. Also recall before asserting the history of anything — that it was never built, was dropped, is out of scope, or was never discussed; a confident claim about a past decision is the cue you're missing context this holds. To recall from a different memory than the server's default (e.g. a shared `<org>/<repo>` dataset on the HF Hub), pass `memory` — no CLI needed."
+        description = "Recall decisions, rationale, and context from the user's past AI agent sessions. Returns ranked passages with provenance (timestamp, session, block type) plus surrounding neighbor chunks. Each hit carries a `→ get <session_id> --from <seq> --to <seq>` line — call `get` with exactly those to read the full surrounding turns. Use when the user references earlier work, or when you lack context that may exist in a prior session. Recall subject-matter, not only decisions: before re-deriving how an API, library, or system behaves — or anything a past session already investigated — query the topic itself; research subagents accumulate exactly these findings and recall surfaces them, often as the top hit, so check before re-investigating from scratch. Also recall before asserting the history of anything — that it was never built, was dropped, is out of scope, or was never discussed; a confident claim about a past decision is the cue you're missing context this holds. To recall from a different memory than the server's default (e.g. a shared `<org>/<repo>` dataset on the HF Hub), pass `memory` — no CLI needed."
     )]
     async fn recall(
         &self,
@@ -105,18 +109,19 @@ impl Funes {
     }
 
     #[tool(
-        description = "Drill down on a recall hit: fetch the named turn plus the turns within `window` of it, each reassembled into readable text. Pass the `session_id` and `turn_uuid` from a recall hit's `→ get` line — and the `memory` it names."
+        description = "Read a range of one session's turns, each reassembled into readable text. Turns are addressed by `seq`, the session's own dense counter over its turns; a recall hit's `→ get` line carries the session, the range around the hit, and the memory to pass. A session id on its own reads from the start. Every reply closes with the range it covered and the session's size."
     )]
     async fn get(
         &self,
         Parameters(GetRequest {
             session_id,
-            turn_uuid,
-            window,
+            from,
+            to,
             memory,
         }): Parameters<GetRequest>,
     ) -> String {
-        match recall::get(self.memory(memory), session_id, turn_uuid, window.unwrap_or(3)).await {
+        let range = recall::TurnRange { from, to };
+        match recall::get(self.memory(memory), session_id, range).await {
             Ok(s) if !s.is_empty() => s,
             Ok(_) => "no results".to_string(),
             Err(e) => format!("get error: {e}"),

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -15,8 +15,18 @@ use rmcp::{schemars, tool, tool_handler, tool_router, ServerHandler, ServiceExt}
 pub struct RecallRequest {
     #[schemars(description = "Natural-language description of what to recall from past sessions")]
     pub query: String,
-    #[schemars(description = "Number of results to return (default 8)")]
+    #[schemars(description = "Number of results to return")]
     pub k: Option<usize>,
+    #[schemars(
+        description = "Recency half-life in days: a hit that old keeps half its score. Pass 0 to weigh every age alike, for a memory spanning months or an answer that may be old."
+    )]
+    pub half_life: Option<f64>,
+    #[schemars(description = "Adjacent chunks attached to each hit for context; 0 returns the hits alone.")]
+    pub neighbors: Option<i64>,
+    #[schemars(
+        description = "How many fused candidates to rerank. Raise it when a topic is rare and the first pass may not surface it."
+    )]
+    pub candidates: Option<usize>,
     #[schemars(description = "Restrict to a block type: text | thinking | tool_use | tool_result")]
     pub block_type: Option<String>,
     #[schemars(description = "Restrict to a harness: claude | codex | pi | hermes")]
@@ -85,6 +95,9 @@ impl Funes {
         Parameters(RecallRequest {
             query,
             k,
+            half_life,
+            neighbors,
+            candidates,
             block_type,
             harness,
             memory,
@@ -93,10 +106,10 @@ impl Funes {
         match recall::recall(
             self.memory(memory),
             query,
-            k.unwrap_or(8),
-            30,
-            30.0,
-            1,
+            k.unwrap_or(recall::DEFAULT_K),
+            candidates.unwrap_or(recall::DEFAULT_CANDIDATES),
+            half_life.unwrap_or(recall::DEFAULT_HALF_LIFE),
+            neighbors.unwrap_or(recall::DEFAULT_NEIGHBORS),
             block_type,
             harness,
         )

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -56,6 +56,28 @@ pub struct GetRequest {
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct SessionsRequest {
+    #[schemars(description = "Keep only sessions whose checkout resolved to this repo, as `owner/name`")]
+    pub repo: Option<String>,
+    #[schemars(description = "Keep only sessions that started on or after this date, `YYYY-MM-DD`")]
+    pub since: Option<String>,
+    #[schemars(description = "Keep only sessions that started on or before this date, `YYYY-MM-DD`")]
+    pub until: Option<String>,
+    #[schemars(
+        description = "Rows to list, keeping the most recent. More than the maximum cannot fit in one reply — walk with `offset` instead. Zero is an error, not every match."
+    )]
+    pub limit: Option<usize>,
+    #[schemars(
+        description = "Skip this many of the most recent matches before taking `limit`, to walk a listing back through time. The closing line names the offset that continues, and a given offset always names the same session."
+    )]
+    pub offset: Option<usize>,
+    #[schemars(
+        description = "Memory to list — `<org>/<repo>`, an `hf://…` URI, a local path, or `local`. Defaults to the server's memory."
+    )]
+    pub memory: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct StatusRequest {
     #[schemars(
         description = "Memory to inspect — `<org>/<repo>`, an `hf://…` URI, a local path, or `local`. Defaults to the server's memory."
@@ -138,6 +160,34 @@ impl Funes {
             Ok(s) if !s.is_empty() => s,
             Ok(_) => "no results".to_string(),
             Err(e) => format!("get error: {e}"),
+        }
+    }
+
+    #[tool(
+        description = "List a memory's sessions, oldest first: date, harness, source repo (or workdir when the checkout did not resolve), turn count, full session id, and the prompt each session opened with. That prompt says what a session was for without reading any of it. Use it to size a memory, to pick the sessions a criterion is about, or to check whether a session you heard about by id is there at all. Narrow with `repo`, `since` and `until` rather than listing everything; the closing line states the full match count, so an elided row is never silently dropped."
+    )]
+    async fn sessions(
+        &self,
+        Parameters(SessionsRequest {
+            repo,
+            since,
+            until,
+            limit,
+            offset,
+            memory,
+        }): Parameters<SessionsRequest>,
+    ) -> String {
+        let filter = recall::SessionFilter {
+            repo,
+            since,
+            until,
+            limit,
+            offset: offset.unwrap_or(0),
+        };
+        match recall::sessions(self.memory(memory), filter).await {
+            Ok(s) if !s.is_empty() => s,
+            Ok(_) => "no results".to_string(),
+            Err(e) => format!("sessions error: {e}"),
         }
     }
 

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -78,6 +78,30 @@ pub struct SessionsRequest {
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct ScanRequest {
+    #[schemars(
+        description = "The literal string to find. Not regex — a pattern that silently matched nothing would read as a clean result."
+    )]
+    pub needle: String,
+    #[schemars(description = "Session to scan — the id from a `sessions` row or a recall hit's `→ get` line")]
+    pub session_id: String,
+    #[schemars(
+        description = "First turn to scan, as the session's own seq. Omit to start at the session's beginning; pass the seq a capped scan told you to continue from."
+    )]
+    pub from: Option<i64>,
+    #[schemars(description = "Last turn to scan, as the session's own seq. Omit to scan to the end of the session.")]
+    pub to: Option<i64>,
+    #[schemars(description = "Match regardless of case")]
+    pub ignore_case: Option<bool>,
+    #[schemars(description = "Characters of surrounding text shown on each side of a match")]
+    pub context: Option<usize>,
+    #[schemars(
+        description = "Memory to scan — `<org>/<repo>`, an `hf://…` URI, a local path, or `local`. Defaults to the server's memory."
+    )]
+    pub memory: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct StatusRequest {
     #[schemars(
         description = "Memory to inspect — `<org>/<repo>`, an `hf://…` URI, a local path, or `local`. Defaults to the server's memory."
@@ -188,6 +212,38 @@ impl Funes {
             Ok(s) if !s.is_empty() => s,
             Ok(_) => "no results".to_string(),
             Err(e) => format!("sessions error: {e}"),
+        }
+    }
+
+    #[tool(
+        description = "Find a literal string in every block of one session — exhaustive and unranked. Use it to screen a session against a criterion, or to locate where a term you already expect actually occurs. Splits are stitched back together first, so a needle straddling a chunk boundary is still found, and each hit carries a `→ get` line to read the turn around it. Scanning is per session: name the session with `session_id`. A needle that returns nothing is absent from that session and says nothing about any other; absence clears only the exact spelling passed, so use `ignore_case` for case variation. Listing stops at a cap and names the `from` to continue at; `from`/`to` also scan just a stretch of a session, and then a zero clears only that stretch."
+    )]
+    async fn scan(
+        &self,
+        Parameters(ScanRequest {
+            needle,
+            session_id,
+            from,
+            to,
+            ignore_case,
+            context,
+            memory,
+        }): Parameters<ScanRequest>,
+    ) -> String {
+        match recall::scan(
+            self.memory(memory),
+            needle,
+            session_id,
+            from,
+            to,
+            ignore_case.unwrap_or(false),
+            context.unwrap_or(recall::DEFAULT_CONTEXT),
+        )
+        .await
+        {
+            Ok(s) if !s.is_empty() => s,
+            Ok(_) => "no results".to_string(),
+            Err(e) => format!("scan error: {e}"),
         }
     }
 

--- a/src/commands/recall.rs
+++ b/src/commands/recall.rs
@@ -59,6 +59,43 @@ pub struct Hit {
     pub neighbors: Vec<Neighbor>,
 }
 
+/// One session in a memory's listing: when and where it started, how much it holds, and the prompt
+/// it opened with.
+pub struct Session {
+    pub session_id: String,
+    /// First timestamp in the session.
+    pub ts: String,
+    pub workdir: String,
+    pub harness: String,
+    /// The session's source repo(s) as `owner/name`, space-joined; empty when unresolvable.
+    pub repo: String,
+    /// Distinct turns, not rows: chunking is an indexing artifact, and a turn is what `get` reads,
+    /// so this counts (seq, turn_uuid) pairs. A uuid alone would undercount — a compacted
+    /// transcript replays turns under a uuid it has already used.
+    pub turns: usize,
+    /// The opening real prompt, scaffolding skipped — what the session was for, in one line.
+    pub first_prompt: String,
+}
+
+impl Session {
+    /// The `YYYY-MM-DD` the session started.
+    pub fn date(&self) -> &str {
+        self.ts.get(..10).unwrap_or(&self.ts)
+    }
+
+    /// Best available provenance: the repo when the checkout resolved, else the working directory.
+    pub fn origin(&self) -> &str {
+        self.repo.split_whitespace().next().unwrap_or(&self.workdir)
+    }
+}
+
+/// Sessions a listing renders when no limit is given.
+pub const SESSIONS_LIMIT: usize = 50;
+
+/// The most rows one listing will render, whatever `limit` asks for. Past this the reply is larger
+/// than a tool result can carry; `offset` walks the rest.
+pub const SESSIONS_LIMIT_MAX: usize = 200;
+
 /// One reassembled turn from `get`: its blocks in order, splits stitched back together.
 pub struct Turn {
     pub seq: i64,
@@ -419,12 +456,15 @@ async fn fts_candidates(ds: &Dataset, query: &str, limit: usize, filter: Option<
     collect_hits(scan).await
 }
 
-/// Whether the memory carries the `harness` column — false for one built before the facet existed
-/// (an un-migrated memory).
+/// Whether the dataset carries `name`. Projecting a column a memory predates errors, so every
+/// migrated column is asked for before it is read.
+fn has_col(ds: &Dataset, name: &str) -> bool {
+    arrow_schema::Schema::from(ds.schema()).column_with_name(name).is_some()
+}
+
+/// Whether the memory carries the `harness` column — false for one built before the facet existed.
 fn has_harness_col(ds: &Dataset) -> bool {
-    arrow_schema::Schema::from(ds.schema())
-        .column_with_name("harness")
-        .is_some()
+    has_col(ds, "harness")
 }
 
 /// `HIT_COLS`, minus `harness` on an un-migrated memory: projecting a column the dataset lacks errors,
@@ -648,6 +688,185 @@ pub async fn get_turns(memory: Memory, session_id: String, range: TurnRange) -> 
     let to = range.to.unwrap_or(from + DEFAULT_SPAN - 1);
     let kept = rows.iter().filter(|r| r.0 >= from && r.0 <= to);
     Ok((note, turns_from_rows(kept), total))
+}
+
+/// What narrows a listing.
+#[derive(Default)]
+pub struct SessionFilter {
+    /// Keep sessions whose stored repo names this `owner/name`.
+    pub repo: Option<String>,
+    /// Keep sessions that started on or after this `YYYY-MM-DD`.
+    pub since: Option<String>,
+    /// Keep sessions that started on or before this `YYYY-MM-DD`.
+    pub until: Option<String>,
+    /// Rows to render; `None` takes [`SESSIONS_LIMIT`], and anything above [`SESSIONS_LIMIT_MAX`] is
+    /// clamped to it.
+    pub limit: Option<usize>,
+    /// Skip this many of the most recent matches before taking `limit`. Rows are ordered on
+    /// (timestamp, session id), so a given offset always names the same row.
+    pub offset: usize,
+}
+
+impl SessionFilter {
+    /// Whether `s` survives every filter that was given.
+    fn keeps(&self, s: &Session) -> bool {
+        // A session's repo field can name several checkouts; any of them counts. Empty means the
+        // checkout didn't resolve at index time, which no `--repo` can claim.
+        if let Some(repo) = &self.repo {
+            if !s.repo.split_whitespace().any(|i| i == repo) {
+                return false;
+            }
+        }
+        if let Some(since) = &self.since {
+            if s.date() < since.as_str() {
+                return false;
+            }
+        }
+        if let Some(until) = &self.until {
+            if s.date() > until.as_str() {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+/// The sessions of a memory that `filter` keeps, oldest first, rendered in the agent format. The
+/// prompts are read after the filter and the bound, so their cost follows the rows rendered rather
+/// than the size of the memory.
+pub async fn sessions(memory: Memory, filter: SessionFilter) -> Result<String> {
+    // Zero would render nothing, which is never what a caller wants.
+    if filter.limit == Some(0) {
+        bail!("a limit of 0 would list nothing — omit it for {SESSIONS_LIMIT} rows, raise it to at most {SESSIONS_LIMIT_MAX}, and walk the rest with --offset");
+    }
+    let read = open_read(&memory).await?;
+    let note = read.note.clone().unwrap_or_default();
+    let label = read.memory_label.clone().unwrap_or_else(|| memory.label());
+    let all = scan_sessions(&read.ds).await?;
+    if all.is_empty() {
+        return Ok(format!("{note}no sessions in {label}\n"));
+    }
+    let matched: Vec<Session> = all.into_iter().filter(|s| filter.keeps(s)).collect();
+    if matched.is_empty() {
+        return Ok(format!("{note}no session in {label} matches\n"));
+    }
+
+    // Oldest first is the reading order, but a page is taken from the recent end and `offset` walks
+    // back from there.
+    let total = matched.len();
+    let limit = filter.limit.unwrap_or(SESSIONS_LIMIT).min(SESSIONS_LIMIT_MAX);
+    let end = total.saturating_sub(filter.offset);
+    let mut shown: Vec<Session> = matched.into_iter().take(end).skip(end.saturating_sub(limit)).collect();
+    if shown.is_empty() {
+        return Ok(format!(
+            "{note}offset {} is past the {total} session(s) in {label}\n",
+            filter.offset
+        ));
+    }
+    let ids: Vec<String> = shown.iter().map(|s| s.session_id.clone()).collect();
+    let mut prompts = first_prompts(&read.ds, &ids).await?;
+    for s in shown.iter_mut() {
+        s.first_prompt = prompts.remove(&s.session_id).unwrap_or_default();
+    }
+    Ok(crate::ui::render::sessions_agent(&note, &shown, total, filter.offset))
+}
+
+/// The opening real prompt of each session in `ids` — its earliest user text block that isn't
+/// injected scaffolding, collapsed to one line. A session whose user turns are all scaffolding is
+/// absent from the map.
+async fn first_prompts(ds: &Dataset, ids: &[String]) -> Result<HashMap<String, String>> {
+    if ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let list: Vec<String> = ids.iter().map(|id| format!("'{}'", esc(id))).collect();
+    // Split 0 only: `is_scaffolding` reads a block's start, and a later split begins mid-text.
+    let filter = format!(
+        "session_id IN ({}) AND role = 'user' AND block_type = 'text' AND split_idx = 0",
+        list.join(", ")
+    );
+    let cols = ["session_id", "seq", "block_idx", "text"];
+    let batches = dataset::scan_rows(ds, &cols, Some(&filter), None).await?;
+    let mut best: HashMap<String, ((i64, i64), String)> = HashMap::new();
+    for batch in &batches {
+        let (sid, text) = (scol(batch, "session_id"), scol(batch, "text"));
+        let (seq, bi) = (icol(batch, "seq"), icol(batch, "block_idx"));
+        for i in 0..batch.num_rows() {
+            let body = sval(text, i);
+            if crate::commands::curate::is_scaffolding(&body) {
+                continue;
+            }
+            let key = (ival(seq, i), ival(bi, i));
+            match best.entry(sval(sid, i)) {
+                std::collections::hash_map::Entry::Occupied(mut e) if key < e.get().0 => {
+                    e.insert((key, body));
+                }
+                std::collections::hash_map::Entry::Vacant(e) => {
+                    e.insert((key, body));
+                }
+                _ => {}
+            }
+        }
+    }
+    Ok(best.into_iter().map(|(id, (_, text))| (id, text)).collect())
+}
+
+/// Fold every row into its session: earliest timestamp, provenance, and distinct turn count. Reads
+/// metadata only — the opening prompts cost a `text` read, so they are fetched separately.
+async fn scan_sessions(ds: &Dataset) -> Result<Vec<Session>> {
+    let mut cols = vec!["session_id", "ts", "workdir", "turn_uuid", "seq"];
+    if has_harness_col(ds) {
+        cols.push("harness");
+    }
+    if has_col(ds, "repo") {
+        cols.push("repo");
+    }
+    let batches = dataset::scan_rows(ds, &cols, None, None).await?;
+
+    let mut by_id: HashMap<String, (Session, HashSet<(i64, String)>)> = HashMap::new();
+    for batch in &batches {
+        let (sid, ts, wd, turn, harness, repo) = (
+            scol(batch, "session_id"),
+            scol(batch, "ts"),
+            scol(batch, "workdir"),
+            scol(batch, "turn_uuid"),
+            scol(batch, "harness"),
+            scol(batch, "repo"),
+        );
+        let seq = icol(batch, "seq");
+        for i in 0..batch.num_rows() {
+            let id = sval(sid, i);
+            let (session, turns) = by_id.entry(id.clone()).or_insert_with(|| {
+                (
+                    Session {
+                        session_id: id,
+                        ts: sval(ts, i),
+                        workdir: sval(wd, i),
+                        harness: sval(harness, i),
+                        repo: sval(repo, i),
+                        turns: 0,
+                        first_prompt: String::new(),
+                    },
+                    HashSet::new(),
+                )
+            });
+            // Rows arrive in scan order, not time order, so the first one seen isn't the earliest.
+            let row_ts = sval(ts, i);
+            if row_ts < session.ts {
+                session.ts = row_ts;
+            }
+            turns.insert((ival(seq, i), sval(turn, i)));
+        }
+    }
+
+    let mut out: Vec<Session> = by_id
+        .into_values()
+        .map(|(session, turns)| Session {
+            turns: turns.len(),
+            ..session
+        })
+        .collect();
+    out.sort_by(|a, b| (&a.ts, &a.session_id).cmp(&(&b.ts, &b.session_id)));
+    Ok(out)
 }
 
 /// Reassemble rows into turns: group by (seq, turn_uuid), order blocks by (block_idx, split_idx),

--- a/src/commands/recall.rs
+++ b/src/commands/recall.rs
@@ -10,7 +10,7 @@ use crate::inference::{self, Embedder, Reranker};
 use crate::memory::dataset;
 use crate::memory::{Memory, MemoryState};
 use crate::traces::harness::Harness;
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use arrow_array::{Float32Array, Int64Array, RecordBatch, StringArray, UInt64Array};
 use chrono::{DateTime, Utc};
 use futures::TryStreamExt;
@@ -567,25 +567,39 @@ async fn attach_neighbors(ds: &Dataset, hits: &mut [&mut Hit], window: i64) -> R
     Ok(())
 }
 
-/// Drill down on a recall hit: the named turn plus the turns within `window` of it, rendered in
-/// the agent format.
-pub async fn get(memory: Memory, session_id: String, turn_uuid: String, window: i64) -> Result<String> {
-    let (note, turns) = get_turns(memory, session_id.clone(), turn_uuid.clone(), window).await?;
-    if turns.is_empty() {
-        return Ok(format!("{note}turn {turn_uuid} not found in session {session_id}\n"));
-    }
-    Ok(crate::ui::render::get_agent(&note, &turns))
+/// Which turns of a session to read, as a `seq` range: `seq` is the session's own dense counter over
+/// its turns, so a range is turns n through m.
+#[derive(Default)]
+pub struct TurnRange {
+    /// First seq to read. Defaults to the session's start.
+    pub from: Option<i64>,
+    /// Last seq to read. Defaults to [`DEFAULT_SPAN`] turns from `from`.
+    pub to: Option<i64>,
 }
 
-/// The turns behind `get`: the named one plus those within `window` of it, each reassembled
-/// (blocks in order, splits de-overlapped). Returns the degradation note and the turns — empty
-/// when the turn isn't in the session; rendering is the caller's choice.
-pub async fn get_turns(
-    memory: Memory,
-    session_id: String,
-    turn_uuid: String,
-    window: i64,
-) -> Result<(String, Vec<Turn>)> {
+/// Turns a read covers when only a start is given. The CLI and the MCP server defer to it rather
+/// than carrying a default of their own.
+pub const DEFAULT_SPAN: i64 = 20;
+
+/// Read a range of a session's turns, rendered in the agent format.
+pub async fn get(memory: Memory, session_id: String, range: TurnRange) -> Result<String> {
+    let label = memory.label();
+    let (note, turns, total) = get_turns(memory, session_id.clone(), range).await?;
+    // A session with no rows is absent, not empty: only a range can come back empty.
+    if total == 0 {
+        bail!("no session {session_id} in {label}");
+    }
+    if turns.is_empty() {
+        return Ok(format!(
+            "{note}no turns in that range of session {session_id} (it holds {total})\n"
+        ));
+    }
+    Ok(crate::ui::render::get_agent(&note, &turns, total))
+}
+
+/// The turns behind `get`, each reassembled (blocks in order, splits de-overlapped). Returns the
+/// degradation note, the turns — empty when the range holds none — and the session's turn count.
+pub async fn get_turns(memory: Memory, session_id: String, range: TurnRange) -> Result<(String, Vec<Turn>, usize)> {
     let read = open_read(&memory).await?;
     let note = read.note.clone().unwrap_or_default();
     let ds = &read.ds;
@@ -621,14 +635,13 @@ pub async fn get_turns(
         }
     }
 
-    let center = match rows.iter().find(|r| r.1 == turn_uuid) {
-        Some(r) => r.0,
-        None => return Ok((note, Vec::new())),
-    };
-    Ok((
-        note,
-        turns_from_rows(rows.iter().filter(|r| (r.0 - center).abs() <= window)),
-    ))
+    let total = rows.iter().map(|r| (r.0, &r.1)).collect::<HashSet<_>>().len();
+    let from = range
+        .from
+        .unwrap_or_else(|| rows.iter().map(|r| r.0).min().unwrap_or(0));
+    let to = range.to.unwrap_or(from + DEFAULT_SPAN - 1);
+    let kept = rows.iter().filter(|r| r.0 >= from && r.0 <= to);
+    Ok((note, turns_from_rows(kept), total))
 }
 
 /// Reassemble rows into turns: group by (seq, turn_uuid), order blocks by (block_idx, split_idx),

--- a/src/commands/recall.rs
+++ b/src/commands/recall.rs
@@ -243,6 +243,12 @@ async fn models() -> Result<&'static Mutex<Models>> {
         .await
 }
 
+/// A recall's defaults, owned here so the CLI and the MCP server search the same way.
+pub const DEFAULT_K: usize = 8;
+pub const DEFAULT_CANDIDATES: usize = 30;
+pub const DEFAULT_HALF_LIFE: f64 = 30.0;
+pub const DEFAULT_NEIGHBORS: i64 = 1;
+
 /// Run the recall pipeline over one memory and return the results rendered in the agent format.
 #[allow(clippy::too_many_arguments)]
 pub async fn recall(

--- a/src/commands/recall.rs
+++ b/src/commands/recall.rs
@@ -59,6 +59,51 @@ pub struct Hit {
     pub neighbors: Vec<Neighbor>,
 }
 
+/// Matching blocks `scan` lists before it stops. What the cap dropped is always reported.
+const SCAN_HIT_CAP: usize = 200;
+
+/// Characters of surrounding text a `scan` hit shows on each side of its match.
+pub const DEFAULT_CONTEXT: usize = 100;
+
+/// Why a `scan` listing stopped short, and what the caller can do about it.
+pub enum ScanCut {
+    /// Hits remain from this turn onward; a continuing scan starts exactly there. The page was cut
+    /// back to a turn boundary so that resuming neither repeats a hit nor skips one.
+    Resume(i64),
+    /// This one turn holds more matches than the cap by itself, so paging cannot step over it.
+    Crowded(i64),
+}
+
+/// One block of a session carrying a `scan` needle.
+pub struct ScanHit {
+    pub turn_uuid: String,
+    pub ts: String,
+    pub block_type: String,
+    pub seq: i64,
+    /// Byte offset of the match within `text`.
+    pub at: usize,
+    /// Chars the match spans — its own length, which case folding leaves unchanged.
+    pub len: usize,
+    /// The whole reassembled block, for the caller to excerpt around `at`.
+    pub text: String,
+}
+
+/// What a `scan` needle found in one session, or in the window of it that was scanned.
+pub struct ScanResult {
+    pub needle: String,
+    pub session_id: String,
+    /// Matching blocks in reading order, capped at [`SCAN_HIT_CAP`].
+    pub hits: Vec<ScanHit>,
+    /// Matching blocks past the cap, absent from `hits`.
+    pub dropped: usize,
+    /// Why the listing stopped, when it did.
+    pub cut: Option<ScanCut>,
+    /// The seq window scanned, when one was asked for. A zero over a window clears the window, not
+    /// the session, so the window rides with the result.
+    pub from: Option<i64>,
+    pub to: Option<i64>,
+}
+
 /// One session in a memory's listing: when and where it started, how much it holds, and the prompt
 /// it opened with.
 pub struct Session {
@@ -867,6 +912,213 @@ async fn scan_sessions(ds: &Dataset) -> Result<Vec<Session>> {
         .collect();
     out.sort_by(|a, b| (&a.ts, &a.session_id).cmp(&(&b.ts, &b.session_id)));
     Ok(out)
+}
+
+/// One block of a memory, its splits stitched back together, with the facets a `scan` hit prints.
+struct Block {
+    turn_uuid: String,
+    ts: String,
+    block_type: String,
+    seq: i64,
+    block_idx: i64,
+    text: String,
+}
+
+/// Blocks under assembly, keyed by (seq, turn_uuid, block_idx): each one's facets, and the split
+/// rows still to be stitched into its `text`. The seq is part of the key because a turn uuid can
+/// recur at different positions in a session — a compacted transcript replays turns — so two blocks
+/// that merely share a uuid are two blocks, not one.
+type BlockParts = HashMap<(i64, String, i64), (Block, Vec<(i64, String)>)>;
+
+/// Find `needle` in every block of one session, rendered in the agent format. Literal, never a
+/// pattern: a regex that silently matched nothing would read as a clearance.
+///
+/// A session that isn't in the memory is an error, not an empty result.
+pub async fn scan(
+    memory: Memory,
+    needle: String,
+    session_id: String,
+    from: Option<i64>,
+    to: Option<i64>,
+    ignore_case: bool,
+    context: usize,
+) -> Result<String> {
+    let read = open_read(&memory).await?;
+    let note = read.note.clone().unwrap_or_default();
+    let label = read.memory_label.clone().unwrap_or_else(|| memory.label());
+    let blocks = reassembled_blocks(&read.ds, &session_id, from, to).await?;
+    if blocks.is_empty() {
+        // A window that holds nothing is not the same as a session that isn't there: only the
+        // unwindowed case can conclude the session is absent.
+        if from.is_some() || to.is_some() {
+            let scanned = reassembled_blocks(&read.ds, &session_id, None, None).await?;
+            if !scanned.is_empty() {
+                return Ok(format!(
+                    "{note}no turns in that range of session {session_id} (it holds {})\n",
+                    scanned.iter().map(|b| b.seq).collect::<HashSet<_>>().len()
+                ));
+            }
+        }
+        bail!("no session {session_id} in {label}");
+    }
+    let result = find_needle(&blocks, &needle, &session_id, from, to, ignore_case);
+    Ok(crate::ui::render::scan_agent(
+        &note,
+        &memory_hint(read.memory_label.as_deref()),
+        &result,
+        context,
+    ))
+}
+
+/// Every block of one session, splits de-overlapped. Matching raw chunks would miss a needle that
+/// straddles a split boundary, so the session's rows are bucketed by block before anything is
+/// matched. Ordered by position in the session. Empty when the session isn't in the memory.
+async fn reassembled_blocks(ds: &Dataset, session_id: &str, from: Option<i64>, to: Option<i64>) -> Result<Vec<Block>> {
+    let cols = ["turn_uuid", "seq", "ts", "block_type", "block_idx", "split_idx", "text"];
+    let mut filter = format!("session_id = '{}'", esc(session_id));
+    if let Some(from) = from {
+        filter.push_str(&format!(" AND seq >= {from}"));
+    }
+    if let Some(to) = to {
+        filter.push_str(&format!(" AND seq <= {to}"));
+    }
+    let batches = dataset::scan_rows(ds, &cols, Some(filter.as_str()), None).await?;
+
+    // Splits of one block can land in different batches, so every row is bucketed before any of it
+    // is stitched.
+    let mut blocks: BlockParts = HashMap::new();
+    for batch in &batches {
+        let (turn, ts, bt, text) = (
+            scol(batch, "turn_uuid"),
+            scol(batch, "ts"),
+            scol(batch, "block_type"),
+            scol(batch, "text"),
+        );
+        let (seq, bi, si) = (icol(batch, "seq"), icol(batch, "block_idx"), icol(batch, "split_idx"));
+        for i in 0..batch.num_rows() {
+            let key = (ival(seq, i), sval(turn, i), ival(bi, i));
+            let entry = blocks.entry(key).or_insert_with(|| {
+                (
+                    Block {
+                        turn_uuid: sval(turn, i),
+                        ts: sval(ts, i),
+                        block_type: sval(bt, i),
+                        seq: ival(seq, i),
+                        block_idx: ival(bi, i),
+                        text: String::new(),
+                    },
+                    Vec::new(),
+                )
+            });
+            entry.1.push((ival(si, i), sval(text, i)));
+        }
+    }
+    drop(batches);
+
+    let mut out: Vec<Block> = blocks
+        .into_values()
+        .map(|(mut block, mut splits)| {
+            splits.sort_by_key(|(si, _)| *si);
+            let mut pieces = splits.into_iter().map(|(_, t)| t);
+            block.text = pieces.next().unwrap_or_default();
+            for piece in pieces {
+                block.text = chunk::stitch(&block.text, &piece);
+            }
+            block
+        })
+        .collect();
+    out.sort_by_key(|b| (b.seq, b.block_idx));
+    Ok(out)
+}
+
+/// Every block of the scanned window carrying `needle`, in reading order, capped at
+/// [`SCAN_HIT_CAP`] — with the coordinate a continuing scan resumes from when the cap bites.
+fn find_needle(
+    blocks: &[Block],
+    needle: &str,
+    session_id: &str,
+    from: Option<i64>,
+    to: Option<i64>,
+    ignore_case: bool,
+) -> ScanResult {
+    let folded: Vec<char> = if ignore_case {
+        needle.chars().map(fold).collect()
+    } else {
+        Vec::new()
+    };
+    let mut hits: Vec<ScanHit> = Vec::new();
+    for b in blocks {
+        let at = if ignore_case {
+            find_folded(&b.text, &folded)
+        } else {
+            b.text.find(needle)
+        };
+        let Some(at) = at else { continue };
+        hits.push(ScanHit {
+            turn_uuid: b.turn_uuid.clone(),
+            ts: b.ts.clone(),
+            block_type: b.block_type.clone(),
+            seq: b.seq,
+            at,
+            len: needle.chars().count(),
+            text: b.text.clone(),
+        });
+    }
+
+    // Cut at a turn boundary. Hits are in reading order, so dropping the trailing hits that share
+    // the first dropped hit's turn leaves a page a caller can continue from exactly: everything
+    // rendered lies before that turn.
+    let found = hits.len();
+    let cut = hits.get(SCAN_HIT_CAP).map(|h| h.seq).map(|boundary| {
+        match hits[..SCAN_HIT_CAP].iter().rposition(|h| h.seq < boundary) {
+            Some(last) => {
+                hits.truncate(last + 1);
+                ScanCut::Resume(boundary)
+            }
+            // The cap falls inside a single turn's own matches: no boundary to cut at.
+            None => {
+                hits.truncate(SCAN_HIT_CAP);
+                ScanCut::Crowded(boundary)
+            }
+        }
+    });
+    ScanResult {
+        needle: needle.to_string(),
+        session_id: session_id.to_string(),
+        dropped: found - hits.len(),
+        hits,
+        cut,
+        from,
+        to,
+    }
+}
+
+/// Byte offset of the first case-folded occurrence of `needle` (already folded) in `text`. Folding
+/// is per char, so the offset stays an offset into the original.
+fn find_folded(text: &str, needle: &[char]) -> Option<usize> {
+    if needle.is_empty() {
+        return None;
+    }
+    let hay: Vec<(usize, char)> = text.char_indices().collect();
+    if hay.len() < needle.len() {
+        return None;
+    }
+    hay.windows(needle.len()).find_map(|w| {
+        w.iter()
+            .zip(needle)
+            .all(|(&(_, c), &want)| fold(c) == want)
+            .then_some(w[0].0)
+    })
+}
+
+/// Lowercase `c` when that is a single char. One whose lowercase is several (`İ`) stays as it is and
+/// simply won't fold-match.
+fn fold(c: char) -> char {
+    let mut it = c.to_lowercase();
+    match (it.next(), it.next()) {
+        (Some(one), None) => one,
+        _ => c,
+    }
 }
 
 /// Reassemble rows into turns: group by (seq, turn_uuid), order blocks by (block_idx, split_idx),

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,16 +34,16 @@ enum Cmd {
         #[arg(required = true, num_args = 1..)]
         query: Vec<String>,
         /// How many results to show.
-        #[arg(short, long, default_value_t = 8)]
+        #[arg(short, long, default_value_t = recall::DEFAULT_K)]
         k: usize,
         /// How many fused candidates to rerank.
-        #[arg(long, default_value_t = 30)]
+        #[arg(long, default_value_t = recall::DEFAULT_CANDIDATES)]
         candidates: usize,
         /// Recency half-life in days (a hit this old keeps half its weight). 0 disables.
-        #[arg(long, default_value_t = 30.0)]
+        #[arg(long, default_value_t = recall::DEFAULT_HALF_LIFE)]
         half_life: f64,
         /// Adjacent chunks (within this seq window) to attach to each hit. 0 disables.
-        #[arg(long, default_value_t = 1)]
+        #[arg(long, default_value_t = recall::DEFAULT_NEIGHBORS)]
         neighbors: i64,
         /// Restrict to a block type: text | thinking | tool_use | tool_result.
         #[arg(long = "type", value_name = "BLOCK_TYPE")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,6 +101,25 @@ enum Cmd {
         #[arg(long)]
         yes: bool,
     },
+    /// List a memory's sessions, oldest first.
+    Sessions {
+        /// Keep only sessions whose checkout resolved to this repo (`owner/name`).
+        #[arg(long, value_name = "OWNER/NAME")]
+        repo: Option<String>,
+        /// Keep only sessions that started on or after this date (`YYYY-MM-DD`).
+        #[arg(long, value_name = "DATE")]
+        since: Option<String>,
+        /// Keep only sessions that started on or before this date (`YYYY-MM-DD`).
+        #[arg(long, value_name = "DATE")]
+        until: Option<String>,
+        #[arg(long, value_name = "N", help = format!("Rows to list, keeping the most recent. Defaults to {}, capped at {} — walk with --offset for more. Zero is an error.", recall::SESSIONS_LIMIT, recall::SESSIONS_LIMIT_MAX))]
+        limit: Option<usize>,
+        /// Skip this many of the most recent matches before taking --limit, to walk back in time.
+        #[arg(long, value_name = "N", default_value_t = 0)]
+        offset: usize,
+        #[command(flatten)]
+        memory: MemoryOpts,
+    },
     /// Show index statistics.
     Status {
         /// Memory to inspect — an `<org>/<repo>` shorthand, an `hf://…` URI, a local path, or
@@ -318,6 +337,24 @@ async fn main() -> Result<()> {
                     render::recall_agent(&note, &recall::memory_hint(memory_label.as_deref()), &hits)
                 );
             }
+            Ok(())
+        }
+        Cmd::Sessions {
+            repo,
+            since,
+            until,
+            limit,
+            offset,
+            memory,
+        } => {
+            let filter = recall::SessionFilter {
+                repo,
+                since,
+                until,
+                limit,
+                offset,
+            };
+            print!("{}", recall::sessions(memory.resolve(), filter).await?);
             Ok(())
         }
         Cmd::Get {

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,14 +13,11 @@ use funes::traces::harness::Harness;
 use funes::ui::render;
 
 use anyhow::{anyhow, Context, Result};
-use clap::{Args, Parser, Subcommand, ValueEnum};
+use clap::{Args, Parser, Subcommand};
 use std::io::{IsTerminal, Write};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-
-/// Turns around a `get` target when no window is given.
-const DEFAULT_WINDOW: i64 = 3;
 
 #[derive(Parser)]
 #[command(name = "funes", version, about = "Recall over your past AI agent sessions.")]
@@ -57,21 +54,15 @@ enum Cmd {
         #[command(flatten)]
         memory: MemoryOpts,
     },
-    /// Drill down on a recall hit: a turn plus the turns around it, reassembled.
+    /// Read a range of a session's turns, addressed by the session's own seq.
     Get {
         /// Session id (from a recall hit's `→ get` line).
         session_id: String,
-        /// Turn uuid (from a recall hit's `→ get` line).
-        turn_uuid: String,
-        /// Turns within this seq window of the target are included.
-        #[arg(long, default_value_t = DEFAULT_WINDOW)]
-        window: i64,
-        /// Output format. Default: human in a terminal, agent when piped.
-        #[arg(long, value_enum)]
-        format: Option<OutputFormat>,
-        /// Highlight this text in the human rendering (matched whitespace-insensitively).
-        #[arg(long)]
-        highlight: Option<String>,
+        /// First turn to read, as the session's own seq. Defaults to the session's start.
+        #[arg(long, value_name = "SEQ")]
+        from: Option<i64>,
+        #[arg(long, value_name = "SEQ", help = format!("Last turn to read, as the session's own seq. Defaults to {} turns from --from.", recall::DEFAULT_SPAN))]
+        to: Option<i64>,
         #[command(flatten)]
         memory: MemoryOpts,
     },
@@ -281,29 +272,6 @@ impl MemoryOpts {
     }
 }
 
-/// The two output layouts for `get`.
-#[derive(Clone, Copy, ValueEnum)]
-enum OutputFormat {
-    /// A numbered list with a hit selector.
-    Human,
-    /// The stable agent layout: multi-line hits with provenance, previews, and neighbors.
-    Agent,
-}
-
-impl OutputFormat {
-    /// Resolve the effective format: an explicit flag wins; otherwise human when both stdin and
-    /// stdout are terminals (the hit selector needs both), agent when piped or scripted.
-    fn resolve(flag: Option<OutputFormat>) -> OutputFormat {
-        flag.unwrap_or_else(|| {
-            if std::io::stdin().is_terminal() && std::io::stdout().is_terminal() {
-                OutputFormat::Human
-            } else {
-                OutputFormat::Agent
-            }
-        })
-    }
-}
-
 /// Color and width for the human renderings: color needs a terminal and no `NO_COLOR`; width
 /// follows `$COLUMNS` when exported, else 100.
 fn human_io() -> (bool, usize) {
@@ -354,27 +322,12 @@ async fn main() -> Result<()> {
         }
         Cmd::Get {
             session_id,
-            turn_uuid,
-            window,
-            format,
-            highlight,
+            from,
+            to,
             memory,
         } => {
-            let format = OutputFormat::resolve(format);
-            let (note, turns) =
-                recall::get_turns(memory.resolve(), session_id.clone(), turn_uuid.clone(), window).await?;
-            if turns.is_empty() {
-                print!("{note}");
-                println!("turn {turn_uuid} not found in session {session_id}");
-            } else if matches!(format, OutputFormat::Human) {
-                let (color, width) = human_io();
-                print!(
-                    "{}",
-                    render::get_human(&note, &turns, color, width, highlight.as_deref())
-                );
-            } else {
-                print!("{}", render::get_agent(&note, &turns));
-            }
+            let range = recall::TurnRange { from, to };
+            print!("{}", recall::get(memory.resolve(), session_id, range).await?);
             Ok(())
         }
         Cmd::Ask { agent } => match agent {

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,6 +101,29 @@ enum Cmd {
         #[arg(long)]
         yes: bool,
     },
+    /// Find a literal string everywhere in one session — exhaustive, unranked.
+    Scan {
+        /// The literal to find. Not a regex.
+        #[arg(value_name = "NEEDLE")]
+        needle: String,
+        /// The session to scan (from a `sessions` row or a recall hit's `→ get` line).
+        #[arg(value_name = "SESSION_ID")]
+        session_id: String,
+        /// First turn to scan, as the session's own seq. Defaults to the session's start.
+        #[arg(long, value_name = "SEQ")]
+        from: Option<i64>,
+        /// Last turn to scan, as the session's own seq. Defaults to the session's end.
+        #[arg(long, value_name = "SEQ")]
+        to: Option<i64>,
+        /// Match regardless of case.
+        #[arg(short, long)]
+        ignore_case: bool,
+        /// Characters of surrounding text to show on each side of a match.
+        #[arg(long, default_value_t = recall::DEFAULT_CONTEXT)]
+        context: usize,
+        #[command(flatten)]
+        memory: MemoryOpts,
+    },
     /// List a memory's sessions, oldest first.
     Sessions {
         /// Keep only sessions whose checkout resolved to this repo (`owner/name`).
@@ -337,6 +360,21 @@ async fn main() -> Result<()> {
                     render::recall_agent(&note, &recall::memory_hint(memory_label.as_deref()), &hits)
                 );
             }
+            Ok(())
+        }
+        Cmd::Scan {
+            needle,
+            session_id,
+            from,
+            to,
+            ignore_case,
+            context,
+            memory,
+        } => {
+            print!(
+                "{}",
+                recall::scan(memory.resolve(), needle, session_id, from, to, ignore_case, context).await?
+            );
             Ok(())
         }
         Cmd::Sessions {

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -5,7 +5,7 @@
 //! a terminal: tool chunks compressed to a deterministic one-liner, prose wrapped, marks
 //! highlighted.
 
-use crate::commands::recall::{Hit, Turn};
+use crate::commands::recall::{Hit, Session, Turn};
 use std::fmt::Write as _;
 
 /// Turns each side of a hit that a `→ get` line reaches for.
@@ -43,6 +43,67 @@ pub fn recall_agent(note: &str, memory_arg: &str, hits: &[(Hit, f64)]) -> String
             let _ = writeln!(out, "  ~ [{} {} seq{}] {}", n.role, n.block_type, n.seq, np);
         }
         let _ = writeln!(out, "---");
+    }
+    out
+}
+
+/// Characters of a session's opening prompt a listing shows.
+const PROMPT_CHARS: usize = 120;
+
+/// Characters a `sessions` listing renders. A row renders whole, so a listing bounded by `limit`
+/// can still stop short of it.
+const SESSIONS_BUDGET: usize = 40_000;
+
+/// `s` collapsed onto one line and cut to `max` chars, `…` marking the cut.
+fn one_line(s: &str, max: usize) -> String {
+    let flat = s.split_whitespace().collect::<Vec<_>>().join(" ");
+    match flat.char_indices().nth(max) {
+        Some((i, _)) => format!("{}…", &flat[..i]),
+        None => flat,
+    }
+}
+
+/// The agent `sessions` format: a row per session, oldest first, each carrying the prompt it opened
+/// with on an indented second line, closed by the total. The session id is printed whole — it is the
+/// payload here, not a pointer into a hint line. `total` is every session the filter matched and
+/// `offset` where this page started, so the trailer can name the offset that continues.
+/// Byte-stable.
+pub fn sessions_agent(note: &str, sessions: &[Session], total: usize, offset: usize) -> String {
+    let mut out = note.to_string();
+    let mut shown = 0;
+    for s in sessions {
+        let mut row = String::new();
+        let _ = writeln!(
+            row,
+            "[{}] {} {} {} turns {}",
+            s.date(),
+            s.harness,
+            s.origin(),
+            s.turns,
+            s.session_id
+        );
+        if !s.first_prompt.is_empty() {
+            let _ = writeln!(row, "  {}", one_line(&s.first_prompt, PROMPT_CHARS));
+        }
+        if shown > 0 && out.len() + row.len() > SESSIONS_BUDGET {
+            break;
+        }
+        out.push_str(&row);
+        shown += 1;
+    }
+    // What is left is older than this page: `offset + shown` names the row it starts at, and the
+    // ordering is total, so that offset is the same row on every call.
+    let remaining = total.saturating_sub(offset + shown);
+    if remaining == 0 && offset == 0 {
+        let _ = writeln!(out, "---\n{total} sessions");
+    } else if remaining == 0 {
+        let _ = writeln!(out, "---\n{shown} of {total} sessions — the oldest match reached");
+    } else {
+        let _ = writeln!(
+            out,
+            "---\n{shown} of {total} sessions — {remaining} older: continue with --offset {}, or narrow with --repo/--since/--until",
+            offset + shown
+        );
     }
     out
 }

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -136,8 +136,11 @@ fn one_line(s: &str, max: usize) -> String {
 /// Byte-stable.
 pub fn sessions_agent(note: &str, sessions: &[Session], total: usize, offset: usize) -> String {
     let mut out = note.to_string();
-    let mut shown = 0;
-    for s in sessions {
+    // `offset` walks back from the recent end, so a budget cut has to keep that same end of the page:
+    // take the newest rows that fit, then print them back in reading order.
+    let mut budget = SESSIONS_BUDGET.saturating_sub(out.len());
+    let mut rows = Vec::new();
+    for s in sessions.iter().rev() {
         let mut row = String::new();
         let _ = writeln!(
             row,
@@ -151,12 +154,14 @@ pub fn sessions_agent(note: &str, sessions: &[Session], total: usize, offset: us
         if !s.first_prompt.is_empty() {
             let _ = writeln!(row, "  {}", one_line(&s.first_prompt, PROMPT_CHARS));
         }
-        if shown > 0 && out.len() + row.len() > SESSIONS_BUDGET {
+        if !rows.is_empty() && row.len() > budget {
             break;
         }
-        out.push_str(&row);
-        shown += 1;
+        budget = budget.saturating_sub(row.len());
+        rows.push(row);
     }
+    let shown = rows.len();
+    out.extend(rows.into_iter().rev());
     // What is left is older than this page: `offset + shown` names the row it starts at, and the
     // ordering is total, so that offset is the same row on every call.
     let remaining = total.saturating_sub(offset + shown);
@@ -712,6 +717,45 @@ mod tests {
             "got: {}",
             &out[out.len() - 60..]
         );
+    }
+
+    fn session_at(i: usize) -> Session {
+        Session {
+            session_id: format!("session-{i:03}"),
+            ts: "2026-06-19T01:29:59.000Z".to_string(),
+            workdir: "/home/u/funes".to_string(),
+            harness: "codex".to_string(),
+            repo: format!("owner/{}", "r".repeat(100)),
+            turns: 1,
+            first_prompt: "x".repeat(PROMPT_CHARS * 2),
+        }
+    }
+
+    fn listed_session_ids(out: &str) -> Vec<usize> {
+        out.lines()
+            .filter(|line| line.starts_with('['))
+            .map(|line| line.rsplit_once("session-").unwrap().1.parse().unwrap())
+            .collect()
+    }
+
+    #[test]
+    fn sessions_agent_budget_keeps_the_recent_end_of_a_page() {
+        let sessions: Vec<Session> = (0..250).map(session_at).collect();
+        let page = |offset: usize| {
+            let end = sessions.len().saturating_sub(offset);
+            &sessions[end.saturating_sub(200)..end]
+        };
+
+        let first = listed_session_ids(&sessions_agent("", page(0), sessions.len(), 0));
+        assert!(first.len() < page(0).len(), "the fixture must cross the byte budget");
+        assert_eq!(first.last(), Some(&249), "a cut must retain the newest session");
+
+        let second = listed_session_ids(&sessions_agent("", page(first.len()), sessions.len(), first.len()));
+        assert!(
+            first.iter().all(|id| !second.contains(id)),
+            "successive pages must not overlap: {first:?} then {second:?}"
+        );
+        assert_eq!(second.last().map(|id| id + 1), first.first().copied());
     }
 
     #[test]

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -8,6 +8,14 @@
 use crate::commands::recall::{Hit, Turn};
 use std::fmt::Write as _;
 
+/// Turns each side of a hit that a `→ get` line reaches for.
+const HINT_WINDOW: i64 = 3;
+
+/// The `--from a --to b` a `→ get` line carries for a hit at `seq`, clamped at the session's start.
+fn hint_range(seq: i64) -> String {
+    format!(" --from {} --to {}", (seq - HINT_WINDOW).max(0), seq + HINT_WINDOW)
+}
+
 /// Longest scent ever built — beyond any line budget, so final truncation is [`ellipsize`]'s job.
 const SCENT_CAP: usize = 240;
 
@@ -28,7 +36,7 @@ pub fn recall_agent(note: &str, memory_arg: &str, hits: &[(Hit, f64)]) -> String
             "[{}] {} {}/{} {}  score={:.3}",
             h.ts, h.harness, h.workdir, s8, h.block_type, score
         );
-        let _ = writeln!(out, "  → get {} {}{}", h.session_id, h.turn_uuid, memory_arg);
+        let _ = writeln!(out, "  → get {}{}{}", h.session_id, hint_range(h.seq), memory_arg);
         let _ = writeln!(out, "{}", h.text);
         for n in &h.neighbors {
             let np: String = n.text.chars().take(160).collect();
@@ -39,13 +47,39 @@ pub fn recall_agent(note: &str, memory_arg: &str, hits: &[(Hit, f64)]) -> String
     out
 }
 
-/// The agent `get` format: `[ts] role seqN turn=…` headers over reassembled blocks. Byte-stable.
-pub fn get_agent(note: &str, turns: &[Turn]) -> String {
+/// Characters a `get` renders. A turn renders whole, so a single turn larger than this is the one
+/// thing that can exceed it.
+const GET_BUDGET: usize = 40_000;
+
+/// The agent `get` format: `[ts] role seqN turn=…` headers over reassembled blocks, closed by the
+/// range read and the session's size. Byte-stable.
+pub fn get_agent(note: &str, turns: &[Turn], total: usize) -> String {
     let mut out = note.to_string();
+    if turns.is_empty() {
+        return out;
+    }
+    let mut shown = 0;
     for t in turns {
-        let _ = writeln!(out, "[{}] {} seq{} turn={}", t.ts, t.role, t.seq, t.turn_uuid);
-        let _ = writeln!(out, "{}", t.blocks.join("\n\n"));
-        let _ = writeln!(out, "---");
+        let mut turn = String::new();
+        let _ = writeln!(turn, "[{}] {} seq{} turn={}", t.ts, t.role, t.seq, t.turn_uuid);
+        let _ = writeln!(turn, "{}", t.blocks.join("\n\n"));
+        let _ = writeln!(turn, "---");
+        // The first turn renders whatever it weighs; after that, only turns that fit.
+        if shown > 0 && out.len() + turn.len() > GET_BUDGET {
+            break;
+        }
+        out.push_str(&turn);
+        shown += 1;
+    }
+    let (first, last) = (turns[0].seq, turns[shown - 1].seq);
+    let _ = writeln!(out, "turns {first}-{last} of {total}");
+    if shown < turns.len() {
+        let _ = writeln!(
+            out,
+            "{} more turn(s) in range not shown — read them with --from {}",
+            turns.len() - shown,
+            last + 1
+        );
     }
     out
 }
@@ -402,14 +436,25 @@ mod tests {
         assert_eq!(
             out,
             "[2026-06-19T01:29:59.000Z] claude_code -home-u-funes/01234567 text  score=0.578\n\
-             \x20 → get 0123456789abcdef aaaa-bbbb --memory hf://datasets/acme/kb\n\
+             \x20 → get 0123456789abcdef --from 4 --to 10 --memory hf://datasets/acme/kb\n\
              the decision was made\n\
              \x20 ~ [assistant text seq5] hello\n\
              ---\n"
         );
         // The built-in guide has no memory to name: an empty suffix keeps the hint bare.
         let bare = recall_agent("", "", &[(hit("2026-06-19T01:29:59.000Z", "text", "x"), 0.5)]);
-        assert!(bare.contains("  → get 0123456789abcdef aaaa-bbbb\n"), "got: {bare}");
+        assert!(
+            bare.contains("  → get 0123456789abcdef --from 4 --to 10\n"),
+            "got: {bare}"
+        );
+    }
+
+    #[test]
+    fn a_hint_range_never_reaches_before_the_session() {
+        // seq 0 has no turns behind it; the hint must stay runnable rather than ask for -3.
+        assert_eq!(hint_range(0), " --from 0 --to 3");
+        assert_eq!(hint_range(2), " --from 0 --to 5");
+        assert_eq!(hint_range(9), " --from 6 --to 12");
     }
 
     #[test]
@@ -472,8 +517,65 @@ mod tests {
             blocks: vec!["first".to_string(), "second".to_string()],
         };
         assert_eq!(
-            get_agent("", &[t]),
-            "[2026-06-19T01:29:59.000Z] assistant seq3 turn=t-1\nfirst\n\nsecond\n---\n"
+            get_agent("", &[t], 70),
+            "[2026-06-19T01:29:59.000Z] assistant seq3 turn=t-1\nfirst\n\nsecond\n---\n\
+             turns 3-3 of 70\n"
+        );
+    }
+
+    fn turn_at(seq: i64, body: &str) -> Turn {
+        Turn {
+            seq,
+            turn_uuid: format!("t-{seq}"),
+            ts: "2026-06-19T01:29:59.000Z".to_string(),
+            role: "assistant".to_string(),
+            blocks: vec![body.to_string()],
+        }
+    }
+
+    #[test]
+    fn get_agent_leaves_a_turn_that_does_not_fit() {
+        // The range is bounded by rendered bytes, not by a turn count: two of these cannot both
+        // fit, so the second is left for the next read with the coordinate to ask for it.
+        let big = "x".repeat(GET_BUDGET * 3 / 4);
+        let turns: Vec<Turn> = (0..3).map(|i| turn_at(i, &big)).collect();
+        let out = get_agent("", &turns, 100);
+        assert!(
+            out.len() <= GET_BUDGET,
+            "a read of fitting turns stays inside: {}",
+            out.len()
+        );
+        assert!(
+            out.contains("\nturns 0-0 of 100\n"),
+            "states what it read: {}",
+            &out[out.len() - 120..]
+        );
+        assert!(
+            out.contains("2 more turn(s) in range not shown — read them with --from 1"),
+            "names the resume coordinate: {}",
+            &out[out.len() - 120..]
+        );
+    }
+
+    #[test]
+    fn get_agent_fits_every_turn_it_can() {
+        // The stop is the byte limit, not a turn count: small turns all render.
+        let turns: Vec<Turn> = (0..6).map(|i| turn_at(i, "small")).collect();
+        let out = get_agent("", &turns, 6);
+        assert!(out.contains("\nturns 0-5 of 6\n"), "got: {out}");
+        assert!(!out.contains("not shown"), "nothing was left out: {out}");
+    }
+
+    #[test]
+    fn get_agent_always_renders_one_turn() {
+        // One turn always renders, however large.
+        let huge = "x".repeat(GET_BUDGET * 2);
+        let out = get_agent("", &[turn_at(4, &huge)], 9);
+        assert!(out.contains(&huge), "the turn is rendered whole");
+        assert!(
+            out.trim_end().ends_with("turns 4-4 of 9"),
+            "got: {}",
+            &out[out.len() - 60..]
         );
     }
 

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -5,7 +5,7 @@
 //! a terminal: tool chunks compressed to a deterministic one-liner, prose wrapped, marks
 //! highlighted.
 
-use crate::commands::recall::{Hit, Session, Turn};
+use crate::commands::recall::{Hit, ScanCut, ScanResult, Session, Turn};
 use std::fmt::Write as _;
 
 /// Turns each side of a hit that a `→ get` line reaches for.
@@ -45,6 +45,72 @@ pub fn recall_agent(note: &str, memory_arg: &str, hits: &[(Hit, f64)]) -> String
         let _ = writeln!(out, "---");
     }
     out
+}
+
+/// The agent `scan` format: a header naming the needle, the session and the window, then one line
+/// per carrying block with the `→ get` that reads it. A cap is stated with the coordinate that
+/// continues past it. Byte-stable.
+pub fn scan_agent(note: &str, memory_arg: &str, r: &ScanResult, context: usize) -> String {
+    let mut out = note.to_string();
+    let scanned = match (r.from, r.to) {
+        (None, None) => String::new(),
+        (Some(a), Some(b)) => format!(" turns {a}-{b}"),
+        (Some(a), None) => format!(" turns {a} on"),
+        (None, Some(b)) => format!(" turns up to {b}"),
+    };
+    if r.hits.is_empty() {
+        let _ = writeln!(out, "no matches for {:?} in {}{scanned}\n---", r.needle, r.session_id);
+        return out;
+    }
+    let _ = writeln!(
+        out,
+        "scan {:?} in {}{scanned} — {} hits",
+        r.needle,
+        r.session_id,
+        r.hits.len() + r.dropped
+    );
+    for h in &r.hits {
+        let _ = writeln!(out, "[{}] {} seq{}", h.ts, h.block_type, h.seq);
+        let _ = writeln!(out, "  → get {}{}{}", r.session_id, hint_range(h.seq), memory_arg);
+        let _ = writeln!(out, "  {}", excerpt(&h.text, h.at, h.len, context));
+    }
+    match &r.cut {
+        Some(ScanCut::Resume(seq)) => {
+            let _ = writeln!(out, "{} more hits not shown — continue with --from {seq}", r.dropped);
+        }
+        Some(ScanCut::Crowded(seq)) => {
+            let _ = writeln!(
+                out,
+                "{} more hits not shown, all in turn {seq} — read it with --from {seq} --to {seq}",
+                r.dropped
+            );
+        }
+        None => {}
+    }
+    let _ = writeln!(out, "---");
+    out
+}
+
+/// `context` chars of the block on each side of the match, whitespace-collapsed onto one line. A
+/// `…` marks each end the block runs past.
+fn excerpt(text: &str, at: usize, len: usize, context: usize) -> String {
+    // Stepping back `context` chars means taking the (context - 1)th char in reverse; a context of
+    // zero steps nowhere and starts at the match.
+    let start = if context == 0 {
+        at
+    } else {
+        text[..at].char_indices().rev().nth(context - 1).map_or(0, |(j, _)| j)
+    };
+    let end = text[at..]
+        .char_indices()
+        .nth(len + context)
+        .map_or(text.len(), |(j, _)| at + j);
+    format!(
+        "{}{}{}",
+        if start > 0 { "… " } else { "" },
+        text[start..end].split_whitespace().collect::<Vec<_>>().join(" "),
+        if end < text.len() { " …" } else { "" }
+    )
 }
 
 /// Characters of a session's opening prompt a listing shows.
@@ -566,6 +632,14 @@ mod tests {
         assert_eq!(word_span(text, "nope delta"), None);
         // A long mark cut mid-word at its start still anchors via the skip.
         assert_eq!(word_span(text, "pha beta gamma delta epsilon zeta eta"), Some(1..7));
+    }
+
+    #[test]
+    fn excerpt_with_no_context_shows_the_match_alone() {
+        // A context of zero asks for the match and nothing around it, not the char before it.
+        assert_eq!(excerpt("xbeta gamma", 1, 4, 0), "… beta …");
+        // One char of context reaches the start of the block, so nothing is elided on the left.
+        assert_eq!(excerpt("xbeta gamma", 1, 4, 1), "xbeta …");
     }
 
     #[test]

--- a/tests/index_recall.rs
+++ b/tests/index_recall.rs
@@ -81,6 +81,45 @@ async fn index_then_read_surface() {
     .unwrap();
     assert!(tu.contains("tool_use"), "type filter should keep tool_use rows: {tu}");
 
+    // sessions: the memory enumerates to the one indexed session, counted in turns not rows.
+    let listed = funes::commands::recall::sessions(funes::memory::Memory::local(), Default::default())
+        .await
+        .unwrap();
+    assert!(
+        listed.contains(&session) && listed.contains(" turns "),
+        "sessions should list the session with its turn count: {listed}"
+    );
+    assert!(
+        listed.trim_end().ends_with("1 sessions"),
+        "a complete listing closes with the total: {listed}"
+    );
+
+    // A limit of zero would render nothing, so it is an error that names the bounds.
+    let zero = funes::commands::recall::sessions(
+        funes::memory::Memory::local(),
+        funes::commands::recall::SessionFilter {
+            limit: Some(0),
+            ..Default::default()
+        },
+    )
+    .await;
+    assert!(
+        zero.is_err_and(|e| e.to_string().contains("would list nothing")),
+        "a limit of 0 should error"
+    );
+
+    // A date filter narrows the population; one that excludes everything says so.
+    let none = funes::commands::recall::sessions(
+        funes::memory::Memory::local(),
+        funes::commands::recall::SessionFilter {
+            since: Some("2099-01-01".to_string()),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    assert!(none.contains("matches"), "an empty filter result says so: {none}");
+
     // get: a session id alone reads from the start, and says what range it read.
     let got = funes::commands::recall::get(
         funes::memory::Memory::local(),

--- a/tests/index_recall.rs
+++ b/tests/index_recall.rs
@@ -81,11 +81,28 @@ async fn index_then_read_surface() {
     .unwrap();
     assert!(tu.contains("tool_use"), "type filter should keep tool_use rows: {tu}");
 
-    // get: reassemble the assistant turn by its uuid.
-    let got = funes::commands::recall::get(funes::memory::Memory::local(), session.clone(), "t2".into(), 3)
-        .await
-        .unwrap();
+    // get: a session id alone reads from the start, and says what range it read.
+    let got = funes::commands::recall::get(
+        funes::memory::Memory::local(),
+        session.clone(),
+        funes::commands::recall::TurnRange::default(),
+    )
+    .await
+    .unwrap();
     assert!(got.contains("typed blocks"), "get should return the turn text: {got}");
+    assert!(got.contains("turns "), "get should close with the range it read: {got}");
+
+    // An unknown session id is absent, not an empty range.
+    let missing = funes::commands::recall::get(
+        funes::memory::Memory::local(),
+        "no-such-session".into(),
+        funes::commands::recall::TurnRange::default(),
+    )
+    .await;
+    assert!(
+        missing.is_err_and(|e| e.to_string().contains("no session no-such-session")),
+        "an unknown session id should error"
+    );
 
     // Every hit names the memory it was read from — the default memory and an explicit one alike.
     let default_hint = format!("--memory {}", db_dir.path().join("memory").display());

--- a/tests/index_recall.rs
+++ b/tests/index_recall.rs
@@ -81,6 +81,75 @@ async fn index_then_read_surface() {
     .unwrap();
     assert!(tu.contains("tool_use"), "type filter should keep tool_use rows: {tu}");
 
+    // scan: an exhaustive literal search of one session, and a zero that names what it cleared.
+    let scanned = funes::commands::recall::scan(
+        funes::memory::Memory::local(),
+        "typed blocks".into(),
+        session.clone(),
+        None,
+        None,
+        false,
+        40,
+    )
+    .await
+    .unwrap();
+    assert!(
+        scanned.contains(&format!("scan \"typed blocks\" in {session} — 1 hits")),
+        "scan should find the literal exactly once: {scanned}"
+    );
+    assert!(
+        scanned.contains(&format!("→ get {session} --from 0 --to 4")),
+        "a hit carries a runnable range around its turn, clamped at the start: {scanned}"
+    );
+    let zero = funes::commands::recall::scan(
+        funes::memory::Memory::local(),
+        "nothing anywhere says this".into(),
+        session.clone(),
+        None,
+        None,
+        false,
+        40,
+    )
+    .await
+    .unwrap();
+    assert!(
+        zero.contains(&format!("no matches for \"nothing anywhere says this\" in {session}")),
+        "a zero echoes the needle and the session it cleared: {zero}"
+    );
+
+    // An unknown session is an error, not a clearance: a mistyped id must never read as absence.
+    let unknown = funes::commands::recall::scan(
+        funes::memory::Memory::local(),
+        "typed blocks".into(),
+        "no-such-session".into(),
+        None,
+        None,
+        false,
+        40,
+    )
+    .await;
+    assert!(
+        unknown.is_err_and(|e| e.to_string().contains("no session no-such-session")),
+        "an unknown session must be an error"
+    );
+
+    // A window scopes what a zero clears, and the reply says which stretch it scanned.
+    let windowed = funes::commands::recall::scan(
+        funes::memory::Memory::local(),
+        "typed blocks".into(),
+        session.clone(),
+        Some(2),
+        None,
+        false,
+        40,
+    )
+    .await
+    .unwrap();
+    assert!(
+        windowed.contains("turns 2 on"),
+        "a windowed scan names the stretch it covered: {windowed}"
+    );
+
     // sessions: the memory enumerates to the one indexed session, counted in turns not rows.
     let listed = funes::commands::recall::sessions(funes::memory::Memory::local(), Default::default())
         .await

--- a/tests/redact_on_index.rs
+++ b/tests/redact_on_index.rs
@@ -54,9 +54,13 @@ async fn planted_key_is_redacted_at_index_time() {
         .unwrap();
 
     // Read the stored turn back: the marker is present, the key body is gone.
-    let got = funes::commands::recall::get(funes::memory::Memory::local(), session.into(), "t1".into(), 3)
-        .await
-        .unwrap();
+    let got = funes::commands::recall::get(
+        funes::memory::Memory::local(),
+        session.into(),
+        funes::commands::recall::TurnRange::default(),
+    )
+    .await
+    .unwrap();
     assert!(
         got.contains("[REDACTED:PrivateKey]"),
         "expected a redaction marker, got: {got}"

--- a/tests/scrub.rs
+++ b/tests/scrub.rs
@@ -58,9 +58,13 @@ async fn scrub_redacts_an_existing_secret_in_place() {
     funes::commands::index::run_index(source.path(), false, None)
         .await
         .unwrap();
-    let dirty = funes::commands::recall::get(funes::memory::Memory::local(), session.into(), "t1".into(), 3)
-        .await
-        .unwrap();
+    let dirty = funes::commands::recall::get(
+        funes::memory::Memory::local(),
+        session.into(),
+        funes::commands::recall::TurnRange::default(),
+    )
+    .await
+    .unwrap();
     assert!(
         dirty.contains(&key_body),
         "setup: the key should be in the memory before scrub"
@@ -69,9 +73,13 @@ async fn scrub_redacts_an_existing_secret_in_place() {
     // Scrub with the real scanner: it must redact the key in place.
     std::env::remove_var("FUNES_TRUFFLEHOG");
     funes::commands::scrub::run().await.unwrap();
-    let clean = funes::commands::recall::get(funes::memory::Memory::local(), session.into(), "t1".into(), 3)
-        .await
-        .unwrap();
+    let clean = funes::commands::recall::get(
+        funes::memory::Memory::local(),
+        session.into(),
+        funes::commands::recall::TurnRange::default(),
+    )
+    .await
+    .unwrap();
     assert!(
         clean.contains("[REDACTED:PrivateKey]"),
         "expected a redaction marker after scrub: {clean}"

--- a/tests/scrub_drops_escaped_key.rs
+++ b/tests/scrub_drops_escaped_key.rs
@@ -66,9 +66,16 @@ async fn scrub_redacts_an_escaped_key_in_place() {
     funes::commands::index::run_index(source.path(), false, None)
         .await
         .unwrap();
-    let dirty = funes::commands::recall::get(funes::memory::Memory::local(), session.into(), "t2".into(), 0)
-        .await
-        .unwrap();
+    let dirty = funes::commands::recall::get(
+        funes::memory::Memory::local(),
+        session.into(),
+        funes::commands::recall::TurnRange {
+            from: Some(1),
+            to: Some(1),
+        },
+    )
+    .await
+    .unwrap();
     assert!(
         dirty.contains(&key_body),
         "setup: the escaped key should be in the memory before scrub"
@@ -78,9 +85,16 @@ async fn scrub_redacts_an_escaped_key_in_place() {
     std::env::remove_var("FUNES_TRUFFLEHOG");
     funes::commands::scrub::run().await.unwrap();
 
-    let after_key = funes::commands::recall::get(funes::memory::Memory::local(), session.into(), "t2".into(), 0)
-        .await
-        .unwrap_or_default();
+    let after_key = funes::commands::recall::get(
+        funes::memory::Memory::local(),
+        session.into(),
+        funes::commands::recall::TurnRange {
+            from: Some(1),
+            to: Some(1),
+        },
+    )
+    .await
+    .unwrap_or_default();
     assert!(
         !after_key.contains(&key_body),
         "escaped key survived scrub: {after_key}"
@@ -91,9 +105,16 @@ async fn scrub_redacts_an_escaped_key_in_place() {
     );
 
     // The clean turn is untouched.
-    let clean = funes::commands::recall::get(funes::memory::Memory::local(), session.into(), "t1".into(), 0)
-        .await
-        .unwrap();
+    let clean = funes::commands::recall::get(
+        funes::memory::Memory::local(),
+        session.into(),
+        funes::commands::recall::TurnRange {
+            from: Some(0),
+            to: Some(0),
+        },
+    )
+    .await
+    .unwrap();
     assert!(
         clean.contains("just chatting about parsers"),
         "clean turn was lost: {clean}"


### PR DESCRIPTION
This adds more verbs to funes to list sessions and scan them for "needle" terms.

The goal is to help looking for specific patterns in sessions, as opposed to the recall semantic search.