### PR TITLE
fix(tests): update codex assertions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,25 +117,14 @@ jobs:
             ~/.cache/huggingface/hub/models--BAAI--bge-reranker-base
           key: hf-models-blas-v1
 
-      - name: Integration test
-        run: cargo test --profile ci --test index_recall -- --nocapture
-
-      # `cargo test --test <name>` runs only the named target.
-      - name: Secret redaction tests
-        run: cargo test --profile ci --test redact_on_index --test scrub --test scrub_drops_escaped_key --test scrub_drops_all -- --nocapture
-
-      # Gated: runs only when the secret is present (skips on forks / missing secret).
-      - name: Remote recall test
+      # The whole suite, named by nothing: this job has the model cache and the Hub secret, which
+      # is everything any test needs, so a test added later is covered without touching this file.
+      # The Hub ones skip themselves when the secret is absent (on a fork) and clean up the
+      # scratch paths they create.
+      - name: Integration tests
         env:
           HF_FUNES_TEST_TOKEN: ${{ secrets.HF_FUNES_TEST_TOKEN }}
-        run: cargo test --profile ci --test remote_recall -- --nocapture
-
-      # Gated: create→append→recall→clear against a unique scratch path. Skips without the
-      # secret; cleans up the scratch path itself.
-      - name: Push round-trip test
-        env:
-          HF_FUNES_TEST_TOKEN: ${{ secrets.HF_FUNES_TEST_TOKEN }}
-        run: cargo test --profile ci --test push_round_trip -- --nocapture
+        run: cargo test --profile ci -- --nocapture
 
       - name: Save model weights
         if: ${{ !cancelled() && github.ref == 'refs/heads/main' && steps.models.outputs.cache-hit != 'true' }}

