### PR TITLE
Avoid denormal stalls in blas backend

### DIFF
--- a/benchmark/bench_backends.rs
+++ b/benchmark/bench_backends.rs
@@ -3,9 +3,11 @@
 //! compares whatever backends are compiled in, with ONNX (fastembed) as the reference when present:
 //!   cargo run --release --features onnx --example bench_backends
 //!
-//! Two workloads, because they stress different things: a batch of short docs is dominated by
+//! Three workloads, because they stress different things: a batch of short docs is dominated by
 //! per-call overheads (tokenization, thread spawns), while 30 docs at the 512-token truncation
-//! cap — recall's rerank worst case — is dominated by GEMM throughput and memory behavior.
+//! cap — recall's rerank worst case — is dominated by GEMM throughput and memory behavior. The
+//! ragged batch is real indexing's shape — batch-longest padding masks most attention columns,
+//! the x86 denormal case (see `FtzDazGuard` in src/inference/blas.rs).
 //!
 //! Adding a backend = impl Embedder+Reranker, gate it behind a feature, and push it in `backends()`.
 
@@ -39,12 +41,25 @@ fn short_docs() -> Vec<String> {
     .to_vec()
 }
 
-fn long_docs() -> Vec<String> {
+fn capped_docs(n: usize) -> Vec<String> {
     let sent = "recall fuses vector ann and bm25 hits by reciprocal rank before the cross-encoder \
                 rescores each candidate against the query using joint attention over the pair. ";
     // ~500 tokens after tokenization, truncated at 512 — recall's rerank candidates at the cap.
     let doc = sent.repeat(18);
-    vec![doc; 30]
+    vec![doc; n]
+}
+
+fn long_docs() -> Vec<String> {
+    capped_docs(30)
+}
+
+/// A ragged batch — a couple of ~512-token docs, the rest short: real indexing's shape, and the
+/// one that exposes padding stalls.
+fn mixed_docs() -> Vec<String> {
+    let short = short_docs();
+    let mut docs = capped_docs(2);
+    docs.extend((0..16 - docs.len()).map(|i| short[i % short.len()].clone()));
+    docs
 }
 
 struct Backend {
@@ -101,9 +116,12 @@ fn main() -> Result<()> {
         eprintln!("note: only one backend is compiled — build with `--features onnx` to A/B against the reference\n");
     }
 
-    // (label, docs, warmups, timed iters) — fewer iterations for the long shape, where a single
-    // forward runs for seconds.
-    let workloads = [("16×short", short_docs(), 2, 5), ("30×~500tok", long_docs(), 1, 3)];
+    // (label, docs, warmups, timed iters) — fewer iterations where a single forward runs seconds.
+    let workloads = [
+        ("16×short", short_docs(), 2, 5),
+        ("30×~500tok", long_docs(), 1, 3),
+        ("16×mixed", mixed_docs(), 1, 1),
+    ];
 
     println!(
         "{:<12} {:<12} {:>10} {:>11} {:>16} {:>16}",

--- a/src/inference/blas.rs
+++ b/src/inference/blas.rs
@@ -672,6 +672,50 @@ fn to_batch(encs: &[tokenizers::Encoding]) -> (Vec<i64>, Vec<i64>, usize, usize)
     (ids, mask, n, l)
 }
 
+/// RAII: MXCSR FTZ|DAZ, restored on drop (x86_64 no-op elsewhere) — padded batches leave
+/// softmax's masked scores at ≈FLT_MIN and the scores×V GEMM then stalls on denormals, which
+/// ARM (default FTZ) never sees.
+#[cfg(target_arch = "x86_64")]
+struct FtzDazGuard(u32);
+
+#[cfg(target_arch = "x86_64")]
+impl FtzDazGuard {
+    #[inline]
+    fn new() -> Self {
+        let mut old: u32 = 0;
+        unsafe {
+            core::arch::asm!("stmxcsr [{}]", in(reg) &mut old as *mut u32 as usize,
+                             options(nostack, preserves_flags));
+            let new = old | 0x8040;
+            core::arch::asm!("ldmxcsr [{}]", in(reg) &new as *const u32 as usize,
+                             options(nostack, preserves_flags, readonly));
+        }
+        Self(old)
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+impl Drop for FtzDazGuard {
+    #[inline]
+    fn drop(&mut self) {
+        unsafe {
+            core::arch::asm!("ldmxcsr [{}]", in(reg) &self.0 as *const u32 as usize,
+                             options(nostack, preserves_flags, readonly));
+        }
+    }
+}
+
+#[cfg(not(target_arch = "x86_64"))]
+struct FtzDazGuard;
+
+#[cfg(not(target_arch = "x86_64"))]
+impl FtzDazGuard {
+    #[inline]
+    fn new() -> Self {
+        Self
+    }
+}
+
 /// bge-small-en-v1.5 embedder: BERT encoder → CLS → L2-normalize.
 pub struct BlasEmbedder {
     w: HashMap<String, Vec<f32>>,
@@ -692,6 +736,7 @@ impl BlasEmbedder {
 
 impl Embedder for BlasEmbedder {
     fn embed(&mut self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+        let _ftz = FtzDazGuard::new();
         let encs = self
             .tok
             .encode_batch(texts.to_vec(), true)
@@ -730,6 +775,7 @@ impl BlasReranker {
 
 impl Reranker for BlasReranker {
     fn rerank(&mut self, query: &str, docs: &[&str]) -> Result<Vec<f32>> {
+        let _ftz = FtzDazGuard::new();
         let pairs: Vec<(&str, &str)> = docs.iter().map(|d| (query, *d)).collect();
         let encs = self
             .tok


### PR DESCRIPTION
- Set FTZ/DAZ on x86_64 around embed and rerank.
- Padded batches leave masked scores at ~FLT_MIN and the scores×V GEMM then stalls on denormals.
- Add a mixed ragged batch to bench_backends to cover it.

See #139 , on my laptop I measured:

| workload | unpatched | patched |
| --- | --- | --- |
| 16×short · embed / rerank | 480 / 989 ms | 468 / 921 ms (unchanged — no padding) |
| 30×~500tok · embed / rerank | 3,219 / 8,539 ms | 2,866 / 7,499 ms (unchanged — no padding) |
| **16×mixed · embed** | **26,524 ms** | **1,976 ms (13.4×)** |
| **16×mixed · rerank** | **49,300 ms** | **4,476 ms (11.0×)** |

<details>

# Agent Summary
Work was performed with glm-5.3-flash in pi.

## Root cause

1. Real batches are **ragged**: batch-longest padding stretches every sequence shorter than the
   batch's longest (usually most of them) to that length, with `mask = 0` on the tail.
2. Masked attention scores are set to −1e30 before `softmax_rows`.
3. `vexp` clamps its input to [−87.336, 88.722] — and −87.336 is exactly ln(2⁻¹²⁶). So exp of a
   masked score returns `FLT_MIN` (1.18e-38), the smallest **normal** float — not zero.
4. The AV-GEMM (`scores × V`) multiplies that sea of `FLT_MIN` values; products land in the
   denormal range, and x86 services denormal FMA with microcode assists (~10–100× slower).
5. Rust does not set FTZ/DAZ, so the stalls happen. ARM/NEON flushes denormals by default, so
   the same code on macOS (Accelerate) is unaffected.

## Evidence

Microbenchmark — same real bge-small weights, same shapes, only the mask differs
(256×512-token batch):

| batch | embed time |
| --- | --- |
| all-real tokens (no padding) | 22.6 s (11.3 texts/s) |
| padded: 64 of 512 tokens real | **284.7 s (0.9 texts/s) — 12.6× slower** |
| padded + MXCSR FTZ\|DAZ | **26.1 s — full recovery** |
| padded + zeroing masked scores post-softmax | 44.5 s (partial: padded rows keep softmax tails in unmasked columns) |

End to end — the installed release binary vs the same binary logic with the fix, identical
1237-chunk session set:

| | unpatched | patched |
| --- | --- | --- |
| embed total | 1044 s (1.2 chunks/s) | 124 s (10 chunks/s) |
| CPU time | 12 179 s | 1 892 s |

`benchmark/bench_backends.rs` with the new `16×mixed` workload (2 docs at the 512 cap + 14
short) reproduces the gap in one command:

| workload | unpatched | patched |
| --- | --- | --- |
| 16×short · embed / rerank | 480 / 989 ms | 468 / 921 ms (unchanged — no padding) |
| 30×~500tok · embed / rerank | 3,219 / 8,539 ms | 2,866 / 7,499 ms (unchanged — no padding) |
| **16×mixed · embed** | **26,524 ms** | **1,976 ms (13.4×)** |
| **16×mixed · rerank** | **49,300 ms** | **4,476 ms (11.0×)** |

The uniform workloads stay flat by construction — which is also why the original
`bench_backends` reproduction suggestion could not see the problem.

## The fix

`src/inference/blas.rs`: an RAII `FtzDazGuard` — raised for the duration of each `embed()` /
`rerank()` call, restored on drop, x86_64-only (inline `stmxcsr`/`ldmxcsr`, MXCSR `FTZ` bit 15
+ `DAZ` bit 6; no-op stub elsewhere). Threads spawned while the guard is live (the scoped
attention workers, faer's rayon pool) inherit FP control state at clone on Linux, so one guard
per forward covers the whole pipeline, and the process's FP mode is restored afterwards.

- Numerics: flushing values ≤ 1.2e-38 to zero is insignificant at embedding precision — these
  values are already numerically zero in every downstream use (cosine similarity over L2-
  normalized vectors).
- Alternatives measured: zeroing masked scores post-softmax recovers ~6.4× but is incomplete
  (softmax tails in unmasked columns of padded rows stall too); a value-flush inside
  `softmax_rows` (`if *v < 1e-30 { *v = 0.0 }`) is the local variant of the same idea.
- ONNX note: fastembed/onnxruntime 1.29 on the same box ran the same 256×512 batch in 182 s vs
  the BLAS path's 27 s — BLAS is the *faster* local backend on Linux here; the remote/TEI
  backend discussed in #139 remains the right answer for bulk indexing on a GPU workstation.

## Known gaps / follow-ups

- **aarch64 is not handled**: Linux on ARM also starts with FPCR.FZ off; the same class of
  stall is plausible via NEON. Untested here (no aarch64 hardware).
- The guard is per-thread state: threads spawned *before* the first forward (e.g. a warm rayon
  pool in a long-lived MCP server process) keep whatever mode they started with; in practice
  the pool spawns on the first parallel op, inside the guard.
</details>