### PR TITLE
fix(push): one publish at a time per remote

### DIFF
--- a/docs/automation.md
+++ b/docs/automation.md
@@ -102,8 +102,10 @@ timeout.
 - **Serialized in the binary.** funes holds an advisory lock while it mutates the local memory, so
   only one writer touches it at a time, whatever launched it (a hook, a manual `funes index`, `funes
   scrub`). A run that hits the lock fails loudly and re-sweeps next turn (indexing is idempotent).
-  Reads take no lock. `funes push` is commit-guarded on the remote, so overlapping publishes — and a
-  publish overlapping an index — are safe.
+  Reads take no lock. `funes push` takes one of its own, per remote memory — it only reads the local
+  memory, so it never blocks an index — and a publish that finds another in flight steps aside; the
+  next session start sweeps it. Nothing is serialized across machines: two hosts publishing to one
+  memory still race on the Hub.
 - **Secrets held back.** funes redacts credentials at index time; on push, a separate always-on gate
   withholds any chunk that still contains one — the clean rows publish, and the push exits non-zero
   (code `2`) only if that leaves nothing to publish. Run `funes scrub`, then the next push includes it.

--- a/docs/push.md
+++ b/docs/push.md
@@ -33,8 +33,9 @@ push interactively — once that machine has an index of its own to push.)
 If your token can't write the target, push says so — recall can still read a memory you can't publish
 to.
 
-The hooks [`funes add`](add.md) installs run this at session boundaries automatically; see
-[automation.md](automation.md).
+One publish per memory at a time on a machine: a push that starts while another is still running
+says so and stops, and the next one picks up what it left. The hooks [`funes add`](add.md) installs
+run this at session boundaries automatically; see [automation.md](automation.md).
 
 ## Keeping secrets out: the gate and `funes scrub`
 

--- a/scripts/automation/funes-push.sh
+++ b/scripts/automation/funes-push.sh
@@ -16,9 +16,10 @@
 # next session's catch-up, which is the gap the boundary hook exists to close. Indexing here also
 # covers a per-turn run that never happened. It is the same incremental, local, idempotent sweep.
 #
-# `funes push` is incremental and commit-guarded (it retries against a moved remote
-# head), so overlapping publishes — and a publish that overlaps an index — are safe;
-# no lock is needed. It has a fail-closed secret gate: a chunk holding a credential is
+# `funes push` is incremental and takes a per-remote lock, so a publish that starts while
+# another is still running steps aside and the next session start sweeps it. A publish that
+# overlaps an index is safe — push only reads the local memory. It has a fail-closed secret
+# gate: a chunk holding a credential is
 # withheld (exit 2) rather than published. A first push to a memory your local memory
 # shares no chunks with is refused off a terminal — clear it once by hand (see setup).
 #

--- a/src/commands/push.rs
+++ b/src/commands/push.rs
@@ -22,6 +22,7 @@
 use crate::hub;
 use crate::memory::card::{self, CardAction, CardCtx};
 use crate::memory::dataset;
+use crate::memory::lock;
 use crate::memory::remote::{self, Appended, Reindexed};
 use crate::memory::{Memory, MemoryState};
 use crate::{chunk, scan};