--- a/tests/add_claude_plugin.rs
+++ b/tests/add_claude_plugin.rs
@@ -15,6 +15,10 @@ fn add_claude_generates_the_plugin_tree() {
     std::env::set_var("HOME", home.path());
     // No `claude` on PATH → funes extracts the plugin and returns Ok without registering it.
     std::env::set_var("PATH", "");
+    // The variables that name real state elsewhere: the memory this install would seed, and the
+    // Codex home a sibling test's agent would be asked for.
+    std::env::remove_var("FUNES_HOME");
+    std::env::remove_var("CODEX_HOME");
 
     claude::install(Some("acme/kb".to_string())).unwrap();
 

--- a/tests/add_codex_hooks.rs
+++ b/tests/add_codex_hooks.rs
@@ -25,6 +25,11 @@ fn add_codex_installs_hooks_and_preserves_existing() {
     )
     .unwrap();
 
+    // What an install before the move left in the shared tree, for this one to clear.
+    let old_skill = home.path().join(".agents/skills/funes/SKILL.md");
+    fs::create_dir_all(old_skill.parent().unwrap()).unwrap();
+    fs::write(&old_skill, "stale").unwrap();
+
     codex::install(Some("acme/kb".to_string())).unwrap();
 
     // Scripts written and executable.
@@ -56,8 +61,8 @@ fn add_codex_installs_hooks_and_preserves_existing() {
     let skill = home.path().join(".codex/skills/funes/SKILL.md");
     assert!(skill.exists(), "skill written");
     assert!(fs::read_to_string(&skill).unwrap().contains("name: funes"));
-    let old_skill = home.path().join(".agents/skills/funes/SKILL.md");
     assert!(!old_skill.exists(), "old shared skill removed");
+    assert!(!home.path().join(".agents").exists(), "and its tree pruned");
 
     // The user's own hook is untouched.
     assert_eq!(cfg["hooks"]["PreToolUse"][0]["hooks"][0]["command"], "guard.sh");

--- a/tests/add_codex_hooks.rs
+++ b/tests/add_codex_hooks.rs
@@ -49,10 +49,12 @@ fn add_codex_installs_hooks_and_preserves_existing() {
     );
     let end = cfg["hooks"]["SessionEnd"][0]["hooks"][0]["command"].as_str().unwrap();
     assert!(end.contains("funes-push.sh") && end.contains("acme/kb"), "end: {end}");
-    // The skill Codex lists before loading any tool.
-    let skill = home.path().join(".agents/skills/funes/SKILL.md");
+    // The skill Codex lists before loading any tool (now in Codex's own tree, not shared).
+    let skill = home.path().join(".codex/skills/funes/SKILL.md");
     assert!(skill.exists(), "skill written");
     assert!(fs::read_to_string(&skill).unwrap().contains("name: funes"));
+    let old_skill = home.path().join(".agents/skills/funes/SKILL.md");
+    assert!(!old_skill.exists(), "old shared skill removed");
 
     // The user's own hook is untouched.
     assert_eq!(cfg["hooks"]["PreToolUse"][0]["hooks"][0]["command"], "guard.sh");

--- a/tests/add_codex_hooks.rs
+++ b/tests/add_codex_hooks.rs
@@ -12,6 +12,9 @@ fn add_codex_installs_hooks_and_preserves_existing() {
     let home = tempfile::tempdir().unwrap();
     std::env::set_var("HOME", home.path());
     std::env::set_var("PATH", "");
+    // Codex's home is asked of Codex, and `CODEX_HOME` answers when it can't be run — so a
+    // developer's own variable would send this install into their real Codex home.
+    std::env::remove_var("CODEX_HOME");
     let config = home.path().join(".codex/hooks.json");
 
     // A hook the user already had must survive funes's merge.

--- a/tests/add_codex_hooks.rs
+++ b/tests/add_codex_hooks.rs
@@ -13,8 +13,10 @@ fn add_codex_installs_hooks_and_preserves_existing() {
     std::env::set_var("HOME", home.path());
     std::env::set_var("PATH", "");
     // Codex's home is asked of Codex, and `CODEX_HOME` answers when it can't be run — so a
-    // developer's own variable would send this install into their real Codex home.
+    // developer's own variable would send this install into their real Codex home. `FUNES_HOME`
+    // names the memory this install would seed.
     std::env::remove_var("CODEX_HOME");
+    std::env::remove_var("FUNES_HOME");
     let config = home.path().join(".codex/hooks.json");
 
     // A hook the user already had must survive funes's merge.

--- a/tests/remove.rs
+++ b/tests/remove.rs
@@ -205,7 +205,10 @@ fn malformed_hook_configs_do_not_block_mcp_unregistration() {
     let codex_bin = support::fake_cli(&tmp.path().join("codex-fake"), "codex");
     let codex = support::run_remove(&codex_home, &codex_bin, &codex_log, "codex");
     assert!(!codex.status.success(), "malformed hooks.json remains an error");
-    assert_eq!(fs::read_to_string(codex_log).unwrap(), "mcp remove funes\ndoctor --json\n");
+    assert_eq!(
+        fs::read_to_string(codex_log).unwrap(),
+        "mcp remove funes\ndoctor --json\n"
+    );
 
     let hermes_home = tmp.path().join("hermes-home");
     fs::create_dir_all(hermes_home.join(".hermes")).unwrap();

--- a/tests/remove.rs
+++ b/tests/remove.rs
@@ -76,7 +76,7 @@ fn remove_codex_preserves_user_hooks_and_files() {
     for owned in ["funes-index.sh", "funes-push.sh", "funes-sync.log"] {
         assert!(!hooks.join(owned).exists(), "{owned} removed");
     }
-    assert_eq!(fs::read_to_string(&log).unwrap(), "mcp remove funes\n");
+    assert_eq!(fs::read_to_string(&log).unwrap(), "mcp remove funes\ndoctor --json\n");
 
     let second = support::run_remove(&home, &bin, &log, "codex");
     support::assert_success(&second);
@@ -205,7 +205,7 @@ fn malformed_hook_configs_do_not_block_mcp_unregistration() {
     let codex_bin = support::fake_cli(&tmp.path().join("codex-fake"), "codex");
     let codex = support::run_remove(&codex_home, &codex_bin, &codex_log, "codex");
     assert!(!codex.status.success(), "malformed hooks.json remains an error");
-    assert_eq!(fs::read_to_string(codex_log).unwrap(), "mcp remove funes\n");
+    assert_eq!(fs::read_to_string(codex_log).unwrap(), "mcp remove funes\ndoctor --json\n");
 
     let hermes_home = tmp.path().join("hermes-home");
     fs::create_dir_all(hermes_home.join(".hermes")).unwrap();

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -19,6 +19,9 @@ pub fn run_remove(home: &Path, bin: &Path, log: &Path, agent: &str) -> Output {
         .args(["remove", agent])
         .env("HOME", home)
         .env("PATH", bin)
+        // A developer running the suite with a real `CODEX_HOME` set would otherwise have their own
+        // Codex integration removed: funes asks Codex where its home is, and that variable answers.
+        .env_remove("CODEX_HOME")
         .env("FUNES_TEST_CLI_LOG", log)
         .output()
         .unwrap()

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -19,9 +19,11 @@ pub fn run_remove(home: &Path, bin: &Path, log: &Path, agent: &str) -> Output {
         .args(["remove", agent])
         .env("HOME", home)
         .env("PATH", bin)
-        // A developer running the suite with a real `CODEX_HOME` set would otherwise have their own
-        // Codex integration removed: funes asks Codex where its home is, and that variable answers.
+        // Every variable that would point funes at something real: `CODEX_HOME` answers when funes
+        // asks Codex where its home is, and `FUNES_HOME` names the memory. A developer running the
+        // suite with either set would otherwise have their own integration removed.
         .env_remove("CODEX_HOME")
+        .env_remove("FUNES_HOME")
         .env("FUNES_TEST_CLI_LOG", log)
         .output()
         .unwrap()


### PR DESCRIPTION
- The skill moved from ~/.agents/skills to <codex_home>/skills; update the add_codex_hooks test and assert the old shared copy is removed.
- uninstall now calls codex doctor --json to discover CODEX_HOME; update the remove tests to expect that extra invocation in the fake CLI log.