### PR TITLE
fix(install): make installer test portable

### DIFF
--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -11,6 +11,16 @@ asset="funes-x86_64-linux"
 version="9.9.9"
 mkdir -p "$fixtures/v$version" "$fakebin" "$install"
 
+cat > "$fakebin/uname" <<'SH'
+#!/bin/sh
+set -eu
+case "${1:-}" in
+    -s) printf '%s\n' Linux ;;
+    -m) printf '%s\n' x86_64 ;;
+    *) exit 2 ;;
+esac
+SH
+
 cat > "$fakebin/curl" <<'SH'
 #!/bin/sh
 set -eu
@@ -26,7 +36,7 @@ done
 relative=${url#*/resolve/}
 cp "$FIXTURE_ROOT/$relative" "$output"
 SH
-chmod +x "$fakebin/curl"
+chmod +x "$fakebin/uname" "$fakebin/curl"
 
 printf '%s\n' "$version" > "$fixtures/VERSION"
 printf '%s\n' "$version" > "$fixtures/v$version/VERSION"
@@ -34,7 +44,14 @@ cat > "$fixtures/v$version/$asset" <<SH
 #!/bin/sh
 echo 'funes $version'
 SH
-digest=$(sha256sum "$fixtures/v$version/$asset" | awk '{ print $1 }')
+if command -v sha256sum >/dev/null 2>&1; then
+    digest=$(sha256sum "$fixtures/v$version/$asset" | awk '{ print $1 }')
+elif command -v shasum >/dev/null 2>&1; then
+    digest=$(shasum -a 256 "$fixtures/v$version/$asset" | awk '{ print $1 }')
+else
+    echo "installer test requires sha256sum or shasum" >&2
+    exit 1
+fi
 printf '%s  %s\n' "$digest" "$asset" > "$fixtures/v$version/SHA256SUMS"
 
 PATH="$fakebin:$PATH" FIXTURE_ROOT="$fixtures" FUNES_INSTALL_DIR="$install" \


### PR DESCRIPTION
## Summary

- make the installer test independent of the host OS and architecture by providing a deterministic `uname` fixture
- generate the fixture checksum with either `sha256sum` or the macOS-native `shasum`

## Why

The test fixture only contains `funes-x86_64-linux`, while `install.sh` detects the real host platform. On Apple Silicon, the installer therefore requests `funes-arm64-apple-darwin` and the test fails before exercising the intended checksum behavior.

## Testing

- `sh scripts/test-install.sh`
- `PATH=/usr/bin:/bin sh scripts/test-install.sh`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --all-targets --no-default-features --features onnx -- -D warnings`
- `RUST_MIN_STACK=16777216 cargo test -- --nocapture`