### PR TITLE
Workaround corrupt cache entries

### DIFF
--- a/src/memory/fetch_store.rs
+++ b/src/memory/fetch_store.rs
@@ -37,6 +37,9 @@ use object_store::{
 pub(crate) trait FileFetcher: std::fmt::Debug + Send + Sync {
     /// Resolve `filename` (the object's path) to a local path holding its bytes.
     async fn fetch(&self, filename: &str) -> anyhow::Result<PathBuf>;
+
+    /// Drop the local copy at `path`; a later [`fetch`](Self::fetch) of that key must not yield it.
+    async fn discard(&self, path: &Path) -> anyhow::Result<()>;
 }
 
 /// Reads are served from the whole file `fetcher` supplies for the key; every other method delegates
@@ -52,6 +55,18 @@ impl FetchStore {
     pub(crate) fn new(inner: Arc<dyn OSObjectStore>, fetcher: Arc<dyn FileFetcher>) -> Self {
         Self { inner, fetcher }
     }
+
+    /// Serve `location` from a copy obtained after discarding `corrupt`, at most one discard per read.
+    async fn repair(&self, corrupt: &Path, location: &OPath, options: GetOptions) -> OSResult<GetResult> {
+        if self.fetcher.discard(corrupt).await.is_ok() {
+            if let Ok(fresh) = self.fetcher.fetch(location.as_ref()).await {
+                if let Ok(result) = serve_from_file(&fresh, location, &options) {
+                    return Ok(result);
+                }
+            }
+        }
+        self.inner.get_opts(location, options).await
+    }
 }
 
 impl std::fmt::Display for FetchStore {
@@ -63,15 +78,14 @@ impl std::fmt::Display for FetchStore {
 #[async_trait]
 impl OSObjectStore for FetchStore {
     async fn get_opts(&self, location: &OPath, options: GetOptions) -> OSResult<GetResult> {
-        // Serve the read from the whole file the fetcher supplies for this key, sliced to the request.
-        // Any failure (fetch, or reading the file back) falls back to the inner store, so a transient
-        // miss never breaks a read.
-        match self.fetcher.fetch(location.as_ref()).await {
-            Ok(path) => match serve_from_file(&path, location, &options) {
-                Ok(result) => Ok(result),
-                Err(_) => self.inner.get_opts(location, options).await,
-            },
-            Err(_) => self.inner.get_opts(location, options).await,
+        // A transient fetch or read failure falls back to the inner store, so it never breaks a read.
+        let Ok(path) = self.fetcher.fetch(location.as_ref()).await else {
+            return self.inner.get_opts(location, options).await;
+        };
+        match serve_from_file(&path, location, &options) {
+            Ok(result) => Ok(result),
+            Err(Unservable::Corrupt) => self.repair(&path, location, options).await,
+            Err(Unservable::Unreadable) => self.inner.get_opts(location, options).await,
         }
     }
 
@@ -104,12 +118,19 @@ impl OSObjectStore for FetchStore {
     }
 }
 
+/// Why a fetched file cannot answer a read.
+enum Unservable {
+    /// It does not span the requested range, so its bytes are not the object's.
+    Corrupt,
+    Unreadable,
+}
+
 /// Build a [`GetResult`] over the fetched file at `path` for the request `options`, reporting the
 /// object's `location` and whole-file size. A `head` returns metadata only; a body request hands the
 /// open file to `object_store`, which reads the resolved range off the executor (so a large file is
 /// never buffered here).
-fn serve_from_file(path: &Path, location: &OPath, options: &GetOptions) -> std::io::Result<GetResult> {
-    let total = std::fs::metadata(path)?.len();
+fn serve_from_file(path: &Path, location: &OPath, options: &GetOptions) -> Result<GetResult, Unservable> {
+    let total = std::fs::metadata(path).map_err(|_| Unservable::Unreadable)?.len();
     let meta = meta(location.clone(), total);
     if options.head {
         return Ok(GetResult {
@@ -122,11 +143,9 @@ fn serve_from_file(path: &Path, location: &OPath, options: &GetOptions) -> std::
     let range = match &options.range {
         None => 0..total,
         // Not clamped: an out-of-file range underflows where its length is computed.
-        Some(requested) => requested
-            .as_range(total)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e))?,
+        Some(requested) => requested.as_range(total).map_err(|_| Unservable::Corrupt)?,
     };
-    let file = std::fs::File::open(path)?;
+    let file = std::fs::File::open(path).map_err(|_| Unservable::Unreadable)?;
     Ok(GetResult {
         payload: GetResultPayload::File(file, path.to_path_buf()),
         meta,
@@ -157,24 +176,32 @@ mod tests {
 
     /// A fake fetcher: writes each requested file to a temp dir from a fixed body and returns its
     /// path, counting fetches so a test can assert how often the fetch path was taken. A filename not
-    /// in `bodies` yields an error, exercising the live-fallback path.
+    /// in `bodies` yields an error, exercising the live-fallback path. After a discard, `repaired`
+    /// supplies the body for a key it holds.
     #[derive(Debug)]
     struct FakeFetcher {
         dir: TempDir,
         bodies: std::collections::HashMap<String, Bytes>,
+        repaired: std::collections::HashMap<String, Bytes>,
         calls: AtomicUsize,
+        discards: AtomicUsize,
+    }
+
+    fn bodies_of(files: &[(&str, &[u8])]) -> std::collections::HashMap<String, Bytes> {
+        files
+            .iter()
+            .map(|(name, body)| (name.to_string(), Bytes::copy_from_slice(body)))
+            .collect()
     }
 
     impl FakeFetcher {
-        fn new(files: &[(&str, &[u8])]) -> Self {
-            let bodies = files
-                .iter()
-                .map(|(name, body)| (name.to_string(), Bytes::copy_from_slice(body)))
-                .collect();
+        fn new(files: &[(&str, &[u8])], repaired: &[(&str, &[u8])]) -> Self {
             Self {
                 dir: tempfile::tempdir().unwrap(),
-                bodies,
+                bodies: bodies_of(files),
+                repaired: bodies_of(repaired),
                 calls: AtomicUsize::new(0),
+                discards: AtomicUsize::new(0),
             }
         }
     }
@@ -183,18 +210,33 @@ mod tests {
     impl FileFetcher for FakeFetcher {
         async fn fetch(&self, filename: &str) -> anyhow::Result<PathBuf> {
             self.calls.fetch_add(1, Ordering::SeqCst);
-            let body = self
-                .bodies
-                .get(filename)
+            let repaired = self.discards.load(Ordering::SeqCst) > 0;
+            let body = repaired
+                .then(|| self.repaired.get(filename))
+                .flatten()
+                .or_else(|| self.bodies.get(filename))
                 .ok_or_else(|| anyhow::anyhow!("no such file: {filename}"))?;
             let path = self.dir.path().join(filename.replace('/', "_"));
             std::fs::write(&path, body)?;
             Ok(path)
         }
+
+        async fn discard(&self, path: &Path) -> anyhow::Result<()> {
+            self.discards.fetch_add(1, Ordering::SeqCst);
+            std::fs::remove_file(path)?;
+            Ok(())
+        }
     }
 
     fn store_with(files: &[(&str, &[u8])]) -> (FetchStore, Arc<FakeFetcher>, Arc<InMemory>) {
-        let fetcher = Arc::new(FakeFetcher::new(files));
+        store_repairing(files, &[])
+    }
+
+    fn store_repairing(
+        files: &[(&str, &[u8])],
+        repaired: &[(&str, &[u8])],
+    ) -> (FetchStore, Arc<FakeFetcher>, Arc<InMemory>) {
+        let fetcher = Arc::new(FakeFetcher::new(files, repaired));
         let inner = Arc::new(InMemory::new());
         let store = FetchStore::new(inner.clone(), fetcher.clone());
         (store, fetcher, inner)
@@ -267,10 +309,35 @@ mod tests {
         );
     }
 
-    /// A copy that cannot span the request is not served: the inner store answers instead.
+    /// A copy that cannot span the request is discarded, and the read reflects the object's bytes.
     #[tokio::test]
-    async fn copy_too_short_for_the_range_falls_back_to_inner() {
-        let (store, _f, inner) = store_with(&[("f", b"<Error/>")]);
+    async fn short_local_copy_is_repaired_and_served() {
+        let (store, fetcher, _inner) = store_repairing(&[("f", b"<Error/>")], &[("f", b"0123456789abcdefghij")]);
+        let opts = GetOptions {
+            range: Some(GetRange::Bounded(12..16)),
+            ..Default::default()
+        };
+
+        let got = store.get_opts(&OPath::from("f"), opts).await.unwrap();
+
+        assert_eq!(got.meta.size, 20, "size is the repaired copy's");
+        assert_eq!(got.bytes().await.unwrap(), Bytes::from_static(b"cdef"));
+        assert_eq!(
+            fetcher.discards.load(Ordering::SeqCst),
+            1,
+            "the short copy was discarded"
+        );
+        assert_eq!(
+            fetcher.calls.load(Ordering::SeqCst),
+            2,
+            "fetched again after the discard"
+        );
+    }
+
+    /// A corrupt copy no refetch repairs leaves the inner store to answer, after one discard.
+    #[tokio::test]
+    async fn unrepairable_copy_falls_back_to_inner() {
+        let (store, fetcher, inner) = store_with(&[("f", b"<Error/>")]);
         let loc = OPath::from("f");
         inner
             .put_opts(&loc, PutPayload::from("0123456789abcdefghij"), PutOptions::default())
@@ -284,6 +351,8 @@ mod tests {
         let got = store.get_opts(&loc, opts).await.unwrap();
 
         assert_eq!(got.bytes().await.unwrap(), Bytes::from_static(b"cdef"));
+        assert_eq!(fetcher.discards.load(Ordering::SeqCst), 1, "one repair attempt only");
+        assert_eq!(fetcher.calls.load(Ordering::SeqCst), 2);
     }
 
     /// `list` is delegated to the inner store (version resolution must stay live) — the fetcher is

--- a/src/memory/fetch_store.rs
+++ b/src/memory/fetch_store.rs
@@ -18,7 +18,6 @@
 //! **A decorator, because Rust has no inheritance** — the inner store is held and every method
 //! forwarded by hand, intercepting only the reads.
 
-use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -27,9 +26,8 @@ use chrono::Utc;
 use futures::stream::{self, BoxStream, StreamExt};
 use object_store::path::Path as OPath;
 use object_store::{
-    Attributes, CopyOptions, GetOptions, GetRange, GetResult, GetResultPayload, ListResult, MultipartUpload,
-    ObjectMeta, ObjectStore as OSObjectStore, PutMultipartOptions, PutOptions, PutPayload, PutResult,
-    Result as OSResult,
+    Attributes, CopyOptions, GetOptions, GetResult, GetResultPayload, ListResult, MultipartUpload, ObjectMeta,
+    ObjectStore as OSObjectStore, PutMultipartOptions, PutOptions, PutPayload, PutResult, Result as OSResult,
 };
 
 /// Supplies a whole local file for an object key: given the object path, return a local filesystem
@@ -121,7 +119,13 @@ fn serve_from_file(path: &Path, location: &OPath, options: &GetOptions) -> std::
             attributes: Attributes::default(),
         });
     }
-    let range = resolve_range(&options.range, total);
+    let range = match &options.range {
+        None => 0..total,
+        // Not clamped: an out-of-file range underflows where its length is computed.
+        Some(requested) => requested
+            .as_range(total)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e))?,
+    };
     let file = std::fs::File::open(path)?;
     Ok(GetResult {
         payload: GetResultPayload::File(file, path.to_path_buf()),
@@ -129,16 +133,6 @@ fn serve_from_file(path: &Path, location: &OPath, options: &GetOptions) -> std::
         range,
         attributes: Attributes::default(),
     })
-}
-
-/// The concrete byte range a [`GetOptions`] selects within a `total`-byte file (clamped to the file).
-fn resolve_range(range: &Option<GetRange>, total: u64) -> Range<u64> {
-    match range {
-        None => 0..total,
-        Some(GetRange::Bounded(r)) => r.start..r.end.min(total),
-        Some(GetRange::Offset(o)) => (*o).min(total)..total,
-        Some(GetRange::Suffix(n)) => total.saturating_sub(*n)..total,
-    }
 }
 
 fn meta(location: OPath, size: u64) -> ObjectMeta {
@@ -158,6 +152,7 @@ mod tests {
 
     use bytes::Bytes;
     use object_store::memory::InMemory;
+    use object_store::GetRange;
     use tempfile::TempDir;
 
     /// A fake fetcher: writes each requested file to a temp dir from a fixed body and returns its
@@ -270,6 +265,25 @@ mod tests {
             1,
             "fetch was attempted before falling back"
         );
+    }
+
+    /// A copy that cannot span the request is not served: the inner store answers instead.
+    #[tokio::test]
+    async fn copy_too_short_for_the_range_falls_back_to_inner() {
+        let (store, _f, inner) = store_with(&[("f", b"<Error/>")]);
+        let loc = OPath::from("f");
+        inner
+            .put_opts(&loc, PutPayload::from("0123456789abcdefghij"), PutOptions::default())
+            .await
+            .unwrap();
+        let opts = GetOptions {
+            range: Some(GetRange::Bounded(12..16)),
+            ..Default::default()
+        };
+
+        let got = store.get_opts(&loc, opts).await.unwrap();
+
+        assert_eq!(got.bytes().await.unwrap(), Bytes::from_static(b"cdef"));
     }
 
     /// `list` is delegated to the inner store (version resolution must stay live) — the fetcher is

--- a/src/memory/remote.rs
+++ b/src/memory/remote.rs
@@ -37,7 +37,7 @@
 
 use std::collections::{BTreeMap, HashMap};
 use std::io::Write as _;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::{ensure, Context, Result};
@@ -487,6 +487,20 @@ impl FileFetcher for HubFetcher {
             .send()
             .await
             .with_context(|| format!("caching {filename}@{}", self.revision))
+    }
+
+    /// A cache entry links to a blob named by the object's expected hash rather than by the bytes
+    /// on disk, so dropping the entry alone would resolve to those same bytes again.
+    async fn discard(&self, path: &Path) -> Result<()> {
+        let blob = std::fs::read_link(path).ok().map(|target| match path.parent() {
+            Some(dir) if target.is_relative() => dir.join(target),
+            _ => target,
+        });
+        std::fs::remove_file(path).with_context(|| format!("discarding {}", path.display()))?;
+        if let Some(blob) = blob {
+            let _ = std::fs::remove_file(blob);
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
When populating the local cache for dataset objects, the hf-hub crate sometimes writes corrupted files. A download fails, and the error response gets saved in the object's place.

funes then reads that file instead of the object. It is far shorter than the object it stands for.

Lance asks for a byte range from the real object's length, taken from the manifest. That range falls past the end of the corrupted file. funes clamped it instead of refusing it, producing a backwards range. Computing its length underflows, and the process aborts on a capacity overflow.

This breaks every read of the memory, not only pushes. It does not heal: nothing removes the corrupted file, so each retry hits it again.

This pull-request refuses a range the local file cannot span, then discards that file and fetches it once more.

The hf-hub bug is untouched. This only recovers from it.