@@ -88,6 +89,15 @@ async fn all_ids(ds: &Dataset) -> Result<HashSet<String>> {
 /// local: a shared remote's sessions from other hosts say nothing about this host's push backlog.
 fn pushed_path(memory_uri: &str) -> PathBuf {
     dataset::funes_dir().join("pushed").join(sanitize(memory_uri))
+}
+
+/// The file a publish to `memory_uri` locks for its whole run — not the receipt's lock, which
+/// [`record_pushed`] takes per write.
+fn push_lock_path(memory_uri: &str) -> PathBuf {
+    dataset::funes_dir()
+        .join("pushed")
+        .join(".locks")
+        .join(format!("{}.push", sanitize(memory_uri)))
 }
 
 fn load_pushed_from(path: &Path) -> Option<HashSet<String>> {
@@ -339,6 +349,15 @@ pub async fn run_push(target: Memory, force_reindex: bool, confirm: Confirm, ses
         Memory::Local { .. } => {
             bail!("push target must be a remote `hf://` memory — it publishes your local index up to the Hub")
         }
+    };
+
+    // A push's delta is only valid against the head it read, so a concurrent one republishes those rows.
+    let Some(_push_lock) = lock::try_lock_file(&push_lock_path(&uri))? else {
+        return Ok(format!(
+            "{}: another push to this memory is in flight — skipped\n",
+            target.label()
+        )
+        .into());
     };
 
     // 1. What the remote *is*, and what's on it — asked before any local build or scan, so an
@@ -1029,6 +1048,16 @@ mod tests {
         let rows = rows_with_ids(&ds, &to_push).await.unwrap();
         let pushed: usize = rows.iter().map(|b| b.num_rows()).sum();
         assert_eq!(pushed, reviewed.len(), "only that session's rows are read");
+    }
+
+    #[test]
+    fn a_push_locks_its_own_file_per_remote() {
+        let uri = "hf://datasets/acme/kb";
+        let receipt = pushed_path(uri);
+        let receipt_lock = receipt.parent().unwrap().join(".locks").join(sanitize(uri));
+        assert_ne!(push_lock_path(uri), receipt);
+        assert_ne!(push_lock_path(uri), receipt_lock);
+        assert_ne!(push_lock_path(uri), push_lock_path("hf://datasets/acme/other"));
     }
 
     #[tokio::test]

--- a/src/memory/lock.rs
+++ b/src/memory/lock.rs
@@ -2,9 +2,11 @@
 //! (Lance's commit guard doesn't prevent it on a local dataset), so at most one mutates at a time. It
 //! lives in the binary, not a launcher script, so the rule holds for every writer however it started.
 //! An advisory `flock`, released on drop and on process death; contention fails loudly, never blocks.
-//! Readers take no lock — Lance gives each a consistent snapshot.
+//! Readers take no lock — Lance gives each a consistent snapshot. [`try_lock_file`] exposes the same
+//! `flock` on any path, for the binary's other advisory locks.
 
 use std::fs::{File, TryLockError};
+use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Context, Result};
 
@@ -14,37 +16,60 @@ use super::dataset;
 #[derive(Debug)]
 pub struct MemoryLock(#[allow(dead_code)] File);
 
-fn open_lockfile() -> Result<File> {
-    let dir = dataset::funes_dir();
-    std::fs::create_dir_all(&dir).with_context(|| format!("creating {}", dir.display()))?;
+/// Take an exclusive advisory lock on `path`, creating the file and its directory if needed. `None`
+/// if another holder has it — including this process, which `flock` treats no differently. Never
+/// blocks; released when the returned handle drops, and on process death.
+pub(crate) fn try_lock_file(path: &Path) -> Result<Option<File>> {
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir).with_context(|| format!("creating {}", dir.display()))?;
+    }
+    let f = File::options()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        .open(path)
+        .with_context(|| format!("opening the lock at {}", path.display()))?;
+    match f.try_lock() {
+        Ok(()) => Ok(Some(f)),
+        Err(TryLockError::WouldBlock) => Ok(None),
+        Err(TryLockError::Error(e)) => Err(e).with_context(|| format!("locking {}", path.display())),
+    }
+}
+
+fn lockfile_path() -> PathBuf {
     // A sibling of memory/, not inside the Lance dataset, so version cleanup never reaps it. The
     // filename stays `store.lock` (the pre-rename name) deliberately: during a `funes update` a
     // pre-rename binary may still be writing under this home, and both must contend on the *same*
     // lock file — renaming it would let old and new writers proceed concurrently and corrupt rows.
-    let path = dir.join("store.lock");
-    File::options()
-        .create(true)
-        .write(true)
-        .truncate(false)
-        .open(&path)
-        .with_context(|| format!("opening the memory lock at {}", path.display()))
+    dataset::funes_dir().join("store.lock")
 }
 
 impl MemoryLock {
     /// Try to take the lock without blocking: `Some` if acquired, `None` if another operation holds
     /// it. A caller that wants to wait retries this itself.
     pub fn try_acquire() -> Result<Option<Self>> {
-        let f = open_lockfile()?;
-        match f.try_lock() {
-            Ok(()) => Ok(Some(Self(f))),
-            Err(TryLockError::WouldBlock) => Ok(None),
-            Err(TryLockError::Error(e)) => Err(e).context("locking the memory"),
-        }
+        Ok(try_lock_file(&lockfile_path())?.map(Self))
     }
 
     /// Take the lock, or fail if another memory operation holds it. Never blocks.
     pub fn acquire() -> Result<Self> {
         Self::try_acquire()?
             .ok_or_else(|| anyhow!("another funes memory operation is in progress; retry once it finishes"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_locked_file_is_taken_until_its_holder_drops_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nested").join("a.lock");
+        let held = try_lock_file(&path).unwrap().expect("a free lock is taken");
+        assert!(try_lock_file(&path).unwrap().is_none());
+        assert!(try_lock_file(&dir.path().join("b.lock")).unwrap().is_some());
+        drop(held);
+        assert!(try_lock_file(&path).unwrap().is_some());
     }
 }

--- a/tests/push_round_trip.rs
+++ b/tests/push_round_trip.rs
@@ -263,18 +263,17 @@ async fn push_round_trip_create_append_recall() {
         recall_reindexed.contains("SYNCSMOKE2"),
         "remote recall should still surface the turn after reindex: {recall_reindexed}"
     );
+    let mut published = 0;
     for (who, r) in [("a", race_a), ("b", race_b)] {
-        // Any of these outcomes is fine; an error or a second copy is not.
         let report = r.unwrap_or_else(|e| panic!("racing push {who} failed: {e}")).report;
         eprintln!("racing push {who}: {}", report.trim_end());
+        published += usize::from(report.contains("pushed"));
         assert!(
-            report.contains("pushed")
-                || report.contains("skipped")
-                || report.contains("already published")
-                || report.contains("up to date"),
+            report.contains("pushed") || report.contains("skipped") || report.contains("up to date"),
             "racing push {who} reported: {report}"
         );
     }
+    assert_eq!(published, 1, "one racer publishes the new chunk, the other stands down");
     assert_eq!(
         remote_rows, remote_ids,
         "two pushes racing must not leave duplicate rows on the remote"

--- a/tests/push_round_trip.rs
+++ b/tests/push_round_trip.rs
@@ -27,6 +27,27 @@ use hf_hub::{HFClient, HFError, HFRepository, RepoTypeDataset};
 const OWNER: &str = "optimum-internal-testing";
 const NAME: &str = "funes-test";
 
+/// The remote's row count and its distinct chunk-id count.
+async fn remote_rows_and_ids(uri: &str) -> (usize, usize) {
+    let ds = Memory::parse(uri).open().await.expect("opening the remote");
+    let batches = funes::memory::dataset::scan_rows(&ds, &["id"], None, None)
+        .await
+        .expect("scanning the remote ids");
+    let mut rows = 0usize;
+    let mut ids = std::collections::HashSet::new();
+    for b in &batches {
+        rows += b.num_rows();
+        let col = b
+            .column_by_name("id")
+            .and_then(|c| c.as_any().downcast_ref::<arrow_array::StringArray>())
+            .expect("an id column");
+        for i in 0..b.num_rows() {
+            ids.insert(col.value(i).to_string());
+        }
+    }
+    (rows, ids.len())
+}
+
 /// Write `projects/<proj>/sess.jsonl` with the given (uuid, text) user turns.
 fn write_session(source: &std::path::Path, turns: &[(&str, &str)]) {
     let dir = source.join("projects").join("-synctest-proj");
@@ -158,6 +179,24 @@ async fn push_round_trip_create_append_recall() {
     // the index as its own commit (capture_reindex + a separate commit), then recall it again.
     let reindex = funes::commands::push::run_push(Memory::parse(&uri), true, Confirm::Yes, &[]).await;
     let recall_reindexed = recall_remote(&uri, "SYNCSMOKE2 continuation").await;
+    // Two pushes at once — what N subagents ending together do.
+    write_session(
+        src.path(),
+        &[
+            ("s1", "SYNCSMOKE parsing transcripts into turns"),
+            ("s2", "SYNCSMOKE2 the continuation adds only this new turn"),
+            ("s3", "SYNCSMOKE3 the turn two pushes race to publish"),
+        ],
+    );
+    funes::commands::index::run_index(src.path(), false, None)
+        .await
+        .unwrap();
+    let (race_a, race_b) = tokio::join!(
+        funes::commands::push::run_push(Memory::parse(&uri), false, Confirm::Yes, &[]),
+        funes::commands::push::run_push(Memory::parse(&uri), false, Confirm::Yes, &[]),
+    );
+    let (remote_rows, remote_ids) = remote_rows_and_ids(&uri).await;
+
     let readme_after = root_readme(&repo).await;
     // The model id must travel with the memory (stamped in the schema metadata, uploaded by push).
     let remote_model = match Memory::parse(&uri).open().await {
@@ -223,6 +262,22 @@ async fn push_round_trip_create_append_recall() {
     assert!(
         recall_reindexed.contains("SYNCSMOKE2"),
         "remote recall should still surface the turn after reindex: {recall_reindexed}"
+    );
+    for (who, r) in [("a", race_a), ("b", race_b)] {
+        // Any of these outcomes is fine; an error or a second copy is not.
+        let report = r.unwrap_or_else(|e| panic!("racing push {who} failed: {e}")).report;
+        eprintln!("racing push {who}: {}", report.trim_end());
+        assert!(
+            report.contains("pushed")
+                || report.contains("skipped")
+                || report.contains("already published")
+                || report.contains("up to date"),
+            "racing push {who} reported: {report}"
+        );
+    }
+    assert_eq!(
+        remote_rows, remote_ids,
+        "two pushes racing must not leave duplicate rows on the remote"
     );
     assert_eq!(
         remote_model.as_deref(),


### PR DESCRIPTION
Each push computes its delta against the head it read, so two overlapping runs publish the same rows twice. The hooks push per session boundary, so subagents ending together pushed together — up to seven concurrent here, which is what put x7 copies of some chunks on the shared memory.

An advisory lock per remote, held for the whole run: a push that finds one in flight steps aside, and the next session start sweeps it. Per machine only — two hosts pushing to one memory still race on the Hub.