### PR TITLE
feat(windows): add native CLI and Codex support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
       - "scripts/install.sh"
+      - "scripts/install.ps1"
       - ".github/workflows/release.yml"
   workflow_dispatch:
     inputs:
@@ -268,17 +269,72 @@ jobs:
           name: macos-arm64
           path: dist/
 
-  # Runs only after both builds succeed. The release itself — tag + GitHub Release with the binaries
+  build-windows:
+    name: Build Windows (x86_64)
+    needs: [compute]
+    if: |
+      !cancelled() &&
+      (startsWith(github.ref, 'refs/tags/') || needs.compute.result == 'success'
+        || github.event_name == 'pull_request' || github.ref == 'refs/heads/main')
+    runs-on: windows-latest
+    timeout-minutes: 90
+    env:
+      PROFILE: ${{ (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')) && 'dist' || 'release' }}
+      CARGO_BUILD_JOBS: '2'
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582
+        with:
+          toolchain: 1.95.0
+          targets: x86_64-pc-windows-msvc
+      - uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16
+        with:
+          key: release-windows-${{ env.PROFILE }}
+      - name: Install protoc
+        run: |
+          $archive = Join-Path $env:RUNNER_TEMP 'funes-protoc.zip'
+          $destination = Join-Path $env:RUNNER_TEMP 'funes-protoc'
+          Invoke-WebRequest 'https://github.com/protocolbuffers/protobuf/releases/download/v28.3/protoc-28.3-win64.zip' -OutFile $archive
+          Expand-Archive $archive -DestinationPath $destination
+          "PROTOC=$destination\bin\protoc.exe" >> $env:GITHUB_ENV
+      - name: Set release version
+        if: needs.compute.outputs.version != ''
+        env:
+          RELEASE_VERSION: ${{ needs.compute.outputs.version }}
+        run: |
+          $manifest = [IO.File]::ReadAllText('Cargo.toml')
+          $pattern = [regex]::new('(?m)^version = "[^"]+"')
+          [IO.File]::WriteAllText((Join-Path $PWD 'Cargo.toml'), $pattern.Replace($manifest, ('version = "' + $env:RELEASE_VERSION + '"'), 1))
+      - name: Build and verify version
+        run: |
+          cargo build --profile $env:PROFILE --target x86_64-pc-windows-msvc
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $binary = "target/x86_64-pc-windows-msvc/$env:PROFILE/funes.exe"
+          $expected = [regex]::Match([IO.File]::ReadAllText('Cargo.toml'), '(?m)^version = "([^"]+)"').Groups[1].Value
+          $reported = & $binary --version
+          if ($LASTEXITCODE -ne 0 -or $reported -cne "funes $expected") { throw 'Binary version mismatch' }
+          $null = New-Item -ItemType Directory -Force dist
+          Copy-Item $binary dist/funes-x86_64-windows.exe
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: windows-x86_64
+          path: dist/
+
+  # Runs only after all builds succeed. The release itself — tag + GitHub Release with the binaries
   # — never touches main, so branch protection doesn't apply. The only change to main, advancing the
   # `+dev` version marker, is pushed as a branch; the org blocks Actions from opening PRs, so a
   # maintainer opens that PR (one click from the run summary) and merges it.
   publish:
     name: Publish Release
-    needs: [compute, build-linux, build-macos]
+    needs: [compute, build-linux, build-macos, build-windows]
     if: |
       !cancelled() &&
       needs.build-linux.result == 'success' &&
       needs.build-macos.result == 'success' &&
+      needs.build-windows.result == 'success' &&
       (startsWith(github.ref, 'refs/tags/') || needs.compute.result == 'success')
     runs-on: ubuntu-24.04
     timeout-minutes: 15
@@ -293,7 +349,7 @@ jobs:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
-          pattern: "{linux-*,macos-*}"
+          pattern: "{linux-*,macos-*,windows-*}"
           merge-multiple: true
 
       - name: Validate release metadata and generate checksums
@@ -313,7 +369,8 @@ jobs:
           set -- \
             funes-x86_64-linux \
             funes-aarch64-linux \
-            funes-arm64-apple-darwin
+            funes-arm64-apple-darwin \
+            funes-x86_64-windows.exe
           for ASSET in "$@"; do
             test -f "artifacts/$ASSET" || {
               echo "::error::missing release asset: $ASSET"
@@ -361,11 +418,12 @@ jobs:
           ROOT="hf://buckets/huggingface/funes"
 
           "$HF" buckets sync ./artifacts "$ROOT/$TAG" --ignore-existing
-          for ASSET in funes-x86_64-linux funes-aarch64-linux funes-arm64-apple-darwin; do
+          for ASSET in funes-x86_64-linux funes-aarch64-linux funes-arm64-apple-darwin funes-x86_64-windows.exe; do
             "$HF" buckets cp "./artifacts/$ASSET" "$ROOT/$ASSET"
           done
           "$HF" buckets cp ./artifacts/VERSION "$ROOT/VERSION"
           "$HF" buckets cp scripts/install.sh "$ROOT/install.sh"
+          "$HF" buckets cp scripts/install.ps1 "$ROOT/install.ps1"
 
       # Dispatch only: push a branch advancing main's version marker to `<version>+dev`. The org
       # blocks Actions from opening PRs, so the workflow stops at the branch and surfaces a one-click

--- a/.github/workflows/windows-probe.yml
+++ b/.github/workflows/windows-probe.yml
@@ -1,11 +1,13 @@
-name: Windows dependency probe
+name: Windows native
 
 on:
   push:
-    branches: [feature/windows-minimum-support]
+    branches: [main, feature/windows-minimum-support]
   pull_request:
     paths:
       - 'src/**'
+      - 'tests/**'
+      - 'scripts/**'
       - 'Cargo.*'
       - 'build.rs'
       - '.github/workflows/windows-probe.yml'
@@ -26,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        backend: [blas, onnx]
+        backend: [blas]
     env:
       RUST_BACKTRACE: '1'
       RUST_MIN_STACK: '16777216'
@@ -35,11 +37,16 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582
         with:
+          toolchain: 1.95.0
           targets: x86_64-pc-windows-msvc
           components: clippy
       - uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16
         with:
           key: windows-probe-${{ matrix.backend }}
+          cache-directories: ~/.cache/huggingface
+      - name: PowerShell installer and automation tests
+        shell: powershell
+        run: ./scripts/test-windows.ps1
       - name: Install pinned protoc
         shell: pwsh
         run: |
@@ -57,4 +64,14 @@ jobs:
         shell: pwsh
         run: |
           cargo test --locked --profile ci --test index_recall --target x86_64-pc-windows-msvc --no-default-features --features '${{ matrix.backend }}' -- --nocapture
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      - name: Clippy
+        shell: pwsh
+        run: |
+          cargo clippy --locked --all-targets --profile ci --target x86_64-pc-windows-msvc -- -D warnings
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      - name: Unit and native Codex tests
+        shell: pwsh
+        run: |
+          cargo test --locked --profile ci --lib --test add_codex_hooks --test windows_codex --target x86_64-pc-windows-msvc
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/.github/workflows/windows-probe.yml
+++ b/.github/workflows/windows-probe.yml
@@ -1,0 +1,60 @@
+name: Windows dependency probe
+
+on:
+  push:
+    branches: [feature/windows-minimum-support]
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'Cargo.*'
+      - 'build.rs'
+      - '.github/workflows/windows-probe.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: windows-probe-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  native:
+    name: MSVC (${{ matrix.backend }})
+    runs-on: windows-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        backend: [blas, onnx]
+    env:
+      RUST_BACKTRACE: '1'
+      RUST_MIN_STACK: '16777216'
+      CARGO_BUILD_JOBS: '2'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582
+        with:
+          targets: x86_64-pc-windows-msvc
+          components: clippy
+      - uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16
+        with:
+          key: windows-probe-${{ matrix.backend }}
+      - name: Install pinned protoc
+        shell: pwsh
+        run: |
+          $archive = Join-Path $env:RUNNER_TEMP 'funes-protoc.zip'
+          $destination = Join-Path $env:RUNNER_TEMP 'funes-protoc'
+          Invoke-WebRequest 'https://github.com/protocolbuffers/protobuf/releases/download/v28.3/protoc-28.3-win64.zip' -OutFile $archive
+          Expand-Archive $archive -DestinationPath $destination
+          "PROTOC=$destination\bin\protoc.exe" >> $env:GITHUB_ENV
+      - name: Check native crate and exact dependency graph
+        shell: pwsh
+        run: |
+          cargo check --locked --profile ci --bin funes --target x86_64-pc-windows-msvc --no-default-features --features '${{ matrix.backend }}'
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      - name: Build and run real index and recall
+        shell: pwsh
+        run: |
+          cargo test --locked --profile ci --test index_recall --target x86_64-pc-windows-msvc --no-default-features --features '${{ matrix.backend }}' -- --nocapture
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,10 @@ You need:
 
 ## Building and testing
 
+For native Windows setup and the PowerShell test suite, see [docs/windows.md](docs/windows.md).
+Run `powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/test-windows.ps1` for the
+hermetic installer and detached-worker tests.
+
 ```bash
 cargo build --release          # binary at target/release/funes
 cargo test --lib               # unit tests — hermetic, no network
@@ -80,6 +84,7 @@ fine; CI runs them with the repository secret.
   | `commands/` | what funes does when you run it: orchestration and decisions |
   | `ui/` | how a result reaches the terminal |
   | `agents/` | registering funes with a coding agent (MCP + automation hooks) |
+  | `platform.rs` | shared host filesystem conventions (profile discovery and path classification) |
 
   Where does a new function go? Names an HF concept → transport. Names Lance → mechanics.
   Answers *what is this memory, what state is it in* → domain. Decides *what to do about it* →

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3089,6 +3089,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "async-trait",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ parquet = "58"                   # read agent-trace datasets stored as parquet (
 object_store = "=0.13.2"         # the ObjectStore trait the capture wrapper implements (matches lance-io)
 async-trait = "0.1"              # for the ObjectStore impl in src/memory/capture_store.rs
 bytes = "1"                      # captured write payloads
+base64 = "0.22"                  # shell-safe UTF-16 PowerShell hook commands
 chrono = "0.4"                   # recency weighting
 rusqlite = { version = "0.32", features = ["bundled"] }  # read hermes' ~/.hermes/state.db; bundled = SQLite compiled in, no runtime dep
 serde_yaml = "0.9"               # merge funes' hooks into hermes' ~/.hermes/config.yaml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ safetensors = { version = "0.8", optional = true }
 
 # The `blas` backend's Linux seam. Both are pure Rust with runtime CPU dispatch, so release
 # binaries stay baseline x86-64/aarch64 yet use AVX2/AVX-512/NEON where the host has them.
-[target.'cfg(target_os = "linux")'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "windows"))'.dependencies]
 faer = { version = "0.24", optional = true, default-features = false, features = ["std", "rayon"] }  # GEMM ("std" pulls its fast x86 kernels)
 multiversion = { version = "0.8", optional = true }  # per-CPU clones of the vectorized exp
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ agent can recall from it.
 
 ## Get funes
 
+For native Windows x86-64, see the [Windows instructions](docs/windows.md) (core CLI and Codex
+automation). This port is awaiting its first release; older releases have no Windows asset.
+
 The [installer](scripts/install.sh) detects your platform, downloads the matching prebuilt binary,
 verifies its tagged release checksum and version, and puts it on your PATH (`~/.local/bin` by
 default):

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -81,5 +81,6 @@ The Windows job runs PowerShell installer/hook tests, the real-memory test under
 paths, Clippy, unit tests, and Codex integration tests with a compiled native fixture. Before
 advertising a desktop release, run a clean Windows 10/11 install → CMD version → index → recall →
 Codex turn/hook → remove journey. CI uses a Windows Server runner; it does not constitute that
-manual desktop test. Authenticated Hub round trips passed with synthetic data; cross-OS memory
-transfer and installation from a versioned release asset remain unverified.
+manual desktop test. Authenticated Hub round trips and Windows/Linux memory exchange passed with
+synthetic data. Clean desktop installation and installation from a versioned release asset remain
+unverified.

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -74,11 +74,12 @@ installer, and Bash automation separately.
 The native dependency probe passed real index/recall tests with both BLAS and ONNX on an MSVC
 Windows runner. The release backend remains the default BLAS/faer; the models and memory schema
 are unchanged. See the [execution record](../openspec/changes/add-windows-minimum-support/execution.md)
-for exact commits, runs, and remaining validation.
+for the initial build evidence and the [acceptance record](../openspec/changes/add-windows-minimum-support/acceptance.md)
+for subsequent desktop and authenticated Hub validation.
 
 The Windows job runs PowerShell installer/hook tests, the real-memory test under space/non-ASCII
 paths, Clippy, unit tests, and Codex integration tests with a compiled native fixture. Before
 advertising a desktop release, run a clean Windows 10/11 install → CMD version → index → recall →
 Codex turn/hook → remove journey. CI uses a Windows Server runner; it does not constitute that
-manual desktop test. Authenticated Hub round trips and cross-OS memory transfer remain release
-checks where the required credentials and machines are available.
+manual desktop test. Authenticated Hub round trips passed with synthetic data; cross-OS memory
+transfer and installation from a versioned release asset remain unverified.

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -1,0 +1,84 @@
+# Native Windows
+
+The minimum tier is the x86-64 native CLI plus Codex MCP, skills, and automatic indexing/publishing.
+The executable runs from PowerShell or CMD without Bash or WSL. Automation and installation use
+Windows PowerShell 5.1. Claude, pi, and Hermes transcript files can still be indexed explicitly;
+their automatic integrations, Windows ARM64, desktop UI, and in-place self-update are excluded.
+
+## Availability and installation
+
+The Windows asset is `funes-x86_64-windows.exe`. It will be available in the first release containing
+this change; the installer intentionally fails if a selected older release has no Windows checksum.
+Until that release, build this branch with Rust 1.95.0, Visual Studio C++ build tools, and protoc 28.3:
+
+```powershell
+$env:PROTOC = 'C:\tools\protoc\bin\protoc.exe'
+cargo build --release --target x86_64-pc-windows-msvc
+.\target\x86_64-pc-windows-msvc\release\funes.exe --version
+```
+
+After a Windows release is published, download the installer and run it from PowerShell:
+
+```powershell
+Invoke-WebRequest https://huggingface.co/buckets/huggingface/funes/resolve/install.ps1 -OutFile "$env:TEMP\funes-install.ps1"
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$env:TEMP\funes-install.ps1"
+```
+
+The default location is `%LOCALAPPDATA%\Programs\funes\bin`. The installer verifies the tagged
+version, the SHA-256 manifest, and the staged executable's reported version before replacing an
+existing binary. Open a new terminal after its user PATH update. Options are `-InstallDir`,
+`-Version` (for example `1.3.0` or `v1.3.0`), and `-NoPathUpdate`. A custom install directory is not
+added to PATH automatically. No administrator permission or persistent execution-policy change is
+required; organizational policies can still restrict script execution.
+
+Close running agents and MCP servers before reinstalling. `funes update` prints the reinstall
+command and does not download or attempt to overwrite its running executable on Windows.
+
+## CLI and Codex
+
+```powershell
+funes --version
+funes index 'C:\Users\Alice\transcripts' --harness codex
+funes recall 'why did we choose this design'
+funes add codex
+# In Codex, use /hooks to review and trust the installed commands.
+funes remove codex
+```
+
+In CMD, quote paths with double quotes: `funes index "C:\Users\Alice\transcripts" --harness codex`.
+Drive paths and UNC paths remain local memory paths rather than Hub repository shorthands.
+
+`codex doctor --json` selects Codex's configuration directory when available, followed by
+`CODEX_HOME`, then the user's Windows profile plus `.codex`. The installed scripts are
+`hooks\funes-index.ps1` and `hooks\funes-push.ps1`; logs go beside them in `funes-sync.log`.
+The foreground hook drains its input and starts a detached worker. Encoded PowerShell commands keep
+paths and arguments out of CMD's expansion rules. The push worker retries indexing up to five times
+before publishing what is already stored; secret-gate exit code 2 is logged as a warning.
+
+Codex native executables and npm `.cmd` shims are resolved from PATH. Arguments are passed through
+Rust's process API, including its batch-file escaping rules, rather than concatenated into a CMD
+command ([Rust process documentation](https://doc.rust-lang.org/std/process/index.html)).
+
+State defaults to `%USERPROFILE%\.funes`, with `FUNES_HOME` taking precedence. `CODEX_HOME` also
+controls the sessions directory used by automated indexing. `HF_HOME` overrides the Hugging Face
+cache root; `HF_TOKEN_PATH` overrides its token file. Token environment variables retain priority.
+`FUNES_BIN` can point hooks and MCP registration to an explicit `funes.exe` path.
+
+Publishing requires a Windows `trufflehog.exe` on PATH or an absolute `FUNES_TRUFFLEHOG` override.
+Install the official trufflehog executable before binding an agent to a remote memory. The scan
+fails closed when the executable is unavailable. WSL continues to use the existing Linux binary,
+installer, and Bash automation separately.
+
+## Verification and release checklist
+
+The native dependency probe passed real index/recall tests with both BLAS and ONNX on an MSVC
+Windows runner. The release backend remains the default BLAS/faer; the models and memory schema
+are unchanged. See the [execution record](../openspec/changes/add-windows-minimum-support/execution.md)
+for exact commits, runs, and remaining validation.
+
+The Windows job runs PowerShell installer/hook tests, the real-memory test under space/non-ASCII
+paths, Clippy, unit tests, and Codex integration tests with a compiled native fixture. Before
+advertising a desktop release, run a clean Windows 10/11 install → CMD version → index → recall →
+Codex turn/hook → remove journey. CI uses a Windows Server runner; it does not constitute that
+manual desktop test. Authenticated Hub round trips and cross-OS memory transfer remain release
+checks where the required credentials and machines are available.

--- a/openspec/architecture.md
+++ b/openspec/architecture.md
@@ -1,0 +1,136 @@
+# Funes architecture and Windows-readiness analysis
+
+Status: baseline analysis; implementation evidence is recorded in the change's execution.md
+Repository snapshot: `huggingface/funes` `main@1a01cc243b06a2d70f08f0da338b9bf29c275631`
+Related issue: [#136 — When to support Windows and desktop app for agents](https://github.com/huggingface/funes/issues/136)
+
+## 1. Conclusion
+
+Windows support is not only a matter of adapting the user-facing command line from Bash to CMD.
+The public CLI is already mostly ordinary Rust and should work in both CMD and PowerShell once it
+builds, but the product currently has five platform seams that block a native Windows release:
+
+1. the default inference backend only defines macOS and Linux implementations;
+2. hook installation and self-update import Unix-only filesystem APIs;
+3. automatic indexing/publishing is implemented by Bash scripts and Unix detachment primitives;
+4. home-directory, cache, known-session-root, and local-path detection assume POSIX conventions;
+5. CI, release packaging, checksums, and installation publish only Linux and Apple Silicon macOS.
+
+The smallest credible Windows release is therefore a native x86-64 CLI plus Codex integration,
+not a desktop GUI and not full four-agent parity. It should be installable with PowerShell and then
+usable from either PowerShell or CMD.
+
+## 2. Product invariants
+
+The Windows change must preserve the design constraints in `docs/RATIONALE.md`:
+
+- memory remains an append-only event log;
+- ingest remains deterministic (`parse -> chunk -> embed`) with no LLM;
+- indexing, embedding, reranking, and local recall stay local-first;
+- recall remains explicitly pulled by the user or agent;
+- stored chunks retain exact session/turn provenance;
+- the embedding model identity and memory compatibility contract do not change by OS.
+
+Windows support is a platform port. It must not redesign the memory model or retrieval behavior.
+
+## 3. Runtime architecture
+
+```mermaid
+flowchart TD
+    A["Agent transcripts"] --> B["TraceSource adapters"]
+    B --> C["Generic turns and blocks"]
+    C --> D["Chunk and redact"]
+    D --> E["Local embedding"]
+    E --> F["Lance memory"]
+    F --> G["Vector plus BM25"]
+    G --> H["Rerank and recency"]
+    H --> I["CLI or MCP tools"]
+```
+
+| Layer | Current implementation | Contract |
+| --- | --- | --- |
+| CLI entry and dispatch | `src/main.rs` | `clap` commands route into command modules; human output and MCP output are separate contracts. |
+| Agent integrations | `src/agents/{claude,codex,pi,hermes}.rs` | `funes add/remove` installs MCP/skills/hooks without overwriting unrelated user config. |
+| Trace discovery | `src/traces/harness.rs`, `src/traces/source.rs` | Known agent roots or explicit paths become a `TraceSource`. |
+| Parsing | `src/traces/*.rs` | Agent-specific records become generic turns and blocks with provenance. |
+| Indexing | `src/commands/index.rs`, `src/chunk.rs` | Incremental, idempotent, tiered parse/chunk/embed/write pipeline. |
+| Inference | `src/inference.rs`, `src/inference/blas.rs` | Pinned local embedder and reranker behind common traits. |
+| Storage | `src/memory.rs`, `src/memory/*` | Local or Hub-backed Lance dataset; local memory is rebuildable from transcripts. |
+| Retrieval | `src/commands/recall.rs` | Vector + BM25 fusion, cross-encoder rerank, recency weight, neighbor expansion. |
+| Agent-facing API | `src/commands/mcp.rs` | Stdio MCP exposes recall/get/sessions/scan/sketch/status; stdout is reserved for JSON-RPC. |
+| Automation | `src/agents/hooks.rs`, `scripts/automation/*.sh` | Per-turn indexing and session-boundary publishing detach from the agent hook. |
+| Distribution | `.github/workflows/*.yml`, `scripts/install.sh`, `src/commands/update.rs` | Build, checksum, publish, install, and self-update platform assets. |
+
+## 4. Existing behavior that is already close to Windows-ready
+
+- CLI argument parsing, JSON/JSONL/SQLite/Parquet parsing, chunking, redaction, MCP stdio, and most
+  retrieval logic use portable Rust APIs.
+- `std::process::Command` can launch `codex.exe`, `claude.exe`, or other executables through Windows
+  `PATH` without going through CMD.
+- Existing Claude fixtures already contain Windows drive paths and PowerShell tool records, so part
+  of the trace parser has incidental Windows coverage.
+- Ratatui/crossterm and Tokio support Windows, subject to a native CI run.
+- `FUNES_HOME`, `CODEX_HOME`, `PI_CODING_AGENT_DIR`, `FUNES_BIN`, and HF token environment
+  overrides can remain platform-independent escape hatches.
+
+## 5. Concrete blockers
+
+| Severity | Blocker | Evidence | Minimum change |
+| --- | --- | --- | --- |
+| Compile blocker | `src/inference/blas.rs` defines a `seam` only for macOS and Linux. | `#[cfg(target_os = "macos")]` and `#[cfg(target_os = "linux")]` | Reuse the pure-Rust faer seam on Windows, or select the ONNX backend after a dependency spike. |
+| Compile blocker | Unix-only `PermissionsExt` is imported by hooks and updater code/tests. | `src/agents/hooks.rs`, `src/commands/update.rs`, integration-test support | Gate executable-bit logic/tests with `cfg(unix)` and add Windows-specific behavior. |
+| Runtime blocker | Automation invokes Bash and uses `nohup`, `/dev/null`, and `disown`. | `scripts/automation/funes-index.sh`, `funes-push.sh`, `hooks::command`, pi extension | Add Windows PowerShell hook scripts and a platform-specific command builder. |
+| Runtime blocker | Home and HF-cache discovery directly read `HOME`. | agent integrations, `traces/harness.rs`, `memory/dataset.rs`, `hub.rs`, `inference/blas.rs` | Centralize profile/home/cache resolution and preserve env overrides. |
+| Correctness blocker | Harness detection string-matches `".codex/sessions"`; Windows canonical paths use `\\`. | `Harness::from_known_dir` | Compare `Path` components rather than rendered strings. |
+| Correctness blocker | `<org>/<repo>` shorthand detection can confuse Windows paths containing `/`. | `hub::is_remote_shorthand`, `Memory::parse` | Recognize drive-rooted and UNC paths before remote shorthand. |
+| Update blocker | Self-update relies on renaming over the currently running Unix executable. | `src/commands/update.rs` | For the minimum release, provide actionable re-install guidance; implement deferred self-replacement later. |
+| Delivery blocker | No Windows CI job, asset, checksum entry, or installer exists. | CI/release workflows and README platform table | Add `windows-latest`, an MSVC x64 asset, `install.ps1`, installer tests, and release manifest wiring. |
+| Dependency risk | Native Windows compatibility of the exact Lance/faer/multiversion dependency graph is not proven in this repo. | Linux-only CI | Make a Windows dependency build spike the first implementation gate. |
+
+## 6. Minimum support boundary
+
+### Included
+
+- Native Windows 10/11 x86-64 (`x86_64-pc-windows-msvc`), without WSL.
+- Install with Windows PowerShell 5.1+; run `funes.exe` from PowerShell or CMD.
+- Core commands: `index`, `recall`, `get`, `sessions`, `sketch`, `scan`, `status`, `scrub`, `push`,
+  `ask codex`, and `mcp`.
+- Local and Hub-backed memory flows, with the external trufflehog prerequisite documented for push.
+- `funes add codex` / `funes remove codex`, including the skill, MCP registration, per-turn index,
+  and bound-memory session publication.
+- Windows-aware home/cache/session paths, drive paths, UNC paths, spaces, and non-ASCII paths.
+- Windows CI, installer verification, release asset, checksum, and documentation.
+- A deterministic message for unsupported Windows integrations or self-update paths; no partial
+  configuration writes.
+
+### Excluded from this change
+
+- Desktop GUI, tray app, service, or background daemon.
+- Windows ARM64-native release.
+- Full native Windows support for Claude, pi, and Hermes integrations; their trace files may still
+  be indexed explicitly.
+- Winget, Chocolatey, Scoop, MSI, or Microsoft Store distribution.
+- Redesigning storage, retrieval ranking, chunk schema, or model selection.
+- Replacing Unix automation scripts with a new cross-platform daemon.
+- In-place `funes update` on Windows; re-running `install.ps1` is the minimum update path.
+
+## 7. Recommended sequencing
+
+1. Prove the exact dependency graph on `windows-latest` before changing product behavior.
+2. Make the Rust core compile by adding the inference and Unix-API platform seams.
+3. Centralize path/profile handling and add Windows-path tests.
+4. Validate explicit-path indexing and local recall end to end.
+5. Port only the Codex automation path to PowerShell.
+6. Add installer/release packaging and then make Windows CI required.
+7. Document explicit limitations and open separate changes for self-update, additional agents, and GUI.
+
+## 8. Research basis
+
+- [Funes README](https://github.com/huggingface/funes/blob/1a01cc243b06a2d70f08f0da338b9bf29c275631/README.md)
+- [Design rationale](https://github.com/huggingface/funes/blob/1a01cc243b06a2d70f08f0da338b9bf29c275631/docs/RATIONALE.md)
+- [Indexing pipeline](https://github.com/huggingface/funes/blob/1a01cc243b06a2d70f08f0da338b9bf29c275631/docs/index.md)
+- [Agent automation](https://github.com/huggingface/funes/blob/1a01cc243b06a2d70f08f0da338b9bf29c275631/docs/automation.md)
+- [Agent hook implementation](https://github.com/huggingface/funes/blob/1a01cc243b06a2d70f08f0da338b9bf29c275631/src/agents/hooks.rs)
+- [Inference platform seam](https://github.com/huggingface/funes/blob/1a01cc243b06a2d70f08f0da338b9bf29c275631/src/inference/blas.rs)
+- [Trace-root discovery](https://github.com/huggingface/funes/blob/1a01cc243b06a2d70f08f0da338b9bf29c275631/src/traces/harness.rs)
+- [Release workflow](https://github.com/huggingface/funes/blob/1a01cc243b06a2d70f08f0da338b9bf29c275631/.github/workflows/release.yml)

--- a/openspec/changes/add-windows-minimum-support/.openspec.yaml
+++ b/openspec/changes/add-windows-minimum-support/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-08

--- a/openspec/changes/add-windows-minimum-support/acceptance.md
+++ b/openspec/changes/add-windows-minimum-support/acceptance.md
@@ -20,7 +20,7 @@ case; it was fixed and reviewed again before final validation.
 ## Local verification
 
 - `cargo fmt --check` and `git diff --check` passed.
-- `cargo test --locked --profile ci --target x86_64-pc-windows-msvc` passed, including 257 library
+- `cargo test --locked --profile ci --target x86_64-pc-windows-msvc` passed, including 258 library
   tests and the main/integration targets. Unix-only/prerequisite-gated cases and tests gated on the upstream HF fixture token did not
   perform remote work; the separate authenticated checks below supply that evidence.
 - All-target Clippy with `-D warnings` passed for both default and `--no-default-features
@@ -33,6 +33,10 @@ case; it was fixed and reviewed again before final validation.
 - The actual npm Codex `.CMD` shim was exercised under space/Unicode paths. Add/repeat/remove and
   user-hook preservation passed. The ownership regression also failed on the old executable and
   passed on the repaired executable.
+- A synthetic drive-rooted Codex rollout preserves PowerShell arguments, Unicode paths, CRLF
+  output, and tool-call correlation. All eight Codex parser tests passed on Windows.
+- The native Codex test also checks profile/state/cache resolution with `HOME` unset and explicit
+  `FUNES_HOME`/`HF_HOME` overrides, using isolated directories and invented token files.
 
 ## Authenticated Hub checks
 
@@ -54,10 +58,15 @@ was uploaded or bound to automatic publishing.
 - Clean Windows 10/11 installation and standard-user CMD/PowerShell journeys.
 - Windows-created memory queried on Linux and Linux-created memory queried on Windows.
 - Installation from a real versioned release asset and matching manifest.
-- Current-commit Windows/Linux CI and release build results must be checked separately; older
-  successful runs are not proof for the repaired source.
 
-No Windows release has been published. The earlier CI evidence is in
-[the Windows run](https://github.com/wellorbetter/funes/actions/runs/34239759269),
-[Linux CI](https://github.com/wellorbetter/funes/actions/runs/34239759267), and
-[release builds](https://github.com/wellorbetter/funes/actions/runs/34239759213).
+## CI evidence
+
+Runtime repair `ad776ee8c026037b972611d52597c591c55de0de` passed
+[Windows native](https://github.com/wellorbetter/funes/actions/runs/34672802662),
+[Linux unit/integration and installer tests](https://github.com/wellorbetter/funes/actions/runs/34672802666),
+and [all four release builds](https://github.com/wellorbetter/funes/actions/runs/34672802674).
+Both Windows jobs started without a cache. The Windows release binary passed its version check
+and was uploaded as a CI artifact. No Windows release has been published.
+
+Subsequent changes add only the regression fixtures described above and documentation. The PR
+checks report their final-head results separately from this runtime-repair evidence.

--- a/openspec/changes/add-windows-minimum-support/acceptance.md
+++ b/openspec/changes/add-windows-minimum-support/acceptance.md
@@ -2,7 +2,7 @@
 
 The native Windows 11 CLI/Codex and authenticated Hub journeys have been exercised on
 Windows 11 build 26200 with Rust 1.95.0 MSVC and Codex 0.153.4. Release qualification remains
-open for clean Windows 10/11 installations and cross-OS memory exchange.
+open for clean Windows 10/11 installations and installation from a versioned release asset.
 
 ## Regression fixes
 
@@ -53,10 +53,18 @@ Only invented transcripts were used in a private, user-authorized dataset. In a 
 The original malformed prefix was retained as diagnostic evidence. No real conversation history
 was uploaded or bound to automatic publishing.
 
+## Cross-OS memory exchange
+
+[The one-off exchange run](https://github.com/wellorbetter/funes/actions/runs/34675674228)
+used the Windows/Linux x86-64 artifacts from final source `94fbec1`. Each OS created a two-chunk
+synthetic Codex memory; the other OS then opened it and retrieved the expected marker and session.
+The producer's file list and SHA-256 hashes matched after transfer and remained unchanged after
+status/recall. Both directions passed without reindexing or migration. The temporary test branch
+is separate from this PR; no user history or Hub credentials were uploaded.
+
 ## Remaining release checks
 
 - Clean Windows 10/11 installation and standard-user CMD/PowerShell journeys.
-- Windows-created memory queried on Linux and Linux-created memory queried on Windows.
 - Installation from a real versioned release asset and matching manifest.
 
 ## CI evidence
@@ -70,3 +78,7 @@ and was uploaded as a CI artifact. No Windows release has been published.
 
 Subsequent changes add only the regression fixtures described above and documentation. The PR
 checks report their final-head results separately from this runtime-repair evidence.
+Source `94fbec1` also passed [Windows native](https://github.com/wellorbetter/funes/actions/runs/34675275335),
+[Linux CI](https://github.com/wellorbetter/funes/actions/runs/34675275419), and
+[release builds](https://github.com/wellorbetter/funes/actions/runs/34675275355).
+The Windows native job passed with its cache restored as well as without a cache in the earlier run.

--- a/openspec/changes/add-windows-minimum-support/acceptance.md
+++ b/openspec/changes/add-windows-minimum-support/acceptance.md
@@ -1,0 +1,58 @@
+# Windows acceptance review — 2026-09-09
+
+Tested implementation: `176a3790bc7a750c5af5f3202ee2dafbe76c2dc3`.
+
+## Decision
+
+Automated CI acceptance passes for the covered scenarios. Full desktop/release acceptance remains
+open. This review inspected completed job logs and artifact metadata; it did not execute a new
+Windows desktop session. Keep the PR as a draft until the intended acceptance scope is resolved.
+
+## Verified evidence
+
+| Area | Result | Evidence and limit |
+| --- | --- | --- |
+| Windows native tests | Pass | Windows Server 2025: 255 unit tests, one real index/recall integration test, add_codex_hooks and windows_codex each passed |
+| Configuration regression fixes | Pass | The 255 unit tests include the four review regressions for mixed hook groups, invalid containers, preservation, and read errors |
+| Installer and background hooks | Pass with fixtures | PowerShell suite reports success; installation uses mocked downloads and hooks invoke a fixture executable |
+| Codex registration and cleanup | Pass with fixture | Compiled codex.exe verifies argument forwarding, home selection, idempotency and cleanup; this does not prove a real Codex conversation triggers hooks |
+| Windows static checks | Pass | Native dependency check and all-target Clippy completed successfully |
+| Linux regression CI | Pass | Completed CI workflow at the tested implementation |
+| Release builds | Pass | Windows x64, Linux x64/ARM64 and macOS ARM64 built successfully; Windows job checks the staged executable's version |
+| Published release | Not performed | Publish Release was skipped for this PR build |
+
+- [Windows tests and full log](https://github.com/wellorbetter/funes/actions/runs/34239759269/job/102106600876)
+- [Linux CI](https://github.com/wellorbetter/funes/actions/runs/34239759267)
+- [Release builds](https://github.com/wellorbetter/funes/actions/runs/34239759213)
+
+The Windows artifact is `windows-x86_64`, artifact ID `10064575172`, ZIP size 74,993,499 bytes.
+GitHub reports ZIP SHA-256
+`880ac0448b453e61e21507391ed219c1918a5669c5f9f9b35699e57bc95620a4`.
+This is the archive digest, not the executable digest. The artifact download connector succeeded,
+but transferring its returned URL into the local inspection process returned HTTP 403; independent
+ZIP/PE/hash inspection was therefore not completed or claimed.
+
+## Remaining acceptance checks
+
+| Check | Required evidence |
+| --- | --- |
+| Clean Windows 11 and Windows 10 journey | Standard user installation, new CMD and PowerShell sessions, version, explicit-path index, recall, real Codex add/turn/background index/remove; retain logs and exact OS versions |
+| Real Codex and npm shim | Record supported Codex version, test native executable and npm .cmd invocation with space/Unicode paths, trust hooks, complete a turn and observe real indexing |
+| MCP stdio | Initialize/list tools/call a recall tool through the actual funes process; verify stdout contains protocol messages only |
+| Full CLI surface | Exercise status, get, sessions, sketch, scan, scrub, ask codex and relevant error paths; a passing index/recall test is not evidence for every CLI command |
+| Authenticated Hub and scanner | Use an authorized disposable memory and synthetic data; verify read/push, real trufflehog discovery, missing-scanner failure and secret rejection |
+| Cross-OS memory compatibility | Open/query a Windows-created memory on Linux and a Linux-created memory on Windows; assert records and metadata survive both directions |
+| Installer with the actual release asset | Use the staged release executable and matching manifest in a clean profile; verify first install, reinstall, version, PATH and failed-update preservation |
+| Repeatability | Two native runs succeeded, but no deliberate cold-cache/warm-cache comparison was performed; do not mark cache-independent repeatability complete |
+
+No Windows desktop/VM runtime, real Codex session, or authenticated Hub test environment was available
+for this review. The existing OpenSpec checklist remains authoritative for uncompleted work. A
+successful macOS build also does not establish that macOS automation integration tests ran.
+
+## Next acceptance session
+
+Use a clean Windows machine or connected Windows runner and a synthetic transcript. Keep application
+state under a temporary FUNES_HOME and Codex configuration under a temporary CODEX_HOME. Capture
+commands, exit codes, tool versions and hook logs. Establish the local and MCP journeys before
+performing authenticated Hub tests with a separately authorized disposable target. Do not use real
+conversation history as acceptance data.

--- a/openspec/changes/add-windows-minimum-support/acceptance.md
+++ b/openspec/changes/add-windows-minimum-support/acceptance.md
@@ -1,58 +1,63 @@
-# Windows acceptance review — 2026-09-09
+# Windows acceptance — 2026-09-12
 
-Tested implementation: `176a3790bc7a750c5af5f3202ee2dafbe76c2dc3`.
+The native Windows 11 CLI/Codex and authenticated Hub journeys have been exercised on
+Windows 11 build 26200 with Rust 1.95.0 MSVC and Codex 0.153.4. Release qualification remains
+open for clean Windows 10/11 installations and cross-OS memory exchange.
 
-## Decision
+## Regression fixes
 
-Automated CI acceptance passes for the covered scenarios. Full desktop/release acceptance remains
-open. This review inspected completed job logs and artifact metadata; it did not execute a new
-Windows desktop session. Keep the PR as a draft until the intended acceptance scope is resolved.
+- First publish now converts staged filesystem paths into slash-separated Hub keys. Before the
+  fix, Windows uploaded backslash-containing filenames, recall could not find the manifest, and
+  a second push repeated first publication.
+- Detached PowerShell workers redirect stdin. Previously, the native child inherited a terminal
+  and could wait indefinitely at the index budget prompt while holding the memory lock.
+- Hook cleanup recognizes complete generated invocations and exact script basenames. References
+  to the same filename, compound commands, and Bash command substitutions remain untouched.
 
-## Verified evidence
+Each fix has a regression test. Read-only independent review found an additional Bash substitution
+case; it was fixed and reviewed again before final validation.
 
-| Area | Result | Evidence and limit |
-| --- | --- | --- |
-| Windows native tests | Pass | Windows Server 2025: 255 unit tests, one real index/recall integration test, add_codex_hooks and windows_codex each passed |
-| Configuration regression fixes | Pass | The 255 unit tests include the four review regressions for mixed hook groups, invalid containers, preservation, and read errors |
-| Installer and background hooks | Pass with fixtures | PowerShell suite reports success; installation uses mocked downloads and hooks invoke a fixture executable |
-| Codex registration and cleanup | Pass with fixture | Compiled codex.exe verifies argument forwarding, home selection, idempotency and cleanup; this does not prove a real Codex conversation triggers hooks |
-| Windows static checks | Pass | Native dependency check and all-target Clippy completed successfully |
-| Linux regression CI | Pass | Completed CI workflow at the tested implementation |
-| Release builds | Pass | Windows x64, Linux x64/ARM64 and macOS ARM64 built successfully; Windows job checks the staged executable's version |
-| Published release | Not performed | Publish Release was skipped for this PR build |
+## Local verification
 
-- [Windows tests and full log](https://github.com/wellorbetter/funes/actions/runs/34239759269/job/102106600876)
-- [Linux CI](https://github.com/wellorbetter/funes/actions/runs/34239759267)
-- [Release builds](https://github.com/wellorbetter/funes/actions/runs/34239759213)
+- `cargo fmt --check` and `git diff --check` passed.
+- `cargo test --locked --profile ci --target x86_64-pc-windows-msvc` passed, including 257 library
+  tests and the main/integration targets. Unix-only/prerequisite-gated cases and tests gated on the upstream HF fixture token did not
+  perform remote work; the separate authenticated checks below supply that evidence.
+- All-target Clippy with `-D warnings` passed for both default and `--no-default-features
+  --features onnx` builds under the same locked CI profile and target.
+- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/test-windows.ps1` passed.
+  Its native fixture rejects nonredirected stdin, exercising both detached workers.
+- The optimized default-backend executable builds and starts without a custom stack argument.
+- Real Codex MCP status, a completed turn, background indexing, and retrieval of that turn passed.
+  MCP initialize/list/recall and the remaining local read commands also passed.
+- The actual npm Codex `.CMD` shim was exercised under space/Unicode paths. Add/repeat/remove and
+  user-hook preservation passed. The ownership regression also failed on the old executable and
+  passed on the repaired executable.
 
-The Windows artifact is `windows-x86_64`, artifact ID `10064575172`, ZIP size 74,993,499 bytes.
-GitHub reports ZIP SHA-256
-`880ac0448b453e61e21507391ed219c1918a5669c5f9f9b35699e57bc95620a4`.
-This is the archive digest, not the executable digest. The artifact download connector succeeded,
-but transferring its returned URL into the local inspection process returned HTTP 403; independent
-ZIP/PE/hash inspection was therefore not completed or claimed.
+## Authenticated Hub checks
 
-## Remaining acceptance checks
+Only invented transcripts were used in a private, user-authorized dataset. In a fresh prefix:
 
-| Check | Required evidence |
-| --- | --- |
-| Clean Windows 11 and Windows 10 journey | Standard user installation, new CMD and PowerShell sessions, version, explicit-path index, recall, real Codex add/turn/background index/remove; retain logs and exact OS versions |
-| Real Codex and npm shim | Record supported Codex version, test native executable and npm .cmd invocation with space/Unicode paths, trust hooks, complete a turn and observe real indexing |
-| MCP stdio | Initialize/list tools/call a recall tool through the actual funes process; verify stdout contains protocol messages only |
-| Full CLI surface | Exercise status, get, sessions, sketch, scan, scrub, ask codex and relevant error paths; a passing index/recall test is not evidence for every CLI command |
-| Authenticated Hub and scanner | Use an authorized disposable memory and synthetic data; verify read/push, real trufflehog discovery, missing-scanner failure and secret rejection |
-| Cross-OS memory compatibility | Open/query a Windows-created memory on Linux and a Linux-created memory on Windows; assert records and metadata survive both directions |
-| Installer with the actual release asset | Use the staged release executable and matching manifest in a clean profile; verify first install, reinstall, version, PATH and failed-update preservation |
-| Repeatability | Two native runs succeeded, but no deliberate cold-cache/warm-cache comparison was performed; do not mark cache-independent repeatability complete |
+1. First push published 6 chunks; remote recall returned the expected marker.
+2. Repeated push reported all 6 chunks already present.
+3. One appended transcript record produced exactly one new remote chunk; scan found its marker.
+4. Status reported 7 remote chunks; forced reindex completed and recall still found the new marker.
+5. Missing-scanner push failed. A separate, unused generated private-key sample was held back
+   with exit code 2; the corresponding remote prefix contained no files.
+6. The Hub listing contained the expected manifest and no backslash-containing keys in the new prefix.
 
-No Windows desktop/VM runtime, real Codex session, or authenticated Hub test environment was available
-for this review. The existing OpenSpec checklist remains authoritative for uncompleted work. A
-successful macOS build also does not establish that macOS automation integration tests ran.
+The original malformed prefix was retained as diagnostic evidence. No real conversation history
+was uploaded or bound to automatic publishing.
 
-## Next acceptance session
+## Remaining release checks
 
-Use a clean Windows machine or connected Windows runner and a synthetic transcript. Keep application
-state under a temporary FUNES_HOME and Codex configuration under a temporary CODEX_HOME. Capture
-commands, exit codes, tool versions and hook logs. Establish the local and MCP journeys before
-performing authenticated Hub tests with a separately authorized disposable target. Do not use real
-conversation history as acceptance data.
+- Clean Windows 10/11 installation and standard-user CMD/PowerShell journeys.
+- Windows-created memory queried on Linux and Linux-created memory queried on Windows.
+- Installation from a real versioned release asset and matching manifest.
+- Current-commit Windows/Linux CI and release build results must be checked separately; older
+  successful runs are not proof for the repaired source.
+
+No Windows release has been published. The earlier CI evidence is in
+[the Windows run](https://github.com/wellorbetter/funes/actions/runs/34239759269),
+[Linux CI](https://github.com/wellorbetter/funes/actions/runs/34239759267), and
+[release builds](https://github.com/wellorbetter/funes/actions/runs/34239759213).

--- a/openspec/changes/add-windows-minimum-support/design.md
+++ b/openspec/changes/add-windows-minimum-support/design.md
@@ -1,0 +1,262 @@
+## Context
+
+Funes has a portable domain core surrounded by several Unix-specific delivery seams. The domain
+pipeline is agent transcript -> generic turn/block -> deterministic chunk -> local embedding ->
+Lance memory -> hybrid recall/rerank. Platform-specific behavior is concentrated in inference,
+filesystem/home discovery, hook automation, installation, update, and CI/release.
+
+The goal is not abstract “Windows compatibility.” The goal is one explicit support contract that a
+maintainer can continuously validate without owning a Windows machine: native x86-64 core CLI plus
+Codex integration, installable with PowerShell and callable from PowerShell or CMD.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Build a native `x86_64-pc-windows-msvc` binary on every relevant pull request.
+- Keep local indexing, local recall, MCP stdio, and remote memory formats compatible across OSes.
+- Support Windows profile paths, drive paths, UNC paths, spaces, and non-ASCII components.
+- Support Codex MCP, skill, and automatic indexing/publishing without Bash or WSL.
+- Publish an authenticated-by-checksum Windows asset and a non-admin installer.
+- Preserve all existing Linux/macOS behavior and avoid a cross-platform automation rewrite.
+
+**Non-Goals:**
+
+- Desktop or tray UI.
+- Windows ARM64-native binaries.
+- Full Claude, pi, and Hermes Windows integration in this change.
+- Package-manager manifests or MSI packaging.
+- A new background service or daemon.
+- Any change to chunk schema, retrieval scoring, model identity, or privacy boundaries.
+- In-place Windows self-update in the first release.
+
+## Decisions
+
+### 1. Supported runtime and shell boundary
+
+The first supported target SHALL be Windows 10/11 x86-64 using the MSVC Rust target. PowerShell
+5.1+ is the installer and hook-script runtime because it provides reliable HTTP, SHA-256, process,
+and filesystem APIs on supported Windows versions. The installed `funes.exe` itself SHALL be a
+normal native executable usable from both PowerShell and CMD.
+
+CMD batch files are not the automation implementation. Batch quoting, error propagation, detached
+process handling, and retry logic would create a second fragile shell program. CMD remains a valid
+interactive caller of `funes.exe`.
+
+### 2. Dependency and backend spike is an implementation gate
+
+Before product changes, a native `windows-latest` job SHALL compile the current crate with the
+candidate Windows backend. This validates upstream dependencies rather than assuming that portable
+Rust APIs imply a portable dependency graph.
+
+Preferred backend:
+
+- reuse the existing pure-Rust faer seam currently used on Linux;
+- compile faer/multiversion for `cfg(any(target_os = "linux", target_os = "windows"))`;
+- keep Accelerate exclusive to macOS;
+- retain the same tokenizer, safetensors, model identifiers, dimension, and model stamp.
+
+Fallback decision:
+
+- if the default dependency graph cannot be made to pass native Windows CI without patching an
+  upstream crate, build the Windows release with the existing ONNX feature;
+- the fallback is acceptable only if a real index/recall smoke test passes and a memory created on
+  one backend can be opened and queried by the other under the existing compatibility rules;
+- the chosen backend and reason SHALL be recorded in this design before implementation proceeds.
+
+### 3. One platform module owns OS conventions
+
+Introduce `src/platform.rs` for shared host conventions. HF-specific cache/token paths remain in
+`hub.rs`; hook command rendering and permissions remain in `agents/hooks.rs`, following the
+repository's placement rules. Both call the host layer where appropriate.
+
+The module SHALL own:
+
+- `user_home()` with `FUNES_HOME` remaining an explicit higher-level override;
+- default Funes state directory;
+- default HF cache/token path;
+- path classification (`local`, Hub shorthand, `hf://` URI);
+- known-path tail matching using `Path` components;
+- rendering the hook command for the host platform;
+- setting executable permissions as a Unix-only no-op on Windows.
+
+Windows home resolution SHOULD use a standard Rust directory API backed by the Windows profile
+known folder. If a dependency is not accepted, fallback order is `USERPROFILE`, then
+`HOMEDRIVE` + `HOMEPATH`, then `HOME`; an empty result is an actionable error, never the current
+working directory.
+
+`FUNES_HOME`, `CODEX_HOME`, `PI_CODING_AGENT_DIR`, `FUNES_BIN`, `HF_HOME`, and token environment
+variables retain precedence.
+
+### 4. Local path detection precedes Hub shorthand detection
+
+Windows paths such as `C:\\work\\memory`, `C:/work/memory`, and `\\\\server\\share\\memory` must
+never be parsed as `<org>/<repo>`.
+
+Resolution order SHALL be:
+
+1. literal `local`;
+2. explicit `hf://` URI;
+3. platform-recognized absolute/rooted local path or existing local path;
+4. valid Hub shorthand;
+5. relative local path.
+
+Known harness detection SHALL compare path components, not rendered separators. Tests SHALL run on
+Windows for `\\` paths and continue running on Unix for `/` paths.
+
+### 5. Preserve Unix scripts; add PowerShell counterparts
+
+The minimum-risk approach is additive:
+
+- Unix continues to install and invoke `funes-index.sh` and `funes-push.sh` unchanged.
+- Windows installs `funes-index.ps1` and `funes-push.ps1`.
+- `hooks::command` renders a POSIX Bash command on Unix and a PowerShell command on Windows.
+- executable permission changes are compiled and executed only on Unix.
+
+The PowerShell scripts SHALL preserve the shell-script behavior:
+
+- consume hook stdin so the caller does not block on an unread payload;
+- start a hidden/detached worker and return within the hook timeout;
+- resolve `FUNES_BIN` first, then `funes.exe` on `PATH`, then the installed executable location;
+- run `index --harness <agent>` for per-turn hooks;
+- at a session boundary, retry a conflicting index up to five times and then push what is stored;
+- append timestamped diagnostics beside the script to `funes-sync.log`;
+- treat secret-gate exit code 2 as a warning and preserve other exit codes in the log;
+- quote paths and remote names without command injection.
+
+A later change may move automation into hidden Rust subcommands, but doing so now would alter the
+working Unix execution path and expand regression risk.
+
+### 6. Codex is the only required agent integration for the first tier
+
+Codex provides the smallest complete user journey: native agent transcripts, a native MCP client,
+skills, and JSON hooks. `funes add codex` SHALL:
+
+1. discover Codex home via `codex doctor --json`, then `CODEX_HOME`, then the platform home;
+2. install the Funes skill under Codex home;
+3. merge only Funes-owned hook groups into `hooks.json`;
+4. install `.ps1` automation scripts on Windows;
+5. register `funes mcp [memory]` using an argv-based `Command`, not by executing the rendered hint;
+6. leave a manual command only as user-facing fallback text.
+
+Removal SHALL attempt MCP unregister and owned-file cleanup independently, preserving the current
+failure semantics.
+
+Claude, pi, and Hermes installs SHALL either be proven and explicitly added to this change or return
+an unsupported-on-Windows error before any write. They must not be accidentally half-enabled.
+
+### 7. PowerShell installer is non-admin and verification-first
+
+Add `scripts/install.ps1` with parameters equivalent to the POSIX installer:
+
+- `-InstallDir` (default `%LOCALAPPDATA%\\Programs\\funes\\bin`);
+- `-Version` (default latest);
+- `-NoPathUpdate` for users who do not want persistent PATH changes.
+
+The installer SHALL:
+
+1. detect x86-64 Windows and reject unsupported architectures clearly;
+2. download `VERSION`, `SHA256SUMS`, and the tagged asset over HTTPS;
+3. require exactly one manifest entry for the Windows asset;
+4. verify SHA-256 with `Get-FileHash` before executing the staged binary;
+5. verify `funes.exe --version` matches the release metadata;
+6. replace only the target Funes binary after all checks pass;
+7. add the default install directory to the user PATH unless opted out, without duplicating entries;
+8. explain that a new terminal is required for a persistent PATH update.
+
+The installer must leave the previous binary untouched on download, checksum, or version failure.
+
+### 8. Windows self-update is explicitly deferred
+
+Windows does not share Unix's “rename over a running inode” behavior. The first Windows release SHALL
+not pretend the existing updater is safe. `funes update` on Windows SHALL stop before download or
+replacement and print the supported PowerShell reinstall command. `funes status` MAY still report
+that an update exists, but its guidance must be platform-correct.
+
+A future change can implement a verified helper process that waits for the parent to exit, retries
+replacement, and preserves rollback. That behavior is deliberately not hidden inside this minimum
+port.
+
+### 9. Windows CI is the support contract
+
+Add a `windows-latest` job that is required for relevant pull requests and main:
+
+- install a pinned Rust toolchain and protoc;
+- compile and clippy the selected Windows feature set;
+- run library/unit tests with Windows-safe fake executable fixtures;
+- run PowerShell installer tests against a local fixture server or mocked download layer;
+- run Codex add/remove integration tests using a fake `codex.exe`;
+- run one real explicit-path index -> recall smoke test with cached model files;
+- assert MCP stdio emits no non-JSON logs on stdout.
+
+Unix CI remains unchanged. OS-specific tests use `cfg` gates only when behavior is genuinely
+platform-specific; domain tests remain shared.
+
+### 10. Release asset and checksum are first-class
+
+The release workflow SHALL build `x86_64-pc-windows-msvc`, verify its embedded version, upload
+`funes-x86_64-windows.exe`, include it in the exact asset count and `SHA256SUMS`, and publish it to
+both the GitHub release and the existing Hugging Face bucket. Publication remains all-or-nothing:
+the publish job must require Linux, macOS, and Windows build success.
+
+## Risks / Trade-offs
+
+**Risk: upstream native dependencies fail on MSVC.**
+Mitigation: the dependency/backend spike is task 0 and a go/no-go gate; ONNX is a bounded fallback.
+
+**Risk: PowerShell execution policy blocks hooks.**
+Mitigation: invoke `powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File`
+for the current process only; document the exact command and test it on `windows-latest`.
+
+**Risk: quoting paths through agent-owned command strings.**
+Mitigation: keep the executable token unquoted (`powershell.exe`), quote only the `-File` path and
+arguments with a dedicated renderer, and test spaces, quotes, ampersands, parentheses, and Unicode.
+
+**Risk: antivirus/indexers briefly lock the installed binary.**
+Mitigation: installer replacement uses a staged file and bounded retries; failure leaves the old
+binary and reports the staged path.
+
+**Risk: “Windows supported” is mistaken for full agent or GUI parity.**
+Mitigation: README support matrix labels this tier `Core CLI + Codex`; unsupported integrations fail
+before writes and link to follow-up issues.
+
+## Rollout Plan
+
+1. Land the Windows build spike and record the chosen inference backend.
+2. Land platform/path abstractions with shared and Windows-specific tests.
+3. Land core CLI and explicit-path index/recall smoke coverage.
+4. Land PowerShell automation and Codex integration tests.
+5. Land installer, release job, docs, and required CI status.
+6. Publish a prerelease asset, run a clean Windows 10/11 smoke checklist, then promote support.
+
+## Rollback Plan
+
+- Remove the Windows asset from the release manifest and support table if the required Windows job
+  cannot stay green.
+- Keep all Unix paths behind existing branches so rollback does not alter Linux/macOS behavior.
+- Never migrate the memory schema, so a Windows-created memory remains readable by prior supported
+  platforms even if Windows distribution is paused.
+
+## Open Questions
+
+1. Does the exact Lance 7.0.0 graph pass MSVC without patches?
+2. Does the faer/multiversion seam pass the real-model smoke test on Windows, or should the release
+   use the existing ONNX feature?
+3. Does the supported native Codex build execute hook command strings through CMD exactly as assumed?
+4. Should the default installer directory be `%LOCALAPPDATA%\\Programs\\funes\\bin` or a project-wide
+   convention preferred by the maintainers?
+
+Questions 1-3 are resolved by task 0/CI evidence, not by assumption. Question 4 is a maintainer
+choice that does not alter the runtime architecture.
+
+## Implementation decisions from the native probe
+
+Questions 1 and 2 are resolved: both BLAS and ONNX compiled and passed real index/recall on native
+MSVC in [run 34232202952](https://github.com/wellorbetter/funes/actions/runs/34232202952). The release
+keeps the default BLAS/faer backend with the existing Lance lockfile and no upstream patch.
+
+Hook rendering uses PowerShell UTF-16LE `-EncodedCommand` containing single-quoted literals instead
+of a raw `-File` command string. CMD never sees the path or memory argument, so percent expansion,
+ampersands, parentheses, and apostrophes cannot change the invocation. Cleanup decodes the command
+to identify Funes scripts. Native PowerShell tests verify argument preservation and detachment;
+the actual Codex desktop turn remains an explicit manual release check.

--- a/openspec/changes/add-windows-minimum-support/execution.md
+++ b/openspec/changes/add-windows-minimum-support/execution.md
@@ -32,3 +32,27 @@ PowerShell commands use UTF-16LE EncodedCommand instead of interpolating paths t
 - No Windows 10/11 desktop VM or authenticated HF test token was available in this workspace.
   Manual desktop installation, authenticated Hub round trips, and cross-OS memory transfer must be
   checked before release. No tag, binary release, or upstream PR is published by this work.
+
+## Code review follow-up
+
+- Fixed a configuration preservation bug: a group containing both Funes and user hooks lost
+  all its commands during replacement/removal. Merging now removes individual owned hooks and
+  preserves unrelated commands and group metadata. Regression coverage exercises plain and
+  encoded PowerShell commands, removal, replacement, and repeated installation.
+- Fixed malformed JSON container handling: valid JSON with a non-object `hooks` or non-array
+  event could reach unchecked merging. Installation now preserves unsupported configurations
+  with manual guidance; removal returns an error and retains referenced scripts. Tests cover
+  invalid container shapes and byte-for-byte preservation on disk.
+- Fixed install reads that treated every I/O error as a missing configuration. Only NotFound
+  initializes a new configuration; other read errors propagate before script installation.
+  A directory at hooks.json exercises this portably without relying on permission settings.
+- Corrected the Windows integration test's mixed-separator expected path: construct each path
+  component with `join` before comparing encoded commands.
+- Local review validation: all-target default-backend Clippy, formatting, and diff checks pass.
+  All nine tests in the actual shared hooks module pass via a small isolated harness, avoiding
+  the local Arrow/DataFusion archive issue noted above. This is not a full-crate test result.
+- Pre-review commit `45647bf`: Linux lint/unit and real-embedder integration jobs passed.
+  Windows run https://github.com/wellorbetter/funes/actions/runs/34236706924 passed installer/
+  automation tests, native compilation, real index/recall, Clippy, and 251 unit tests; it then
+  failed at the mixed-separator assertion corrected above, before running windows_codex.
+  The review changes require fresh Linux and Windows CI; desktop release checks remain open.

--- a/openspec/changes/add-windows-minimum-support/execution.md
+++ b/openspec/changes/add-windows-minimum-support/execution.md
@@ -1,0 +1,34 @@
+# Execution record
+
+## Dependency gate — passed
+
+- Upstream baseline: `huggingface/funes@1a01cc243b06a2d70f08f0da338b9bf29c275631`.
+- Fork branch: `wellorbetter/funes:feature/windows-minimum-support`.
+- Probe commit: `9d37f7d431fe487dcc0b241312f1df58535266c3`.
+- Native run: https://github.com/wellorbetter/funes/actions/runs/34232202952
+- Both MSVC BLAS and ONNX passed `cargo check --locked` and the real `index_recall` integration test.
+- Selected backend: default BLAS, using the existing faer/multiversion seam. No upstream dependency
+  patch, dependency version change, model change, or memory schema migration was required.
+
+## Implementation
+
+The follow-up adds profile/path handling, CODEX_HOME trace discovery, executable discovery, native
+PowerShell hooks, Codex integration, a verification-first installer, and a Windows release build.
+OpenSpec passed `openspec validate add-windows-minimum-support --strict`.
+
+The shared platform layer owns host conventions. HF cache/token conventions stay in `hub.rs`,
+and hook rendering/permissions stay in `agents/hooks.rs`, preserving the repository's layer rules.
+PowerShell commands use UTF-16LE EncodedCommand instead of interpolating paths through CMD.
+
+## Validation limitations
+
+- Baseline Linux compilation and default-backend all-target Clippy passed before the follow-up.
+- Follow-up Windows and Unix regression results are recorded as CI completes.
+- Local Linux ONNX validation reached ort-sys, whose prebuilt archive download was refused by the
+  local network. OpenSSL discovery was resolved with explicit system include/library paths.
+- Local unit-test compilation twice produced zero-length object/archive failures in different
+  Arrow/DataFusion dependencies despite adequate free disk space. The second attempt used a clean
+  package cache and one build job. This is not reported as a passing test run.
+- No Windows 10/11 desktop VM or authenticated HF test token was available in this workspace.
+  Manual desktop installation, authenticated Hub round trips, and cross-OS memory transfer must be
+  checked before release. No tag, binary release, or upstream PR is published by this work.

--- a/openspec/changes/add-windows-minimum-support/proposal.md
+++ b/openspec/changes/add-windows-minimum-support/proposal.md
@@ -1,0 +1,94 @@
+## Why
+
+Funes currently publishes binaries for Linux x86-64, Linux arm64, and Apple Silicon macOS, while
+Windows users cannot install or run a supported native build. Issue #136 asks for Windows and
+desktop support; the maintainer's stated concern is preventing regressions without a Windows
+development machine. The repository already has a mostly portable Rust core, but its inference,
+automation, path resolution, updater, CI, and release seams encode Unix assumptions.
+
+A narrowly scoped native Windows CLI release, continuously verified on GitHub-hosted Windows CI,
+addresses the immediate user need and the maintainer's regression concern without coupling the work
+to a desktop GUI or full integration parity.
+
+## What Changes
+
+### 1. Define a minimum native Windows support tier
+
+Support Windows 10/11 x86-64 with an MSVC-built `funes.exe`. Users install through a PowerShell
+installer and can run the resulting executable from either PowerShell or CMD. WSL is not required.
+
+### 2. Make the core CLI compile and preserve memory compatibility
+
+- Add a Windows inference platform seam while retaining the pinned embedding/reranking models.
+- Gate Unix-only executable-permission code.
+- Verify the exact Lance, faer/multiversion, SQLite, HF Hub, ratatui/crossterm, and MCP dependency
+  graph on a native Windows runner before committing to a release backend.
+- Preserve the existing memory schema, model stamp, ranking pipeline, and cross-machine memory
+  compatibility.
+
+### 3. Centralize platform path behavior
+
+Resolve the user profile, Funes home, HF cache, Codex home, and known transcript roots through one
+platform-aware layer. Correctly classify Windows drive and UNC paths as local paths and detect known
+harness directories by path components rather than POSIX string suffixes.
+
+### 4. Add minimum Codex automation on Windows
+
+Keep the existing POSIX hook scripts unchanged and add PowerShell counterparts for Windows. The
+Windows scripts preserve the existing contract: drain the hook payload, detach quickly, run an
+incremental index or index-then-push worker, and append diagnostics to `funes-sync.log`.
+
+`funes add codex` and `funes remove codex` SHALL install/remove the Windows hook scripts, merge only
+Funes-owned hook groups, install the skill, and register/unregister the stdio MCP server without
+modifying unrelated Codex configuration.
+
+### 5. Add Windows installation, CI, and release assets
+
+- Add `scripts/install.ps1` with version and SHA-256 verification.
+- Add Windows compile, unit, installer, Codex-integration, and real index/recall smoke coverage.
+- Publish `funes-x86_64-windows.exe` and include it in `SHA256SUMS` and the Hugging Face bucket.
+- Document the supported shell/runtime boundary and known limitations.
+
+### 6. Fail safely outside the minimum tier
+
+On Windows, `funes add claude|pi|hermes` and in-place `funes update` MAY remain outside this first
+support tier, but they SHALL fail before writing partial configuration and SHALL provide an
+actionable explanation. Re-running `install.ps1` is the supported minimum upgrade path.
+
+## Capabilities
+
+### New Capabilities
+
+- `windows-minimum-support`: Native Windows CLI execution, platform-correct paths, Codex automation,
+  verified installation, and release/CI guarantees.
+
+### Modified Capabilities
+
+- None. Funes does not currently maintain an OpenSpec baseline; this change introduces one bounded
+  capability without redefining its platform-neutral memory contracts.
+
+## Impact
+
+- `Cargo.toml`, `Cargo.lock`, `build.rs` — Windows inference/dependency target configuration.
+- `src/platform.rs` (new) — profile/home/cache/path and shell-command platform seams.
+- `src/inference/blas.rs` — Windows backend seam or a documented Windows release-backend selection.
+- `src/agents.rs`, `src/agents/hooks.rs`, `src/agents/codex.rs` — Windows-safe command rendering,
+  scripts, paths, and Codex installation/removal.
+- `src/traces/harness.rs`, `src/memory/dataset.rs`, `src/hub.rs` — platform-correct path handling.
+- `src/commands/update.rs` — Unix gating and Windows reinstall guidance.
+- `integrations/pi/index.ts` and other non-MVP integrations — explicit Windows capability guards only;
+  no partial installation.
+- `scripts/automation/funes-index.ps1`, `scripts/automation/funes-push.ps1` (new) — Windows automation.
+- `scripts/install.ps1` and installer tests (new) — verified Windows installation.
+- `.github/workflows/ci.yml`, `.github/workflows/release.yml` — Windows regression and release jobs.
+- `README.md`, `CONTRIBUTING.md`, `docs/add.md`, `docs/automation.md` — support table and instructions.
+
+## Success Criteria
+
+- A clean `windows-latest` runner builds and tests `funes.exe` natively.
+- A Windows user can install with PowerShell and invoke `funes --version` from a new PowerShell or
+  CMD session.
+- Explicit-path indexing and local recall complete end to end on Windows.
+- `funes add codex` installs a working MCP + skill + automatic index flow without Bash or WSL.
+- Windows path tests cover drive roots, UNC paths, spaces, non-ASCII names, and an unset `HOME`.
+- Existing Linux and macOS tests and release assets remain unchanged and green.

--- a/openspec/changes/add-windows-minimum-support/specs/windows-minimum-support/spec.md
+++ b/openspec/changes/add-windows-minimum-support/specs/windows-minimum-support/spec.md
@@ -1,0 +1,212 @@
+## Purpose
+
+Define the minimum supported native Windows tier for Funes: x86-64 core CLI and Codex integration,
+with platform-correct paths, PowerShell installation/automation, and continuous Windows CI.
+
+## ADDED Requirements
+
+### Requirement: Supported Windows target
+The system SHALL provide a native `x86_64-pc-windows-msvc` executable for supported Windows 10 and
+Windows 11 systems without requiring WSL.
+
+#### Scenario: Execute from PowerShell
+- **WHEN** a user invokes `funes.exe --version` from PowerShell
+- **THEN** the process SHALL exit successfully
+- **AND** print the embedded Funes version
+
+#### Scenario: Execute from CMD
+- **WHEN** a user invokes `funes.exe --version` from CMD
+- **THEN** the process SHALL exit successfully
+- **AND** print the same version as PowerShell
+
+#### Scenario: Unsupported Windows architecture
+- **WHEN** the installer runs on an architecture without a published native asset
+- **THEN** it SHALL stop before changing the installation
+- **AND** report the supported architecture and alternatives
+
+### Requirement: Cross-platform memory compatibility
+The Windows build SHALL preserve the existing chunk schema, pinned model identity, provenance, and
+memory compatibility contract.
+
+#### Scenario: Open a memory created on another supported OS
+- **WHEN** Windows Funes opens a compatible memory created by Linux or macOS Funes of the same schema
+- **THEN** it SHALL read and query that memory without migration
+
+#### Scenario: Open a Windows-created memory on another supported OS
+- **WHEN** Linux or macOS Funes opens a compatible memory created on Windows
+- **THEN** it SHALL read and query that memory without migration
+
+### Requirement: Native core command flow
+The Windows build SHALL support `index`, `recall`, `get`, `sessions`, `sketch`, `scan`, `status`,
+`scrub`, `push`, `ask codex`, and `mcp` with the same command arguments and output contracts as
+other supported OSes.
+
+#### Scenario: Explicit path index and recall
+- **WHEN** a user indexes a Windows transcript directory containing spaces and non-ASCII characters
+- **AND** runs `funes recall` for text present in those transcripts
+- **THEN** Funes SHALL return the matching passage with session and turn provenance
+
+#### Scenario: MCP stdio transport
+- **WHEN** an MCP client starts `funes mcp`
+- **THEN** stdout SHALL contain only the MCP JSON-RPC transport
+- **AND** diagnostics SHALL be written to stderr
+
+#### Scenario: Remote-memory push
+- **WHEN** a user has a valid HF token and the documented trufflehog executable is available
+- **AND** runs `funes push <org>/<repo>`
+- **THEN** the Windows build SHALL preserve the existing overlap and fail-closed secret gates
+
+#### Scenario: Grounded Codex answer
+- **WHEN** Codex is available on `PATH`
+- **AND** a user runs `funes ask codex <question>` against a readable memory
+- **THEN** Funes SHALL launch Codex and return a grounded answer under the existing command contract
+
+### Requirement: Platform-correct user directories
+The system SHALL resolve the Windows user profile and dependent Funes, Codex, agent transcript, and
+HF cache paths without requiring the POSIX `HOME` variable.
+
+#### Scenario: HOME is unset
+- **WHEN** `HOME` is unset on Windows
+- **AND** a valid Windows user profile is available
+- **THEN** Funes SHALL resolve its default state and known agent roots under that profile
+- **AND** SHALL NOT fall back to the current working directory
+
+#### Scenario: Explicit environment override
+- **WHEN** `FUNES_HOME`, `CODEX_HOME`, `PI_CODING_AGENT_DIR`, `FUNES_BIN`, or `HF_HOME` is set
+- **THEN** the corresponding override SHALL retain precedence over the platform default
+
+### Requirement: Windows local path classification
+The system SHALL classify Windows drive-rooted, slash-normalized drive, and UNC paths as local paths
+before evaluating Hub shorthand syntax.
+
+#### Scenario: Backslash drive path
+- **WHEN** a memory or transcript path is `C:\\work\\funes memory`
+- **THEN** the system SHALL treat it as a local path
+- **AND** SHALL NOT interpret it as an HF Hub repository
+
+#### Scenario: Forward-slash drive path
+- **WHEN** a memory or transcript path is `C:/work/funes-memory`
+- **THEN** the system SHALL treat it as a local path
+- **AND** SHALL NOT interpret it as an HF Hub repository
+
+#### Scenario: UNC path
+- **WHEN** a memory or transcript path begins with `\\\\server\\share`
+- **THEN** the system SHALL treat it as a local path
+
+#### Scenario: Hub shorthand remains supported
+- **WHEN** a memory argument is a valid `<org>/<repo>` shorthand and not a Windows path
+- **THEN** the system SHALL resolve it to the existing HF dataset URI form
+
+### Requirement: Platform-independent harness detection
+Known harness roots SHALL be detected from path components rather than rendered path separators.
+
+#### Scenario: Codex root on Windows
+- **WHEN** a path ends in `.codex\\sessions`
+- **THEN** it SHALL be detected as the Codex harness
+
+#### Scenario: Codex root on Unix
+- **WHEN** a path ends in `.codex/sessions`
+- **THEN** it SHALL continue to be detected as the Codex harness
+
+### Requirement: Verified PowerShell installation
+The repository SHALL provide a non-admin PowerShell installer for the published Windows asset.
+
+#### Scenario: Clean installation
+- **WHEN** a user runs the documented installer on supported Windows
+- **THEN** it SHALL download release metadata and the tagged Windows asset
+- **AND** verify the SHA-256 checksum before executing the staged binary
+- **AND** verify the binary's reported version before replacing the target
+- **AND** install `funes.exe` into the selected directory
+
+#### Scenario: Checksum mismatch
+- **WHEN** the downloaded asset does not match `SHA256SUMS`
+- **THEN** the installer SHALL fail
+- **AND** SHALL leave any existing installed binary unchanged
+
+#### Scenario: User PATH update
+- **WHEN** the default install completes without `-NoPathUpdate`
+- **THEN** the installer SHALL add the install directory to the user PATH only when absent
+- **AND** explain that a new terminal is required
+
+### Requirement: Windows Codex integration
+The Windows build SHALL support `funes add codex` and `funes remove codex` without Bash or WSL.
+
+#### Scenario: Add local Codex integration
+- **WHEN** a Windows user runs `funes add codex`
+- **THEN** Funes SHALL install its Codex skill
+- **AND** merge a per-turn indexing hook into Codex configuration
+- **AND** register the Funes stdio MCP server
+- **AND** preserve unrelated skills, hooks, and MCP servers
+
+#### Scenario: Add a bound-memory integration
+- **WHEN** a Windows user runs `funes add codex <org>/<repo>`
+- **THEN** Funes SHALL additionally install session-boundary publication hooks
+- **AND** preserve the existing first-index and first-push safety gates
+
+#### Scenario: Remove Codex integration
+- **WHEN** a Windows user runs `funes remove codex`
+- **THEN** Funes SHALL remove only Funes-owned MCP, skill, hook, script, and log artifacts
+- **AND** leave local memory, transcripts, remote memory, and unrelated configuration untouched
+
+### Requirement: Windows automation semantics
+Windows Codex automation SHALL preserve the existing non-blocking index/push behavior using
+PowerShell scripts.
+
+#### Scenario: Per-turn hook returns promptly
+- **WHEN** Codex invokes the Funes index hook with a payload on stdin
+- **THEN** the hook SHALL consume the payload
+- **AND** start a hidden worker
+- **AND** return before the configured 15-second hook timeout
+
+#### Scenario: Detached index worker
+- **WHEN** the per-turn worker runs
+- **THEN** it SHALL execute `funes index --harness codex`
+- **AND** append timestamped success or failure diagnostics to `funes-sync.log`
+
+#### Scenario: Session-boundary push worker
+- **WHEN** a bound-memory session-start or session-end hook runs
+- **THEN** the worker SHALL attempt to index the Codex harness before publishing
+- **AND** retry transient writer-lock conflicts up to the configured bound
+- **AND** invoke `funes push` for the bound memory
+
+#### Scenario: Path with shell metacharacters
+- **WHEN** the installed script or binary path contains spaces or supported Windows shell
+  metacharacters
+- **THEN** the hook command SHALL pass the path and arguments without truncation or command injection
+
+### Requirement: Safe behavior for out-of-tier Windows features
+Features not included in the minimum Windows tier SHALL fail explicitly and without partial writes.
+
+#### Scenario: Unsupported agent integration
+- **WHEN** a Windows user requests an agent integration not declared supported by this change
+- **THEN** Funes SHALL report that the integration is not yet supported on native Windows
+- **AND** SHALL make no integration-file or config changes
+
+#### Scenario: Windows update command
+- **WHEN** a Windows user runs `funes update`
+- **THEN** Funes SHALL not attempt to rename over the running executable
+- **AND** SHALL print the supported PowerShell reinstall command
+
+### Requirement: Windows regression coverage
+The repository SHALL continuously verify the supported Windows tier on a GitHub-hosted native
+Windows runner.
+
+#### Scenario: Pull request changes platform-sensitive code
+- **WHEN** a pull request changes Rust sources, dependencies, scripts, tests, installer, or workflows
+- **THEN** required Windows CI SHALL compile the selected release feature set
+- **AND** run Windows unit, path, installer, Codex integration, MCP, and index/recall smoke coverage
+
+#### Scenario: Unix non-regression
+- **WHEN** the Windows change is validated
+- **THEN** existing Linux and macOS CI SHALL remain green
+- **AND** existing POSIX hook behavior and release asset names SHALL remain unchanged
+
+### Requirement: Published Windows release asset
+Every release that advertises Windows support SHALL publish the verified Windows binary with the
+same version metadata and checksum process as existing assets.
+
+#### Scenario: Release publication
+- **WHEN** a supported release is published
+- **THEN** `funes-x86_64-windows.exe` SHALL be present in the GitHub release and Hugging Face bucket
+- **AND** `SHA256SUMS` SHALL contain exactly one digest entry for it
+- **AND** publication SHALL require successful Linux, macOS, and Windows builds

--- a/openspec/changes/add-windows-minimum-support/tasks.md
+++ b/openspec/changes/add-windows-minimum-support/tasks.md
@@ -30,18 +30,18 @@
 - [x] 2.2 Move/gate target-specific dependencies in `Cargo.toml` for MSVC compilation
 - [x] 2.3 Gate `PermissionsExt`, chmod behavior, `ExecutableFileBusy`, and Unix-only updater tests
 - [x] 2.4 Add Windows-safe fake executable/test helpers (`.cmd` or fixture executables as appropriate)
-- [ ] 2.5 Run `cargo clippy --all-targets --profile ci -- -D warnings` and unit tests on Windows
+- [x] 2.5 Run `cargo clippy --all-targets --profile ci -- -D warnings` and unit tests on Windows
 
 ## 3. Core CLI and Memory Validation
 
-- [ ] 3.1 Verify `--version`, `status`, explicit-path `index`, `recall`, `get`, `sessions`, `sketch`,
+- [x] 3.1 Verify `--version`, `status`, explicit-path `index`, `recall`, `get`, `sessions`, `sketch`,
   `scan`, `scrub`, `push`, `ask codex`, and `mcp` on native Windows
 - [ ] 3.2 Add a Windows fixture with a drive-rooted Codex transcript and PowerShell tool blocks
-- [ ] 3.3 Add an end-to-end explicit-path index -> recall test under a path containing spaces and
+- [x] 3.3 Add an end-to-end explicit-path index -> recall test under a path containing spaces and
   non-ASCII characters
 - [ ] 3.4 Verify a Windows-created memory opens on Linux and a Linux-created memory opens on Windows
-- [ ] 3.5 Verify MCP stdio keeps diagnostics off stdout
-- [ ] 3.6 Verify Hub read/push and trufflehog discovery on Windows; document/install the required
+- [x] 3.5 Verify MCP stdio keeps diagnostics off stdout
+- [x] 3.6 Verify Hub read/push and trufflehog discovery on Windows; document/install the required
   trufflehog executable if the push path is enabled in the minimum tier
 
 ## 4. Windows PowerShell Automation
@@ -62,9 +62,9 @@
 - [x] 5.1 Make Codex home fallback use the platform profile after `codex doctor --json` and
   `CODEX_HOME`
 - [x] 5.2 Install Windows PowerShell hooks and keep the existing Funes-only JSON merge semantics
-- [ ] 5.3 Verify `codex mcp add/remove` uses argv-based process spawning and supports `funes.exe` paths
+- [x] 5.3 Verify `codex mcp add/remove` uses argv-based process spawning and supports `funes.exe` paths
 - [x] 5.4 Port add/remove integration tests to `windows-latest` with a fake `codex.exe`
-- [ ] 5.5 Test local and bound-memory installs, repeat-run idempotency, malformed config safety, and
+- [x] 5.5 Test local and bound-memory installs, repeat-run idempotency, malformed config safety, and
   independent cleanup failures
 - [x] 5.6 Add pre-write Windows capability guards for Claude, pi, and Hermes until separate changes
   declare those integrations supported

--- a/openspec/changes/add-windows-minimum-support/tasks.md
+++ b/openspec/changes/add-windows-minimum-support/tasks.md
@@ -20,7 +20,7 @@
   and agent integration paths
 - [x] 1.4 Replace string separator matching in `Harness::from_known_dir` with component matching
 - [x] 1.5 Make local-path classification recognize Windows drive and UNC paths before Hub shorthand
-- [ ] 1.6 Add tests for unset `HOME`, overrides, drive paths, UNC paths, spaces, Unicode, and Unix
+- [x] 1.6 Add tests for unset `HOME`, overrides, drive paths, UNC paths, spaces, Unicode, and Unix
   non-regression
 
 ## 2. Native Windows Compilation
@@ -36,7 +36,7 @@
 
 - [x] 3.1 Verify `--version`, `status`, explicit-path `index`, `recall`, `get`, `sessions`, `sketch`,
   `scan`, `scrub`, `push`, `ask codex`, and `mcp` on native Windows
-- [ ] 3.2 Add a Windows fixture with a drive-rooted Codex transcript and PowerShell tool blocks
+- [x] 3.2 Add a Windows fixture with a drive-rooted Codex transcript and PowerShell tool blocks
 - [x] 3.3 Add an end-to-end explicit-path index -> recall test under a path containing spaces and
   non-ASCII characters
 - [ ] 3.4 Verify a Windows-created memory opens on Linux and a Linux-created memory opens on Windows
@@ -104,7 +104,7 @@
 
 ## 9. Final Verification
 
-- [ ] 9.1 Run the full Linux unit/integration and installer suite unchanged
+- [x] 9.1 Run the full Linux unit/integration and installer suite unchanged
 - [ ] 9.2 Run the macOS release build and existing automation integration tests unchanged
 - [ ] 9.3 Run the complete required Windows job twice to verify cache-independent repeatability
 - [ ] 9.4 Perform a clean Windows 11 smoke test: install -> CMD version -> index -> recall -> add Codex ->

--- a/openspec/changes/add-windows-minimum-support/tasks.md
+++ b/openspec/changes/add-windows-minimum-support/tasks.md
@@ -1,0 +1,114 @@
+## 0. Dependency and Backend Gate
+
+- [x] 0.1 Add a temporary `windows-latest` build job for `x86_64-pc-windows-msvc` using the current
+  dependency lockfile and pinned Rust/protoc versions
+- [x] 0.2 Record every native compile blocker from Lance, faer, multiversion, SQLite, hf-hub,
+  ratatui/crossterm, rmcp, and transitive native crates
+- [x] 0.3 Prototype the default BLAS build by reusing the faer platform seam on Windows
+- [x] 0.4 If the BLAS build requires an upstream patch, test the existing ONNX-only feature set and
+  cross-backend memory compatibility instead
+- [x] 0.5 Update `design.md` with the selected Windows release backend and evidence; stop the change
+  if neither candidate passes a real native index/recall smoke test
+
+## 1. Platform Abstraction
+
+- [x] 1.1 Add `src/platform.rs` for profile/home/cache discovery, path classification, known-tail
+  matching, hook command rendering, and executable-permission handling
+- [x] 1.2 Preserve `FUNES_HOME`, `CODEX_HOME`, `PI_CODING_AGENT_DIR`, `FUNES_BIN`, `HF_HOME`, and token
+  override precedence
+- [ ] 1.3 Replace direct `HOME` lookups in memory, Hub token/cache, inference cache, trace discovery,
+  and agent integration paths
+- [x] 1.4 Replace string separator matching in `Harness::from_known_dir` with component matching
+- [x] 1.5 Make local-path classification recognize Windows drive and UNC paths before Hub shorthand
+- [ ] 1.6 Add tests for unset `HOME`, overrides, drive paths, UNC paths, spaces, Unicode, and Unix
+  non-regression
+
+## 2. Native Windows Compilation
+
+- [x] 2.1 Implement the selected Windows inference backend without changing model IDs, dimension, or
+  memory schema/model stamp
+- [x] 2.2 Move/gate target-specific dependencies in `Cargo.toml` for MSVC compilation
+- [x] 2.3 Gate `PermissionsExt`, chmod behavior, `ExecutableFileBusy`, and Unix-only updater tests
+- [x] 2.4 Add Windows-safe fake executable/test helpers (`.cmd` or fixture executables as appropriate)
+- [ ] 2.5 Run `cargo clippy --all-targets --profile ci -- -D warnings` and unit tests on Windows
+
+## 3. Core CLI and Memory Validation
+
+- [ ] 3.1 Verify `--version`, `status`, explicit-path `index`, `recall`, `get`, `sessions`, `sketch`,
+  `scan`, `scrub`, `push`, `ask codex`, and `mcp` on native Windows
+- [ ] 3.2 Add a Windows fixture with a drive-rooted Codex transcript and PowerShell tool blocks
+- [ ] 3.3 Add an end-to-end explicit-path index -> recall test under a path containing spaces and
+  non-ASCII characters
+- [ ] 3.4 Verify a Windows-created memory opens on Linux and a Linux-created memory opens on Windows
+- [ ] 3.5 Verify MCP stdio keeps diagnostics off stdout
+- [ ] 3.6 Verify Hub read/push and trufflehog discovery on Windows; document/install the required
+  trufflehog executable if the push path is enabled in the minimum tier
+
+## 4. Windows PowerShell Automation
+
+- [x] 4.1 Add `scripts/automation/funes-index.ps1` matching the current index script's stdin,
+  detachment, binary-resolution, logging, and exit behavior
+- [x] 4.2 Add `scripts/automation/funes-push.ps1` matching index-before-push, bounded retry, secret-gate,
+  logging, and detachment behavior
+- [x] 4.3 Make `hooks::write_scripts` select `.sh` on Unix and `.ps1` on Windows while preserving Unix
+  file content and executable bits
+- [x] 4.4 Add a Windows hook-command renderer using process-scoped PowerShell execution-policy bypass
+- [x] 4.5 Add injection/quoting tests for spaces, Unicode, quotes, ampersands, and parentheses
+- [x] 4.6 Add timing tests proving the foreground hook returns before the 15-second timeout while the
+  worker completes independently
+
+## 5. Windows Codex Integration
+
+- [x] 5.1 Make Codex home fallback use the platform profile after `codex doctor --json` and
+  `CODEX_HOME`
+- [x] 5.2 Install Windows PowerShell hooks and keep the existing Funes-only JSON merge semantics
+- [ ] 5.3 Verify `codex mcp add/remove` uses argv-based process spawning and supports `funes.exe` paths
+- [x] 5.4 Port add/remove integration tests to `windows-latest` with a fake `codex.exe`
+- [ ] 5.5 Test local and bound-memory installs, repeat-run idempotency, malformed config safety, and
+  independent cleanup failures
+- [x] 5.6 Add pre-write Windows capability guards for Claude, pi, and Hermes until separate changes
+  declare those integrations supported
+
+## 6. Windows Installer and Upgrade Guidance
+
+- [x] 6.1 Add `scripts/install.ps1` with `-InstallDir`, `-Version`, and `-NoPathUpdate`
+- [x] 6.2 Implement HTTPS metadata/asset download, strict manifest parsing, SHA-256 verification, and
+  staged `--version` verification
+- [x] 6.3 Implement failure-safe binary replacement with bounded retries and no change on verification
+  failure
+- [x] 6.4 Add idempotent user-PATH update for the default install and new-terminal guidance
+- [x] 6.5 Add hermetic installer tests for success, pinned version, checksum mismatch, version mismatch,
+  unsupported architecture, existing install, and paths with spaces
+- [x] 6.6 Make `funes update` and update notices print platform-correct PowerShell reinstall guidance on
+  Windows without attempting live-executable replacement
+
+## 7. CI and Release
+
+- [ ] 7.1 Promote the Windows job from the dependency spike to a required PR/main regression job
+- [ ] 7.2 Cache Windows model files without sharing incompatible cache keys with Linux/macOS
+- [x] 7.3 Add a release build for `x86_64-pc-windows-msvc` and verify the embedded version
+- [x] 7.4 Package the asset as `funes-x86_64-windows.exe`
+- [x] 7.5 Include the Windows asset in exact asset-count validation and `SHA256SUMS`
+- [x] 7.6 Require Windows build success before GitHub/HF-bucket publication and upload the asset to both
+
+## 8. Documentation
+
+- [ ] 8.1 Add `Windows x86_64 — Core CLI + Codex` to the README support table
+- [x] 8.2 Document the PowerShell install command and CMD/PowerShell runtime usage
+- [x] 8.3 Document Windows profile/cache paths, overrides, trufflehog requirement, and log location
+- [x] 8.4 Document excluded agent integrations, PowerShell execution-policy behavior, re-install update
+  flow, and WSL distinction
+- [x] 8.5 Update contributor instructions with the Windows toolchain, protoc, and targeted test commands
+- [ ] 8.6 Link issue #136 and open follow-up issues for Windows self-update, additional agents, ARM64,
+  and desktop GUI
+
+## 9. Final Verification
+
+- [ ] 9.1 Run the full Linux unit/integration and installer suite unchanged
+- [ ] 9.2 Run the macOS release build and existing automation integration tests unchanged
+- [ ] 9.3 Run the complete required Windows job twice to verify cache-independent repeatability
+- [ ] 9.4 Perform a clean Windows 11 smoke test: install -> CMD version -> index -> recall -> add Codex ->
+  complete a Codex turn -> verify background index -> remove Codex
+- [ ] 9.5 Perform a Windows 10 smoke test or document the exact CI/VM evidence used to claim support
+- [ ] 9.6 Confirm every requirement scenario has an automated test or an explicitly named manual check
+- [x] 9.7 Run `openspec validate add-windows-minimum-support --strict` after OpenSpec initialization

--- a/openspec/changes/add-windows-minimum-support/tasks.md
+++ b/openspec/changes/add-windows-minimum-support/tasks.md
@@ -39,7 +39,7 @@
 - [x] 3.2 Add a Windows fixture with a drive-rooted Codex transcript and PowerShell tool blocks
 - [x] 3.3 Add an end-to-end explicit-path index -> recall test under a path containing spaces and
   non-ASCII characters
-- [ ] 3.4 Verify a Windows-created memory opens on Linux and a Linux-created memory opens on Windows
+- [x] 3.4 Verify a Windows-created memory opens on Linux and a Linux-created memory opens on Windows
 - [x] 3.5 Verify MCP stdio keeps diagnostics off stdout
 - [x] 3.6 Verify Hub read/push and trufflehog discovery on Windows; document/install the required
   trufflehog executable if the push path is enabled in the minimum tier
@@ -106,7 +106,7 @@
 
 - [x] 9.1 Run the full Linux unit/integration and installer suite unchanged
 - [ ] 9.2 Run the macOS release build and existing automation integration tests unchanged
-- [ ] 9.3 Run the complete required Windows job twice to verify cache-independent repeatability
+- [x] 9.3 Run the complete required Windows job twice to verify cache-independent repeatability
 - [ ] 9.4 Perform a clean Windows 11 smoke test: install -> CMD version -> index -> recall -> add Codex ->
   complete a Codex turn -> verify background index -> remove Codex
 - [ ] 9.5 Perform a Windows 10 smoke test or document the exact CI/VM evidence used to claim support

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,32 @@
+schema: spec-driven
+
+context: |
+  Project: huggingface/funes
+  Tech stack: Rust 2021, Tokio, clap, Lance/Arrow, rmcp, ratatui/crossterm
+  Product: local-first, append-only, deterministic recall over AI coding-agent transcripts
+  Supported platforms before this change: Linux x86_64/aarch64 and macOS Apple Silicon
+  Build prerequisite: protoc
+  Quality gate: cargo fmt, cargo clippy with warnings denied, cargo test
+
+  Product invariants:
+  - Ingest is deterministic parse -> chunk -> embed; no LLM is used at ingest time
+  - Stored passages retain exact session and turn provenance
+  - Recall is pulled on demand rather than injected proactively
+  - The local memory is derived and rebuildable; transcripts remain the source of truth
+  - Platform ports do not change memory schema, model identity, or ranking semantics
+
+rules:
+  specs:
+    - Describe observable user behavior and compatibility guarantees
+    - Include Windows drive, UNC, spaces, Unicode, and missing-HOME scenarios for path changes
+    - State native Windows, PowerShell, CMD, and WSL boundaries explicitly
+    - Preserve Linux and macOS behavior in every platform-sensitive requirement
+  design:
+    - Put platform mechanisms and rejected alternatives here rather than in user requirements
+    - Centralize OS-specific behavior instead of scattering cfg branches
+    - Prefer additive Windows seams over rewriting working Unix behavior in the minimum-support change
+    - Treat exact native dependency compatibility as a CI-proven gate, not an assumption
+  tasks:
+    - Start with a native windows-latest dependency and inference-backend spike
+    - Pair every platform behavior change with native Windows tests and Unix non-regression checks
+    - Keep release publication all-or-nothing across existing and new supported targets

--- a/scripts/automation/funes-index.ps1
+++ b/scripts/automation/funes-index.ps1
@@ -1,0 +1,48 @@
+# Native Windows per-turn index hook. The foreground drains stdin and detaches a worker.
+param(
+    [string]$Harness = 'codex',
+    [switch]$Worker
+)
+$ErrorActionPreference = 'Stop'
+$logPath = Join-Path $PSScriptRoot 'funes-sync.log'
+function Write-Log([string]$Message) {
+    Add-Content -LiteralPath $logPath -Encoding UTF8 -Value ("{0:o} {1}" -f (Get-Date), $Message)
+}
+function Invoke-Funes([string[]]$Arguments) {
+    $ErrorActionPreference = "Continue"
+    & $binary @Arguments 2>&1 | ForEach-Object { Add-Content -LiteralPath $logPath -Encoding UTF8 -Value "$_" }
+    return $LASTEXITCODE
+}
+function Quote-Literal([string]$Value) { "'" + $Value.Replace("'", "''") + "'" }
+
+try {
+    if (-not $Worker) {
+        $null = [Console]::In.ReadToEnd()
+        $command = '& ' + (Quote-Literal $PSCommandPath) + ' -Worker -Harness ' + (Quote-Literal $Harness)
+        $encoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($command))
+        $process = Start-Process -FilePath (Join-Path $env:SystemRoot 'System32\WindowsPowerShell\v1.0\powershell.exe') -WindowStyle Hidden -WorkingDirectory (Get-Location).Path -PassThru `
+            -ArgumentList @('-NoLogo', '-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-EncodedCommand', $encoded)
+        $process.Dispose()
+        exit 0
+    }
+
+    $binary = $env:FUNES_BIN
+    if (-not $binary) {
+        $found = Get-Command funes.exe -CommandType Application -ErrorAction SilentlyContinue
+        if ($found) { $binary = $found.Source }
+    }
+    if (-not $binary -and $env:LOCALAPPDATA) {
+        $binary = Join-Path $env:LOCALAPPDATA 'Programs\funes\bin\funes.exe'
+    }
+    if (-not $binary -or -not (Test-Path -LiteralPath $binary -PathType Leaf)) {
+        Write-Log 'index ABORT: funes not found; set FUNES_BIN to the full executable path.'
+        exit 0
+    }
+    Write-Log "index[$Harness]: start"
+    $result = Invoke-Funes -Arguments @('index', '--harness', $Harness)
+    if ($result -eq 0) { Write-Log "index[$Harness]: ok" }
+    else { Write-Log "index[$Harness]: FAILED (exit $result)" }
+} catch {
+    Write-Log "index: FAILED ($_ )"
+}
+exit 0

--- a/scripts/automation/funes-index.ps1
+++ b/scripts/automation/funes-index.ps1
@@ -10,7 +10,7 @@ function Write-Log([string]$Message) {
 }
 function Invoke-Funes([string[]]$Arguments) {
     $ErrorActionPreference = "Continue"
-    & $binary @Arguments 2>&1 | ForEach-Object { Add-Content -LiteralPath $logPath -Encoding UTF8 -Value "$_" }
+    $null | & $binary @Arguments 2>&1 | ForEach-Object { Add-Content -LiteralPath $logPath -Encoding UTF8 -Value "$_" }
     return $LASTEXITCODE
 }
 function Quote-Literal([string]$Value) { "'" + $Value.Replace("'", "''") + "'" }

--- a/scripts/automation/funes-push.ps1
+++ b/scripts/automation/funes-push.ps1
@@ -11,7 +11,7 @@ function Write-Log([string]$Message) {
 }
 function Invoke-Funes([string[]]$Arguments) {
     $ErrorActionPreference = "Continue"
-    & $binary @Arguments 2>&1 | ForEach-Object { Add-Content -LiteralPath $logPath -Encoding UTF8 -Value "$_" }
+    $null | & $binary @Arguments 2>&1 | ForEach-Object { Add-Content -LiteralPath $logPath -Encoding UTF8 -Value "$_" }
     return $LASTEXITCODE
 }
 function Quote-Literal([string]$Value) { "'" + $Value.Replace("'", "''") + "'" }

--- a/scripts/automation/funes-push.ps1
+++ b/scripts/automation/funes-push.ps1
@@ -1,0 +1,59 @@
+# Native Windows boundary hook: retry indexing, then publish the stored memory.
+param(
+    [Parameter(Mandatory = $true)][string]$Memory,
+    [string]$Harness = 'codex',
+    [switch]$Worker
+)
+$ErrorActionPreference = 'Stop'
+$logPath = Join-Path $PSScriptRoot 'funes-sync.log'
+function Write-Log([string]$Message) {
+    Add-Content -LiteralPath $logPath -Encoding UTF8 -Value ("{0:o} {1}" -f (Get-Date), $Message)
+}
+function Invoke-Funes([string[]]$Arguments) {
+    $ErrorActionPreference = "Continue"
+    & $binary @Arguments 2>&1 | ForEach-Object { Add-Content -LiteralPath $logPath -Encoding UTF8 -Value "$_" }
+    return $LASTEXITCODE
+}
+function Quote-Literal([string]$Value) { "'" + $Value.Replace("'", "''") + "'" }
+
+try {
+    if (-not $Worker) {
+        $null = [Console]::In.ReadToEnd()
+        $command = '& ' + (Quote-Literal $PSCommandPath) + ' -Worker -Memory ' + (Quote-Literal $Memory) +
+            ' -Harness ' + (Quote-Literal $Harness)
+        $encoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($command))
+        $process = Start-Process -FilePath (Join-Path $env:SystemRoot 'System32\WindowsPowerShell\v1.0\powershell.exe') -WindowStyle Hidden -WorkingDirectory (Get-Location).Path -PassThru `
+            -ArgumentList @('-NoLogo', '-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-EncodedCommand', $encoded)
+        $process.Dispose()
+        exit 0
+    }
+
+    $binary = $env:FUNES_BIN
+    if (-not $binary) {
+        $found = Get-Command funes.exe -CommandType Application -ErrorAction SilentlyContinue
+        if ($found) { $binary = $found.Source }
+    }
+    if (-not $binary -and $env:LOCALAPPDATA) {
+        $binary = Join-Path $env:LOCALAPPDATA 'Programs\funes\bin\funes.exe'
+    }
+    if (-not $binary -or -not (Test-Path -LiteralPath $binary -PathType Leaf)) {
+        Write-Log 'push ABORT: funes not found; set FUNES_BIN to the full executable path.'
+        exit 0
+    }
+    for ($attempt = 1; $attempt -le 5; $attempt++) {
+        $result = Invoke-Funes -Arguments @('index', '--harness', $Harness)
+        if ($result -eq 0) { Write-Log "index[$Harness]: ok (before push)"; break }
+        Write-Log "index[$Harness]: busy or failed, retry $attempt"
+        Start-Sleep -Seconds 2
+    }
+    Write-Log "push: start ($Memory)"
+    $result = Invoke-Funes -Arguments @('push', $Memory)
+    switch ($result) {
+        0 { Write-Log 'push: ok' }
+        2 { Write-Log 'push: WARN - secrets held back; run funes scrub, then retry' }
+        default { Write-Log "push: FAILED (exit $result)" }
+    }
+} catch {
+    Write-Log "push: FAILED ($_ )"
+}
+exit 0

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,107 @@
+# Download and verify a native x86-64 Windows release before replacing an existing installation.
+[CmdletBinding()]
+param(
+    [string]$InstallDir = $env:FUNES_INSTALL_DIR,
+    [string]$Version = 'latest',
+    [switch]$NoPathUpdate
+)
+
+function Get-FunesFile([string]$Uri, [string]$Destination) {
+    if (-not $Uri.StartsWith('https://')) { throw 'Release downloads require HTTPS.' }
+    [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+    Invoke-WebRequest -UseBasicParsing -Uri $Uri -OutFile $Destination
+}
+
+function Get-FunesArchitecture {
+    if ($env:PROCESSOR_ARCHITEW6432) { return $env:PROCESSOR_ARCHITEW6432 }
+    return $env:PROCESSOR_ARCHITECTURE
+}
+
+function Read-FunesVersion([string]$Path) {
+    $value = [IO.File]::ReadAllText($Path).Trim()
+    if ($value -notmatch '^v?([0-9]+\.[0-9]+\.[0-9]+)$') { throw 'Invalid release VERSION metadata.' }
+    return $Matches[1]
+}
+
+function Read-FunesDigest([string]$Path, [string]$Asset) {
+    $seen = @{}
+    $digest = $null
+    foreach ($line in [IO.File]::ReadAllLines($Path)) {
+        if ($line -cnotmatch '^([0-9a-f]{64})  ([A-Za-z0-9_.-]+)$') { throw 'Malformed SHA256SUMS manifest.' }
+        $hash = $Matches[1]
+        $name = $Matches[2]
+        if ($seen.ContainsKey($name)) { throw 'Duplicate release asset in SHA256SUMS.' }
+        $seen[$name] = $true
+        if ($name -ceq $Asset) { $digest = $hash }
+    }
+    if (-not $digest) { throw "Missing checksum for $Asset." }
+    return $digest
+}
+
+function Install-Funes([string]$Destination, [string]$RequestedVersion, [bool]$SkipPathUpdate) {
+    $ErrorActionPreference = 'Stop'
+    if ([Environment]::OSVersion.Platform -ne [PlatformID]::Win32NT -or (Get-FunesArchitecture) -ne 'AMD64') {
+        throw 'This installer supports native Windows x86-64 only.'
+    }
+    if (-not $env:LOCALAPPDATA -and -not $Destination) { throw 'Set -InstallDir because LOCALAPPDATA is unavailable.' }
+    $defaultDir = if ($env:LOCALAPPDATA) { Join-Path $env:LOCALAPPDATA 'Programs\funes\bin' } else { $null }
+    if (-not $Destination) { $Destination = $defaultDir }
+    $Destination = [IO.Path]::GetFullPath($Destination)
+    if ($RequestedVersion -ne 'latest' -and $RequestedVersion -notmatch '^v?[0-9]+\.[0-9]+\.[0-9]+$') {
+        throw 'Use -Version latest or a release version such as 1.3.0.'
+    }
+    $null = New-Item -ItemType Directory -Force -Path $Destination
+    $staging = Join-Path $Destination ('.funes-install-' + [Guid]::NewGuid().ToString('N'))
+    $null = New-Item -ItemType Directory -Path $staging
+    $base = 'https://huggingface.co/buckets/huggingface/funes/resolve'
+    $asset = 'funes-x86_64-windows.exe'
+    try {
+        $metadata = Join-Path $staging 'VERSION'
+        if ($RequestedVersion -eq 'latest') {
+            Get-FunesFile "$base/VERSION" $metadata
+            $wanted = Read-FunesVersion $metadata
+        } else { $wanted = $RequestedVersion.TrimStart('v') }
+        $tag = "v$wanted"
+        Get-FunesFile "$base/$tag/VERSION" $metadata
+        if ((Read-FunesVersion $metadata) -cne $wanted) { throw 'Tagged VERSION does not match the requested release.' }
+        $manifest = Join-Path $staging 'SHA256SUMS'
+        Get-FunesFile "$base/$tag/SHA256SUMS" $manifest
+        $expected = Read-FunesDigest $manifest $asset
+        $staged = Join-Path $staging 'funes.exe'
+        Get-FunesFile "$base/$tag/$asset" $staged
+        if ((Get-FileHash -LiteralPath $staged -Algorithm SHA256).Hash.ToLowerInvariant() -cne $expected) {
+            throw 'Release checksum mismatch; the installed binary was not changed.'
+        }
+        $reported = & $staged --version
+        if ($LASTEXITCODE -ne 0 -or "$reported".Trim() -cne "funes $wanted") {
+            throw 'Downloaded binary reports an unexpected version; the installed binary was not changed.'
+        }
+        $target = Join-Path $Destination 'funes.exe'
+        for ($attempt = 1; $attempt -le 5; $attempt++) {
+            try {
+                if ([IO.File]::Exists($target)) {
+                    [IO.File]::Replace($staged, $target, (Join-Path $staging 'previous.exe'))
+                } else { [IO.File]::Move($staged, $target) }
+                break
+            } catch {
+                if ($attempt -eq 5) { throw "Cannot replace $target. Close running agents and MCP servers, then rerun the installer. $($_.Exception.Message)" }
+                Start-Sleep -Milliseconds 500
+            }
+        }
+        if (-not $SkipPathUpdate -and $defaultDir -and $Destination.TrimEnd('\') -ieq $defaultDir.TrimEnd('\')) {
+            $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+            $entries = @($userPath -split ';' | Where-Object { $_ })
+            if (-not ($entries | Where-Object { $_.TrimEnd('\') -ieq $Destination.TrimEnd('\') })) {
+                [Environment]::SetEnvironmentVariable('Path', (($entries + $Destination) -join ';'), 'User')
+            }
+            Write-Host 'Open a new PowerShell or CMD window to use the updated PATH.'
+        } else { Write-Host "Run $target, or add $Destination to PATH." }
+        Write-Host "Installed funes $wanted at $target"
+    } finally {
+        if (Test-Path -LiteralPath $staging) { Remove-Item -LiteralPath $staging -Recurse -Force }
+    }
+}
+
+if ($MyInvocation.InvocationName -ne '.') {
+    Install-Funes $InstallDir $Version $NoPathUpdate.IsPresent
+}

--- a/scripts/test-windows.ps1
+++ b/scripts/test-windows.ps1
@@ -25,6 +25,7 @@ public class FunesFixture {
             Console.WriteLine("funes " + (Environment.GetEnvironmentVariable("FUNES_TEST_VERSION") ?? "1.3.0"));
             return 0;
         }
+        if (!Console.IsInputRedirected) return 42;
         File.AppendAllText(log, String.Join("|", args) + "\n");
         Console.Error.WriteLine("fixture diagnostic on stderr");
         if (args[0] == "index") Thread.Sleep(Int32.Parse(Environment.GetEnvironmentVariable("FUNES_TEST_DELAY") ?? "0"));
@@ -102,11 +103,23 @@ public class FunesFixture {
         $calls = if (Test-Path -LiteralPath $env:FUNES_TEST_LOG) { [IO.File]::ReadAllText($env:FUNES_TEST_LOG) } else { '' }
     } until ($calls.Contains('done:index') -or (Get-Date) -gt $deadline)
     Assert ($calls.Contains("index|--harness|codex`ndone:index")) 'Detached worker lost its arguments or did not finish'
-    $env:FUNES_TEST_DELAY = '0'
-    & (Join-Path $hooks 'funes-push.ps1') -Worker -Memory "acme/a'b & (x) %PATH%" -Harness codex
+    $script = Join-Path $hooks 'funes-push.ps1'
+    $command = "& '" + $script.Replace("'", "''") + "' -Memory 'acme/a''b & (x) %PATH%' -Harness 'codex'"
+    $encoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($command))
+    $info.Arguments = '-NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand ' + $encoded
+    $process = [Diagnostics.Process]::Start($info)
+    $process.StandardInput.WriteLine('{}')
+    $process.StandardInput.Close()
+    Assert ($process.WaitForExit(5000)) 'Foreground push hook blocked on indexing'
+    Assert ($process.ExitCode -eq 0) 'Foreground push hook failed'
+    $process.Dispose()
+    $deadline = (Get-Date).AddSeconds(20)
+    do {
+        Start-Sleep -Milliseconds 200
+        $hookLog = [IO.File]::ReadAllText((Join-Path $hooks 'funes-sync.log'))
+    } until ($hookLog.Contains('WARN - secrets held back') -or (Get-Date) -gt $deadline)
     $calls = [IO.File]::ReadAllText($env:FUNES_TEST_LOG)
     Assert ($calls.Contains("push|acme/a'b & (x) %PATH%")) 'Push arguments were interpreted as commands'
-    $hookLog = [IO.File]::ReadAllText((Join-Path $hooks 'funes-sync.log'))
     Assert ($hookLog.Contains('WARN - secrets held back')) 'Secret-gate exit code was not recorded'
     Write-Host 'Windows installer and hook tests passed.'
 } finally {

--- a/scripts/test-windows.ps1
+++ b/scripts/test-windows.ps1
@@ -1,0 +1,118 @@
+# Hermetic installer and detached-hook tests on Windows PowerShell 5.1.
+$ErrorActionPreference = 'Stop'
+$root = Join-Path ([IO.Path]::GetTempPath()) ("funes test $([char]0x6D4B)$([char]0x8BD5) & (x) ' " + [Guid]::NewGuid().ToString('N'))
+$null = New-Item -ItemType Directory $root
+$savedLocal = $env:LOCALAPPDATA
+$savedBin = $env:FUNES_BIN
+$savedUserPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+function Assert([bool]$Condition, [string]$Message) { if (-not $Condition) { throw $Message } }
+function Must-Fail([scriptblock]$Action) {
+    $failed = $false
+    try { & $Action } catch { $failed = $true }
+    Assert $failed 'Expected the operation to fail'
+}
+try {
+    $fake = Join-Path $root 'fake.exe'
+    Add-Type -OutputAssembly $fake -OutputType ConsoleApplication -TypeDefinition @'
+using System;
+using System.IO;
+using System.Threading;
+public class FunesFixture {
+    public static int Main(string[] args) {
+        string log = Environment.GetEnvironmentVariable("FUNES_TEST_LOG");
+        if (args.Length > 0 && args[0] == "--version") {
+            if (!String.IsNullOrEmpty(log)) File.AppendAllText(log, "version\n");
+            Console.WriteLine("funes " + (Environment.GetEnvironmentVariable("FUNES_TEST_VERSION") ?? "1.3.0"));
+            return 0;
+        }
+        File.AppendAllText(log, String.Join("|", args) + "\n");
+        Console.Error.WriteLine("fixture diagnostic on stderr");
+        if (args[0] == "index") Thread.Sleep(Int32.Parse(Environment.GetEnvironmentVariable("FUNES_TEST_DELAY") ?? "0"));
+        File.AppendAllText(log, "done:" + args[0] + "\n");
+        return args[0] == "push" ? 2 : 0;
+    }
+}
+'@
+    $fixture = Join-Path $root 'release'
+    $null = New-Item -ItemType Directory $fixture
+    Copy-Item $fake (Join-Path $fixture 'funes-x86_64-windows.exe')
+    [IO.File]::WriteAllText((Join-Path $fixture 'VERSION'), "1.3.0`n")
+    $hash = (Get-FileHash $fake -Algorithm SHA256).Hash.ToLowerInvariant()
+    $validManifest = "$hash  funes-x86_64-windows.exe`n"
+    [IO.File]::WriteAllText((Join-Path $fixture 'SHA256SUMS'), $validManifest)
+    . (Join-Path $PSScriptRoot 'install.ps1')
+    function Get-FunesFile([string]$Uri, [string]$Destination) {
+        Assert ($Uri.StartsWith('https://')) 'Download must use HTTPS'
+        Copy-Item -LiteralPath (Join-Path $fixture ($Uri.Split('/')[-1])) -Destination $Destination
+    }
+    $env:LOCALAPPDATA = Join-Path $root 'profile'
+    $env:FUNES_TEST_LOG = Join-Path $root 'calls.txt'
+    $destination = Join-Path $root 'installed bin'
+    Install-Funes $destination '1.3.0' $true
+    $target = Join-Path $destination 'funes.exe'
+    Assert (Test-Path -LiteralPath $target) 'Pinned installation failed'
+    Install-Funes $destination 'latest' $true
+    $before = (Get-FileHash -LiteralPath $target).Hash
+
+    Remove-Item -LiteralPath $env:FUNES_TEST_LOG
+    [IO.File]::WriteAllText((Join-Path $fixture 'SHA256SUMS'), (('0' * 64) + "  funes-x86_64-windows.exe`n"))
+    Must-Fail { Install-Funes $destination '1.3.0' $true }
+    Assert (-not (Test-Path -LiteralPath $env:FUNES_TEST_LOG)) 'Executed binary before checksum verification'
+    Assert ((Get-FileHash -LiteralPath $target).Hash -eq $before) 'Checksum failure changed installation'
+    [IO.File]::WriteAllText((Join-Path $fixture 'SHA256SUMS'), $validManifest + $validManifest)
+    Must-Fail { Install-Funes $destination '1.3.0' $true }
+    [IO.File]::WriteAllText((Join-Path $fixture 'SHA256SUMS'), $validManifest)
+    $env:FUNES_TEST_VERSION = '9.9.9'
+    Must-Fail { Install-Funes $destination '1.3.0' $true }
+    Assert ((Get-FileHash -LiteralPath $target).Hash -eq $before) 'Version failure changed installation'
+    Remove-Item Env:FUNES_TEST_VERSION
+    Must-Fail { Install-Funes $destination '../bad' $true }
+    function Get-FunesArchitecture { 'ARM64' }
+    Must-Fail { Install-Funes $destination '1.3.0' $true }
+    function Get-FunesArchitecture { 'AMD64' }
+    Install-Funes '' '1.3.0' $false
+    Install-Funes '' '1.3.0' $false
+    $defaultDir = Join-Path $env:LOCALAPPDATA 'Programs\funes\bin'
+    $entries = [Environment]::GetEnvironmentVariable('Path', 'User') -split ';'
+    Assert (@($entries | Where-Object { $_ -eq $defaultDir }).Count -eq 1) 'PATH update duplicated the directory'
+
+    $hooks = Join-Path $root 'hooks'
+    $null = New-Item -ItemType Directory $hooks
+    Copy-Item (Join-Path $PSScriptRoot 'automation\*.ps1') $hooks
+    $env:FUNES_BIN = $fake
+    $env:FUNES_TEST_DELAY = '6000'
+    Remove-Item -LiteralPath $env:FUNES_TEST_LOG -ErrorAction SilentlyContinue
+    $script = Join-Path $hooks 'funes-index.ps1'
+    $command = "& '" + $script.Replace("'", "''") + "' 'codex'"
+    $encoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($command))
+    $info = New-Object Diagnostics.ProcessStartInfo
+    $info.FileName = Join-Path $env:SystemRoot 'System32\WindowsPowerShell\v1.0\powershell.exe'
+    $info.Arguments = '-NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand ' + $encoded
+    $info.UseShellExecute = $false
+    $info.RedirectStandardInput = $true
+    $process = [Diagnostics.Process]::Start($info)
+    $process.StandardInput.WriteLine('{}')
+    $process.StandardInput.Close()
+    Assert ($process.WaitForExit(5000)) 'Foreground hook blocked on its six-second worker'
+    Assert ($process.ExitCode -eq 0) 'Foreground hook failed'
+    $process.Dispose()
+    $deadline = (Get-Date).AddSeconds(20)
+    do {
+        Start-Sleep -Milliseconds 200
+        $calls = if (Test-Path -LiteralPath $env:FUNES_TEST_LOG) { [IO.File]::ReadAllText($env:FUNES_TEST_LOG) } else { '' }
+    } until ($calls.Contains('done:index') -or (Get-Date) -gt $deadline)
+    Assert ($calls.Contains("index|--harness|codex`ndone:index")) 'Detached worker lost its arguments or did not finish'
+    $env:FUNES_TEST_DELAY = '0'
+    & (Join-Path $hooks 'funes-push.ps1') -Worker -Memory "acme/a'b & (x) %PATH%" -Harness codex
+    $calls = [IO.File]::ReadAllText($env:FUNES_TEST_LOG)
+    Assert ($calls.Contains("push|acme/a'b & (x) %PATH%")) 'Push arguments were interpreted as commands'
+    $hookLog = [IO.File]::ReadAllText((Join-Path $hooks 'funes-sync.log'))
+    Assert ($hookLog.Contains('WARN - secrets held back')) 'Secret-gate exit code was not recorded'
+    Write-Host 'Windows installer and hook tests passed.'
+} finally {
+    $env:LOCALAPPDATA = $savedLocal
+    $env:FUNES_BIN = $savedBin
+    [Environment]::SetEnvironmentVariable('Path', $savedUserPath, 'User')
+    Remove-Item Env:FUNES_TEST_LOG, Env:FUNES_TEST_VERSION, Env:FUNES_TEST_DELAY -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -9,10 +9,17 @@ pub mod pi;
 
 use anyhow::{bail, Context, Result};
 use std::path::Path;
-use std::process::Command;
 
-/// Render an argv as a copy/paste-safe POSIX shell command.
+/// Render argv as a copy/paste hint for POSIX shells or Windows PowerShell.
 pub(crate) fn shell_command<S: AsRef<str>>(program: &str, args: &[S]) -> String {
+    if cfg!(windows) {
+        let values = std::iter::once(program)
+            .chain(args.iter().map(AsRef::as_ref))
+            .map(|arg| format!("'{}'", arg.replace('\'', "''")))
+            .collect::<Vec<_>>()
+            .join(" ");
+        return format!("& {values}");
+    }
     std::iter::once(program)
         .chain(args.iter().map(AsRef::as_ref))
         .map(shell_arg)
@@ -48,7 +55,7 @@ pub(crate) enum RemoveCommand {
 /// diagnostics and fail rather than claiming a partial uninstall succeeded.
 pub(crate) fn run_remove(program: &str, args: &[&str], absent_markers: &[&str]) -> Result<RemoveCommand> {
     let command = shell_command(program, args);
-    let output = match Command::new(program).args(args).output() {
+    let output = match crate::platform::command(program).args(args).output() {
         Ok(output) => output,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(RemoveCommand::MissingCli),
         Err(e) => return Err(anyhow::Error::new(e).context(format!("running `{command}`"))),
@@ -114,6 +121,7 @@ mod tests {
     use super::shell_command;
 
     #[test]
+    #[cfg(unix)]
     fn shell_command_quotes_only_unsafe_arguments() {
         assert_eq!(
             shell_command(
@@ -127,5 +135,14 @@ mod tests {
             "pi remove '/Users/O'\"'\"'Brien/funes'"
         );
         assert_eq!(shell_command("agent", &[""]), "agent ''");
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn shell_command_is_a_powershell_literal_invocation() {
+        assert_eq!(
+            shell_command("codex", &["mcp", "a'b & %PATH%"]),
+            "& 'codex' 'mcp' 'a''b & %PATH%'"
+        );
     }
 }

--- a/src/agents/claude.rs
+++ b/src/agents/claude.rs
@@ -145,11 +145,11 @@ fn uninstall_hooks() -> Result<()> {
 fn desired_hooks(memory: Option<&str>) -> Vec<hooks::Hook> {
     let mut hooks = vec![hooks::Hook {
         event: "Stop",
-        command: hooks::command("${CLAUDE_PLUGIN_ROOT}/scripts/funes-index.sh", &["claude"]),
+        command: hooks::posix_command("${CLAUDE_PLUGIN_ROOT}/scripts/funes-index.sh", &["claude"]),
         status: INDEX_STATUS,
     }];
     if let Some(memory) = memory {
-        let command = hooks::command("${CLAUDE_PLUGIN_ROOT}/scripts/funes-push.sh", &[memory, "claude"]);
+        let command = hooks::posix_command("${CLAUDE_PLUGIN_ROOT}/scripts/funes-push.sh", &[memory, "claude"]);
         hooks.push(hooks::Hook {
             event: "SessionStart",
             command: command.clone(),

--- a/src/agents/codex.rs
+++ b/src/agents/codex.rs
@@ -247,13 +247,18 @@ fn desired_hooks(hooks_dir: &Path, memory: Option<&str>) -> Vec<hooks::Hook> {
 fn install_hooks(codex_home: &Path, memory: Option<&str>) -> Result<()> {
     let base = codex_home.to_path_buf();
     let hooks_dir = base.join("hooks");
-    hooks::write_scripts(&hooks_dir)?;
     let desired = desired_hooks(&hooks_dir, memory);
 
     let config = base.join("hooks.json");
-    let cfg = match std::fs::read_to_string(&config).ok().as_deref().map(str::trim) {
+    let contents = match std::fs::read_to_string(&config) {
+        Ok(text) => Some(text),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => return Err(error).with_context(|| format!("reading {}", config.display())),
+    };
+    hooks::write_scripts(&hooks_dir)?;
+    let cfg = match contents.as_deref().map(str::trim) {
         Some(s) if !s.is_empty() => match serde_json::from_str::<Value>(s) {
-            Ok(v) if v.is_object() => v,
+            Ok(v) if hooks::config_is_mergeable(&v) => v,
             _ => return manual_hook_instructions(&config, &desired),
         },
         _ => json!({}),
@@ -285,7 +290,7 @@ fn install_hooks(codex_home: &Path, memory: Option<&str>) -> Result<()> {
 fn manual_hook_instructions(path: &Path, desired: &[hooks::Hook]) -> Result<()> {
     let block = serde_json::to_string_pretty(&hooks::apply_funes_hooks(json!({}), desired))?;
     println!(
-        "{} isn't plain JSON — leaving it untouched. Merge this in to enable funes hooks:\n{block}",
+        "{} isn't a supported hooks JSON object — leaving it untouched. Merge this in to enable funes hooks:\n{block}",
         path.display()
     );
     Ok(())
@@ -301,9 +306,9 @@ fn uninstall_hooks(codex_home: &Path) -> Result<()> {
         Ok(s) if !s.trim().is_empty() => {
             let value = serde_json::from_str::<Value>(&s)
                 .with_context(|| format!("parsing {} to remove funes hooks", config.display()))?;
-            if !value.is_object() {
+            if !hooks::config_is_mergeable(&value) {
                 bail!(
-                    "{} isn't a JSON object — leaving it and the hook scripts untouched; remove hook groups whose command contains `funes-index.sh` or `funes-push.sh`, then re-run `funes remove codex`",
+                    "{} isn't a supported hooks JSON object — leaving it and the hook scripts untouched; repair its hooks/event structure, then re-run `funes remove codex`",
                     config.display()
                 );
             }
@@ -340,6 +345,29 @@ mod tests {
     use super::{codex_home_from_report, desired_hooks, mcp_add_args, parse_version_line, MIN_CODEX, SKILL_MD};
     use std::path::Path;
     use std::path::PathBuf;
+
+    #[test]
+    fn malformed_hook_structure_is_preserved_on_install_and_remove() {
+        for text in [r#"{"hooks":{"Stop":{}}}"#, r#"{"hooks":null}"#, r#"{"hooks":[]}"#] {
+            let home = tempfile::tempdir().unwrap();
+            let config = home.path().join("hooks.json");
+            std::fs::write(&config, text).unwrap();
+            super::install_hooks(home.path(), None).unwrap();
+            assert_eq!(std::fs::read_to_string(&config).unwrap(), text);
+            assert!(super::uninstall_hooks(home.path()).is_err());
+            assert_eq!(std::fs::read_to_string(&config).unwrap(), text);
+            assert!(home.path().join("hooks").join(super::hooks::INDEX_NAME).is_file());
+        }
+    }
+
+    #[test]
+    fn unreadable_hooks_are_not_treated_as_missing() {
+        let home = tempfile::tempdir().unwrap();
+        std::fs::create_dir(home.path().join("hooks.json")).unwrap();
+        let error = super::install_hooks(home.path(), None).unwrap_err();
+        assert!(error.to_string().contains("reading"), "{error:#}");
+        assert!(!home.path().join("hooks").exists());
+    }
 
     #[test]
     fn bakes_the_memory_only_when_present() {

--- a/src/agents/codex.rs
+++ b/src/agents/codex.rs
@@ -21,7 +21,6 @@ use crate::commands::update::parse_semver;
 use anyhow::{bail, Context, Result};
 use serde_json::{json, Value};
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 const SKILL_MD: &str = include_str!("../../integrations/codex/SKILL.md");
 
@@ -67,7 +66,7 @@ pub fn install(memory: Option<String>) -> Result<()> {
     let funes = std::env::var("FUNES_BIN").unwrap_or_else(|_| "funes".to_string());
     let args = mcp_add_args(&funes, memory.as_deref());
     let manual = shell_command("codex", &args);
-    let status = match Command::new("codex").args(&args).status() {
+    let status = match crate::platform::command("codex").args(&args).status() {
         Ok(s) => s,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             println!("`codex` isn't on PATH — once it is, run:  {manual}");
@@ -133,15 +132,18 @@ fn codex_home() -> Result<PathBuf> {
     if let Some(dir) = std::env::var_os("CODEX_HOME").filter(|d| !d.is_empty()) {
         return Ok(PathBuf::from(dir));
     }
-    let home = std::env::var_os("HOME").context("resolving $HOME for the Codex home")?;
-    Ok(PathBuf::from(home).join(".codex"))
+    let home = crate::platform::user_home().context("resolving the user profile for the Codex home")?;
+    Ok(home.join(".codex"))
 }
 
 /// The home `codex doctor --json` reports. Its exit status is the health verdict, not whether it
 /// answered, so the report is read whatever it says; anything unreadable yields `None` and leaves
 /// the caller its fallback.
 fn doctor_codex_home() -> Option<PathBuf> {
-    let report = Command::new("codex").args(["doctor", "--json"]).output().ok()?;
+    let report = crate::platform::command("codex")
+        .args(["doctor", "--json"])
+        .output()
+        .ok()?;
     codex_home_from_report(&report.stdout)
 }
 
@@ -169,7 +171,7 @@ fn skill_dir(codex_home: &Path) -> PathBuf {
 /// stops reaching the agents that read that tree. Best-effort: it is gone on every host but the ones
 /// that ran that install.
 fn remove_shared_skill() -> Result<()> {
-    let home = PathBuf::from(std::env::var_os("HOME").context("resolving $HOME for the skills dir")?);
+    let home = crate::platform::user_home().context("resolving the user profile for the skills dir")?;
     let dir = home.join(".agents/skills/funes");
     remove_file(&dir.join("SKILL.md"))?;
     remove_empty_dir(&dir)?;
@@ -201,7 +203,7 @@ fn uninstall_skill(codex_home: &Path) -> Result<()> {
 /// What Codex prints for `--version`. `None` when Codex is absent, which leaves the install to
 /// proceed as the registration does.
 fn codex_version() -> Result<Option<String>> {
-    let out = match Command::new("codex").arg("--version").output() {
+    let out = match crate::platform::command("codex").arg("--version").output() {
         Ok(o) if o.status.success() => o,
         Ok(_) => return Ok(None),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
@@ -218,12 +220,12 @@ fn parse_version_line(printed: &str) -> Option<(u32, u32, u32)> {
 fn desired_hooks(hooks_dir: &Path, memory: Option<&str>) -> Vec<hooks::Hook> {
     let mut hooks = vec![hooks::Hook {
         event: "Stop",
-        command: hooks::command(&hooks_dir.join("funes-index.sh").display().to_string(), &["codex"]),
+        command: hooks::command(&hooks_dir.join(hooks::INDEX_NAME).display().to_string(), &["codex"]),
         status: INDEX_STATUS,
     }];
     if let Some(memory) = memory {
         let command = hooks::command(
-            &hooks_dir.join("funes-push.sh").display().to_string(),
+            &hooks_dir.join(hooks::PUSH_NAME).display().to_string(),
             &[memory, "codex"],
         );
         hooks.push(hooks::Hook {
@@ -320,7 +322,13 @@ fn uninstall_hooks(codex_home: &Path) -> Result<()> {
     }
 
     let hooks_dir = base.join("hooks");
-    for name in ["funes-index.sh", "funes-push.sh", "funes-sync.log"] {
+    for name in [
+        "funes-index.sh",
+        "funes-push.sh",
+        "funes-index.ps1",
+        "funes-push.ps1",
+        "funes-sync.log",
+    ] {
         remove_file(&hooks_dir.join(name))?;
     }
     remove_empty_dir(&hooks_dir)?;
@@ -382,7 +390,16 @@ mod tests {
         let local = desired_hooks(Path::new("/h/hooks"), None);
         assert_eq!(local.len(), 1);
         assert_eq!(local[0].event, "Stop");
-        assert!(local[0].command.contains("/h/hooks/funes-index.sh"));
+        assert_eq!(
+            local[0].command,
+            super::hooks::command(
+                &Path::new("/h/hooks")
+                    .join(super::hooks::INDEX_NAME)
+                    .display()
+                    .to_string(),
+                &["codex"]
+            )
+        );
 
         let remote = desired_hooks(Path::new("/h/hooks"), Some("acme/kb"));
         assert_eq!(remote.len(), 3);
@@ -391,6 +408,13 @@ mod tests {
         assert!(remote
             .iter()
             .filter(|hook| hook.event != "Stop")
-            .all(|hook| hook.command.contains("acme/kb")));
+            .all(|hook| hook.command
+                == super::hooks::command(
+                    &Path::new("/h/hooks")
+                        .join(super::hooks::PUSH_NAME)
+                        .display()
+                        .to_string(),
+                    &["acme/kb", "codex"]
+                )));
     }
 }

--- a/src/agents/hermes.rs
+++ b/src/agents/hermes.rs
@@ -414,10 +414,7 @@ mod tests {
     fn adds_hooks_to_a_fresh_config() {
         let entries = desired(Path::new("/h/hooks"), Some("acme/kb"));
         let out = apply_config_hooks(serde_yaml::Value::Mapping(Default::default()), &entries);
-        assert_eq!(
-            funes_cmd(&out, "post_llm_call").as_deref(),
-            Some(entries[0].1.as_str())
-        );
+        assert_eq!(funes_cmd(&out, "post_llm_call").as_deref(), Some(entries[0].1.as_str()));
         assert_eq!(
             funes_cmd(&out, "on_session_finalize").as_deref(),
             Some(entries[2].1.as_str())
@@ -460,10 +457,7 @@ mod tests {
             .iter()
             .any(|e| e.get("command").unwrap().as_str() == Some("make lint")));
         assert_eq!(list.iter().filter(|e| is_funes_entry(e)).count(), 1);
-        assert_eq!(
-            funes_cmd(&out, "post_llm_call").as_deref(),
-            Some(entries[0].1.as_str())
-        );
+        assert_eq!(funes_cmd(&out, "post_llm_call").as_deref(), Some(entries[0].1.as_str()));
     }
 
     #[test]

--- a/src/agents/hermes.rs
+++ b/src/agents/hermes.rs
@@ -72,9 +72,9 @@ pub fn uninstall() -> Result<()> {
 /// command drives a detached script and is the exact string the allowlist must match.
 fn desired(hooks_dir: &Path, memory: Option<&str>) -> Vec<(&'static str, String)> {
     let index_script = hooks_dir.join("funes-index.sh").display().to_string();
-    let mut out = vec![("post_llm_call", hooks::command(&index_script, &["hermes"]))];
+    let mut out = vec![("post_llm_call", hooks::posix_command(&index_script, &["hermes"]))];
     if let Some(s) = memory {
-        let push = hooks::command(&hooks_dir.join("funes-push.sh").display().to_string(), &[s, "hermes"]);
+        let push = hooks::posix_command(&hooks_dir.join("funes-push.sh").display().to_string(), &[s, "hermes"]);
         out.push(("on_session_start", push.clone()));
         out.push(("on_session_finalize", push));
     }
@@ -416,11 +416,11 @@ mod tests {
         let out = apply_config_hooks(serde_yaml::Value::Mapping(Default::default()), &entries);
         assert_eq!(
             funes_cmd(&out, "post_llm_call").as_deref(),
-            Some("bash \"/h/hooks/funes-index.sh\" \"hermes\"")
+            Some(entries[0].1.as_str())
         );
         assert_eq!(
             funes_cmd(&out, "on_session_finalize").as_deref(),
-            Some("bash \"/h/hooks/funes-push.sh\" \"acme/kb\" \"hermes\"")
+            Some(entries[2].1.as_str())
         );
         assert!(funes_cmd(&out, "on_session_start").is_some());
     }
@@ -462,7 +462,7 @@ mod tests {
         assert_eq!(list.iter().filter(|e| is_funes_entry(e)).count(), 1);
         assert_eq!(
             funes_cmd(&out, "post_llm_call").as_deref(),
-            Some("bash \"/h/hooks/funes-index.sh\" \"hermes\"")
+            Some(entries[0].1.as_str())
         );
     }
 

--- a/src/agents/hooks.rs
+++ b/src/agents/hooks.rs
@@ -7,6 +7,7 @@
 
 use anyhow::{Context, Result};
 use serde_json::{json, Value};
+#[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 
@@ -93,14 +94,21 @@ fn is_funes_hook(hook: &Value) -> bool {
 /// Write the embedded scripts into an agent-chosen `dir`, executable. Returns whether anything
 /// changed (a drifted or absent copy is rewritten); the executable bit is (re)set every time.
 pub fn write_scripts(dir: &Path) -> Result<bool> {
+    // This build probe must never install Bash automation on native Windows.
+    if cfg!(windows) {
+        anyhow::bail!("Windows automation is not implemented yet; use explicit-path index and MCP manually");
+    }
     std::fs::create_dir_all(dir).with_context(|| format!("creating {}", dir.display()))?;
     let mut changed = false;
     for (name, content) in [("funes-index.sh", INDEX_SH), ("funes-push.sh", PUSH_SH)] {
         let path = dir.join(name);
         changed |= write_if_changed(&path, content)?;
-        let mut perms = std::fs::metadata(&path)?.permissions();
-        perms.set_mode(0o755);
-        std::fs::set_permissions(&path, perms).with_context(|| format!("chmod +x {}", path.display()))?;
+        #[cfg(unix)]
+        {
+            let mut perms = std::fs::metadata(&path)?.permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&path, perms).with_context(|| format!("chmod +x {}", path.display()))?;
+        }
     }
     Ok(changed)
 }

--- a/src/agents/hooks.rs
+++ b/src/agents/hooks.rs
@@ -48,6 +48,11 @@ pub fn command(script: &str, args: &[&str]) -> String {
     if cfg!(windows) {
         return powershell_command(script, args);
     }
+    posix_command(script, args)
+}
+
+/// Unix-only agent integrations retain their existing Bash templates on every build host.
+pub(crate) fn posix_command(script: &str, args: &[&str]) -> String {
     let mut out = format!("bash \"{}\"", dquote_escape(script));
     for arg in args {
         out.push_str(&format!(" \"{}\"", dquote_escape(arg)));

--- a/src/agents/hooks.rs
+++ b/src/agents/hooks.rs
@@ -108,7 +108,16 @@ pub(crate) fn apply_funes_hooks(mut cfg: Value, desired: &[Hook]) -> Value {
 
     for group_list in hooks.values_mut() {
         if let Some(list) = group_list.as_array_mut() {
-            list.retain(|g| !is_funes_group(g));
+            list.retain_mut(|group| {
+                let Some(hooks) = group.get_mut("hooks").and_then(Value::as_array_mut) else {
+                    return true;
+                };
+                let previous_len = hooks.len();
+                hooks.retain(|hook| !is_funes_hook(hook));
+                // A group can hold both Funes and user commands. Preserve its metadata and
+                // unrelated commands; only drop a group emptied by removing our own hooks.
+                hooks.len() == previous_len || !hooks.is_empty()
+            });
         }
     }
     for d in desired {
@@ -127,12 +136,23 @@ pub(crate) fn apply_funes_hooks(mut cfg: Value, desired: &[Hook]) -> Value {
 }
 
 /// A hook group is funes's if any of its commands invokes a funes script.
+#[cfg(test)]
 fn is_funes_group(group: &Value) -> bool {
     group
         .get("hooks")
         .and_then(Value::as_array)
         .map(|hs| hs.iter().any(is_funes_hook))
         .unwrap_or(false)
+}
+
+/// Check the structure consumed by merging before modifying an on-disk user configuration.
+pub(crate) fn config_is_mergeable(cfg: &Value) -> bool {
+    cfg.is_object()
+        && cfg.get("hooks").is_none_or(|hooks| {
+            hooks
+                .as_object()
+                .is_some_and(|events| events.values().all(Value::is_array))
+        })
 }
 
 fn is_funes_hook(hook: &Value) -> bool {
@@ -192,6 +212,37 @@ fn file_matches(path: &Path, want: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn mixed_groups_preserve_user_commands_and_metadata() {
+        for owned in [
+            command("/h/funes-index.sh", &["codex"]),
+            powershell_command(r"C:\hooks\funes-index.ps1", &["codex"]),
+        ] {
+            let user = json!({"command":"user-command", "timeout":42});
+            let cfg = json!({"hooks":{"Stop":[{"matcher":"custom", "hooks":[{"command":owned}, user.clone()]}]}});
+            let expected = json!({"hooks":{"Stop":[{"matcher":"custom", "hooks":[user]}]}});
+            assert_eq!(apply_funes_hooks(cfg.clone(), &[]), expected);
+            let replaced = apply_funes_hooks(cfg, &[idx("codex")]);
+            assert_eq!(replaced["hooks"]["Stop"], expected["hooks"]["Stop"]);
+            assert_eq!(apply_funes_hooks(replaced.clone(), &[idx("codex")]), replaced);
+        }
+    }
+
+    #[test]
+    fn malformed_event_shapes_are_not_mergeable() {
+        for cfg in [
+            json!([]),
+            json!({"hooks":null}),
+            json!({"hooks":[]}),
+            json!({"hooks":{"Stop":{}}}),
+            json!({"hooks":{"Stop":"command"}}),
+        ] {
+            assert!(!config_is_mergeable(&cfg), "{cfg}");
+        }
+        assert!(config_is_mergeable(&json!({})));
+        assert!(config_is_mergeable(&json!({"hooks":{"Stop":[]}})));
+    }
 
     #[test]
     fn powershell_preserves_literals_and_owned_hook_cleanup() {

--- a/src/agents/hooks.rs
+++ b/src/agents/hooks.rs
@@ -6,6 +6,7 @@
 //! shell command construction, and JSON hook-group merge used by compatible agents.
 
 use anyhow::{Context, Result};
+use base64::Engine;
 use serde_json::{json, Value};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
@@ -13,6 +14,21 @@ use std::path::Path;
 
 const INDEX_SH: &str = include_str!("../../scripts/automation/funes-index.sh");
 const PUSH_SH: &str = include_str!("../../scripts/automation/funes-push.sh");
+const INDEX_PS: &str = include_str!("../../scripts/automation/funes-index.ps1");
+const PUSH_PS: &str = include_str!("../../scripts/automation/funes-push.ps1");
+
+/// The installed index script for this host.
+pub const INDEX_NAME: &str = if cfg!(windows) {
+    "funes-index.ps1"
+} else {
+    "funes-index.sh"
+};
+/// The installed publish script for this host.
+pub const PUSH_NAME: &str = if cfg!(windows) {
+    "funes-push.ps1"
+} else {
+    "funes-push.sh"
+};
 
 /// The hook's per-run timeout (seconds). Short because both scripts hand off to a detached worker
 /// and return in well under a second — the index/push happen off the hook's critical path.
@@ -29,11 +45,41 @@ pub(crate) struct Hook {
 /// expression expanded by the hook runner; double-quoted so spaces survive. `"`/`\` in every field
 /// are escaped so a value with a quote can't break out (`$` remains available to the runner).
 pub fn command(script: &str, args: &[&str]) -> String {
+    if cfg!(windows) {
+        return powershell_command(script, args);
+    }
     let mut out = format!("bash \"{}\"", dquote_escape(script));
     for arg in args {
         out.push_str(&format!(" \"{}\"", dquote_escape(arg)));
     }
     out
+}
+
+// Encoding the whole invocation keeps CMD's %, &, parentheses and quoting rules out of paths
+// and memory arguments. PowerShell single-quoted literals only escape an apostrophe by doubling it.
+fn powershell_command(script: &str, args: &[&str]) -> String {
+    let literal = |value: &str| format!("'{}'", value.replace('\'', "''"));
+    let mut invocation = format!("& {}", literal(script));
+    for arg in args {
+        invocation.push(' ');
+        invocation.push_str(&literal(arg));
+    }
+    let bytes: Vec<u8> = invocation.encode_utf16().flat_map(u16::to_le_bytes).collect();
+    let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
+    format!("powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand {encoded}")
+}
+
+fn decoded_command(command: &str) -> Option<String> {
+    let (_, encoded) = command.split_once(" -EncodedCommand ")?;
+    let bytes = base64::engine::general_purpose::STANDARD.decode(encoded.trim()).ok()?;
+    if bytes.len() % 2 != 0 {
+        return None;
+    }
+    let words: Vec<u16> = bytes
+        .chunks_exact(2)
+        .map(|b| u16::from_le_bytes([b[0], b[1]]))
+        .collect();
+    String::from_utf16(&words).ok()
 }
 
 /// Escape a value for embedding inside a double-quoted shell string: backslash then double-quote.
@@ -87,20 +133,27 @@ fn is_funes_group(group: &Value) -> bool {
 fn is_funes_hook(hook: &Value) -> bool {
     hook.get("command")
         .and_then(Value::as_str)
-        .map(|c| c.contains("funes-index.sh") || c.contains("funes-push.sh"))
+        .map(|c| {
+            let decoded = decoded_command(c);
+            let c = decoded.as_deref().unwrap_or(c);
+            ["funes-index.sh", "funes-push.sh", "funes-index.ps1", "funes-push.ps1"]
+                .iter()
+                .any(|name| c.contains(name))
+        })
         .unwrap_or(false)
 }
 
 /// Write the embedded scripts into an agent-chosen `dir`, executable. Returns whether anything
 /// changed (a drifted or absent copy is rewritten); the executable bit is (re)set every time.
 pub fn write_scripts(dir: &Path) -> Result<bool> {
-    // This build probe must never install Bash automation on native Windows.
-    if cfg!(windows) {
-        anyhow::bail!("Windows automation is not implemented yet; use explicit-path index and MCP manually");
-    }
     std::fs::create_dir_all(dir).with_context(|| format!("creating {}", dir.display()))?;
     let mut changed = false;
-    for (name, content) in [("funes-index.sh", INDEX_SH), ("funes-push.sh", PUSH_SH)] {
+    let scripts = if cfg!(windows) {
+        [(INDEX_NAME, INDEX_PS), (PUSH_NAME, PUSH_PS)]
+    } else {
+        [(INDEX_NAME, INDEX_SH), (PUSH_NAME, PUSH_SH)]
+    };
+    for (name, content) in scripts {
         let path = dir.join(name);
         changed |= write_if_changed(&path, content)?;
         #[cfg(unix)]
@@ -135,6 +188,24 @@ fn file_matches(path: &Path, want: &str) -> bool {
 mod tests {
     use super::*;
 
+    #[test]
+    fn powershell_preserves_literals_and_owned_hook_cleanup() {
+        let script = r"C:\用户 & (data)\100%\it's\funes-index.ps1";
+        let cmd = powershell_command(script, &["acme/a'b", "codex"]);
+        assert_eq!(
+            decoded_command(&cmd).unwrap(),
+            "& 'C:\\用户 & (data)\\100%\\it''s\\funes-index.ps1' 'acme/a''b' 'codex'"
+        );
+        assert!(cmd
+            .split(" -EncodedCommand ")
+            .nth(1)
+            .unwrap()
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b"+/=".contains(&b)));
+        let config = json!({"hooks":{"Stop":[{"hooks":[{"command":cmd}]}]}});
+        assert_eq!(apply_funes_hooks(config, &[]), json!({"hooks":{}}));
+    }
+
     fn idx(arg: &str) -> Hook {
         Hook {
             event: "TurnComplete",
@@ -144,6 +215,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn command_escapes_quotes_but_keeps_dollar() {
         // Ordinary paths/args are untouched, and every argument is carried.
         assert_eq!(command("/h/x.sh", &["agent"]), "bash \"/h/x.sh\" \"agent\"");
@@ -186,7 +258,7 @@ mod tests {
         let out = apply_funes_hooks(json!({}), &[idx("agent")]);
         assert_eq!(
             funes_command(&out, "TurnComplete"),
-            Some("bash \"/h/funes-index.sh\" \"agent\"")
+            Some(command("/h/funes-index.sh", &["agent"]).as_str())
         );
     }
 
@@ -209,7 +281,7 @@ mod tests {
         assert!(completed.iter().any(|g| g["hooks"][0]["command"] == "make lint"));
         assert_eq!(
             funes_command(&out, "TurnComplete"),
-            Some("bash \"/h/funes-index.sh\" \"agent\"")
+            Some(command("/h/funes-index.sh", &["agent"]).as_str())
         );
         assert_eq!(
             completed.iter().filter(|g| is_funes_group(g)).count(),
@@ -230,11 +302,11 @@ mod tests {
         );
         assert_eq!(
             funes_command(&remote, "Start"),
-            Some("bash \"/h/funes-push.sh\" \"acme/kb\"")
+            Some(command("/h/funes-push.sh", &["acme/kb"]).as_str())
         );
         assert_eq!(
             funes_command(&remote, "End"),
-            Some("bash \"/h/funes-push.sh\" \"acme/kb\"")
+            Some(command("/h/funes-push.sh", &["acme/kb"]).as_str())
         );
     }
 
@@ -249,7 +321,7 @@ mod tests {
         assert!(local["hooks"].get("End").is_none(), "stale push event pruned");
         assert_eq!(
             funes_command(&local, "TurnComplete"),
-            Some("bash \"/h/funes-index.sh\" \"agent\"")
+            Some(command("/h/funes-index.sh", &["agent"]).as_str())
         );
     }
 

--- a/src/agents/hooks.rs
+++ b/src/agents/hooks.rs
@@ -156,16 +156,76 @@ pub(crate) fn config_is_mergeable(cfg: &Value) -> bool {
 }
 
 fn is_funes_hook(hook: &Value) -> bool {
-    hook.get("command")
-        .and_then(Value::as_str)
-        .map(|c| {
-            let decoded = decoded_command(c);
-            let c = decoded.as_deref().unwrap_or(c);
-            ["funes-index.sh", "funes-push.sh", "funes-index.ps1", "funes-push.ps1"]
-                .iter()
-                .any(|name| c.contains(name))
-        })
-        .unwrap_or(false)
+    let Some(command) = hook.get("command").and_then(Value::as_str) else {
+        return false;
+    };
+    // Recognize the invocation templates we install, not mentions in another command's
+    // arguments. Also require the whole command to match: a compound user hook is not ours.
+    let decoded;
+    let (arguments, quote) = if let Some(rest) = command.strip_prefix("bash ") {
+        (rest, '"')
+    } else if command
+        .starts_with("powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand ")
+    {
+        decoded = decoded_command(command).unwrap_or_default();
+        let Some(rest) = decoded.strip_prefix("& ") else {
+            return false;
+        };
+        (rest, '\'')
+    } else {
+        return false;
+    };
+    let Some(args) = quoted_arguments(arguments, quote) else {
+        return false;
+    };
+    args.first().is_some_and(|script| {
+        let name = script.rsplit(['/', '\\']).next().unwrap_or(script);
+        matches!(
+            name,
+            "funes-index.sh" | "funes-push.sh" | "funes-index.ps1" | "funes-push.ps1"
+        )
+    })
+}
+
+/// Parse our quoted templates, preserving ordinary environment references but not user commands.
+fn quoted_arguments(mut input: &str, quote: char) -> Option<Vec<String>> {
+    if quote == '"' && (input.contains("$(") || input.contains('`')) {
+        return None;
+    }
+    let mut args = Vec::new();
+    while !input.is_empty() {
+        input = input.strip_prefix(quote)?;
+        let mut value = String::new();
+        let mut chars = input.char_indices();
+        let end = loop {
+            let (i, ch) = chars.next()?;
+            if ch == quote {
+                if quote == '\'' && chars.clone().next().is_some_and(|(_, c)| c == '\'') {
+                    chars.next();
+                    value.push('\'');
+                } else {
+                    break i + ch.len_utf8();
+                }
+            } else if quote == '"' && ch == '\\' {
+                let (_, escaped) = chars.next()?;
+                if !matches!(escaped, '\\' | '"') {
+                    return None;
+                }
+                value.push(escaped);
+            } else {
+                value.push(ch);
+            }
+        };
+        args.push(value);
+        input = &input[end..];
+        if !input.is_empty() {
+            input = input.strip_prefix(' ')?;
+            if input.is_empty() {
+                return None;
+            }
+        }
+    }
+    Some(args)
 }
 
 /// Write the embedded scripts into an agent-chosen `dir`, executable. Returns whether anything
@@ -212,6 +272,33 @@ fn file_matches(path: &Path, want: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn hook_cleanup_preserves_references_and_compound_commands() {
+        let encoded_reference = powershell_command("Copy-Item", &[r"C:\hooks\funes-index.ps1", "backup"]);
+        let owned = powershell_command(r"C:\hooks\funes-index.ps1", &["codex"]);
+        let commands = [
+            r"Copy-Item C:\hooks\funes-index.ps1 C:\backup\index.ps1".to_string(),
+            posix_command("/tools/other.sh", &["funes-index.sh"]),
+            posix_command("/tools/funes-index.sh.backup", &[]),
+            format!("{}; echo user-work", posix_command("/tools/funes-index.sh", &[])),
+            format!("echo {owned}"),
+            encoded_reference,
+            posix_command("/tools/funes-index.sh", &["$(touch /tmp/user-marker)"]),
+            posix_command("/tools/funes-index.sh", &["`touch /tmp/user-marker`"]),
+        ];
+        for command in commands {
+            let cfg = json!({"hooks":{"Stop":[{"hooks":[{"type":"command","command":command}]}]}});
+            assert_eq!(apply_funes_hooks(cfg.clone(), &[]), cfg);
+        }
+        for command in [
+            posix_command("/old space/it's/funes-index.sh", &["codex"]),
+            posix_command("${CLAUDE_PLUGIN_ROOT}/funes-index.sh", &["claude"]),
+            owned,
+        ] {
+            assert!(is_funes_hook(&json!({"command":command})));
+        }
+    }
 
     #[test]
     fn mixed_groups_preserve_user_commands_and_metadata() {

--- a/src/commands/ask.rs
+++ b/src/commands/ask.rs
@@ -11,7 +11,7 @@
 use anyhow::{anyhow, bail, Result};
 use serde_json::Value;
 use std::io::{BufRead, BufReader, IsTerminal, Read};
-use std::process::{Command, ExitStatus, Stdio};
+use std::process::{ExitStatus, Stdio};
 
 use super::recall::{check_readable, memory_hint, recall_hits};
 use crate::memory::Memory;
@@ -141,7 +141,7 @@ pub async fn grounding(memory: Memory, question: &str, progress: &(dyn Fn(&str) 
 
 /// Probe that an agent CLI exists before any expensive work is done on its behalf.
 pub fn preflight(agent: &str) -> Result<()> {
-    match Command::new(agent)
+    match crate::platform::command(agent)
         .arg("--version")
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -234,7 +234,7 @@ fn run_streaming(
     event: fn(&str) -> Event,
     progress: &(dyn Fn(&str) + Sync),
 ) -> Result<Run> {
-    let mut child = match Command::new(agent)
+    let mut child = match crate::platform::command(agent)
         .args(args)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -28,6 +28,7 @@ const BUCKET_NAME: &str = "funes";
 
 /// Repo, for the build-from-source pointer on platforms with no prebuilt binary.
 const REPO: &str = "https://github.com/huggingface/funes";
+const WINDOWS_REINSTALL: &str = r#"Invoke-WebRequest https://huggingface.co/buckets/huggingface/funes/resolve/install.ps1 -OutFile "$env:TEMP\funes-install.ps1"; powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$env:TEMP\funes-install.ps1""#;
 
 /// How long the CLI `funes status` version check waits before giving up (silently). Short so an
 /// offline or slow Hub barely delays status; the update command itself has no such cap.
@@ -43,6 +44,8 @@ const ASSET: Option<&str> = if cfg!(all(target_os = "linux", target_arch = "x86_
     Some("funes-aarch64-linux")
 } else if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
     Some("funes-arm64-apple-darwin")
+} else if cfg!(all(target_os = "windows", target_arch = "x86_64")) {
+    Some("funes-x86_64-windows.exe")
 } else {
     None
 };
@@ -52,7 +55,7 @@ const ASSET: Option<&str> = if cfg!(all(target_os = "linux", target_arch = "x86_
 pub async fn run(force: bool) -> Result<()> {
     if cfg!(windows) {
         bail!(
-            "Windows self-update is not supported yet; replace funes.exe after closing running agents and MCP servers"
+            "Windows self-update is not supported; close running agents and MCP servers, then reinstall from PowerShell:\n{WINDOWS_REINSTALL}"
         );
     }
     let asset = ASSET.ok_or_else(|| {
@@ -258,6 +261,9 @@ fn notice_for(latest_raw: &str, current_raw: &str) -> Option<String> {
     let latest = parse_semver(latest_raw)?;
     let current = parse_semver(current_raw)?;
     (latest > current).then(|| {
+        if cfg!(windows) {
+            return format!("update available: funes {} (you have {current_raw}) — close running agents/MCP servers, then reinstall from PowerShell:\n{WINDOWS_REINSTALL}\n", latest_raw.trim().trim_start_matches('v'));
+        }
         format!(
             "update available: funes {} (you have {current_raw}) — run `funes update`; restart running agents/MCP servers afterward to load it.\n",
             latest_raw.trim().trim_start_matches('v'),
@@ -322,15 +328,20 @@ pub(crate) fn parse_semver(s: &str) -> Option<(u32, u32, u32)> {
 
 #[cfg(test)]
 mod tests {
-    use super::{expected_digest, install_verified, notice_for, parse_semver, read_release_version, sha256_file};
+    #[cfg(unix)]
+    use super::sha256_file;
+    use super::{expected_digest, install_verified, notice_for, parse_semver, read_release_version};
+    #[cfg(unix)]
     use std::path::Path;
 
+    #[cfg(unix)]
     fn write_manifest(path: &Path, binary: &Path, asset: &str) {
         let digest = hex::encode(sha256_file(binary).unwrap());
         std::fs::write(path, format!("{digest}  {asset}\n")).unwrap();
     }
 
     #[test]
+    #[cfg(unix)]
     fn install_verified_atomically_replaces() {
         use std::fs::Permissions;
         use std::os::unix::fs::PermissionsExt;
@@ -357,6 +368,7 @@ mod tests {
 
     #[test]
     fn checksum_mismatch_is_rejected_before_execution() {
+        #[cfg(unix)]
         use std::os::unix::fs::PermissionsExt;
 
         let dir = tempfile::tempdir().unwrap();
@@ -374,11 +386,13 @@ mod tests {
 
         assert!(install_verified(&staged, &exe, &manifest, "funes-test", "9.9.9").is_err());
         assert!(!marker.exists());
+        #[cfg(unix)]
         assert_eq!(std::fs::metadata(&staged).unwrap().permissions().mode() & 0o111, 0);
         assert_eq!(std::fs::read_to_string(&exe).unwrap(), "old binary");
     }
 
     #[test]
+    #[cfg(unix)]
     fn reported_version_mismatch_does_not_replace() {
         let dir = tempfile::tempdir().unwrap();
         let staged = dir.path().join("staged");
@@ -441,7 +455,8 @@ mod tests {
     fn notice_only_when_strictly_newer() {
         // newer release available → notice, naming both versions and the command
         let n = notice_for("0.8.1", "0.8.0").unwrap();
-        assert!(n.contains("0.8.1") && n.contains("0.8.0") && n.contains("funes update"));
+        let guidance = if cfg!(windows) { "install.ps1" } else { "funes update" };
+        assert!(n.contains("0.8.1") && n.contains("0.8.0") && n.contains(guidance));
         // a `v` prefix on the published version is stripped in the message
         assert!(notice_for("v0.9.0", "0.8.0").unwrap().contains("funes 0.9.0"));
         // equal, and older, → no notice

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -12,8 +12,11 @@ use hf_hub::buckets::BucketDownload;
 use hf_hub::HFBucket;
 use sha2::{Digest, Sha256};
 use std::collections::HashSet;
-use std::fs::{File, Permissions};
+use std::fs::File;
+#[cfg(unix)]
+use std::fs::Permissions;
 use std::io::Read;
+#[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::process::Command;
@@ -47,6 +50,11 @@ const ASSET: Option<&str> = if cfg!(all(target_os = "linux", target_arch = "x86_
 /// `funes update`: fetch the latest release binary for this platform and replace the running
 /// executable in place. Idempotent — with `force`, reinstalls even when already up to date.
 pub async fn run(force: bool) -> Result<()> {
+    if cfg!(windows) {
+        bail!(
+            "Windows self-update is not supported yet; replace funes.exe after closing running agents and MCP servers"
+        );
+    }
     let asset = ASSET.ok_or_else(|| {
         anyhow!(
             "no prebuilt funes binary for this platform ({}/{}) — build from source: {REPO}#building-from-source",
@@ -117,6 +125,7 @@ pub async fn run(force: bool) -> Result<()> {
 /// Verify the staged binary, confirm its reported version, and atomically rename it over `exe`.
 fn install_verified(staged: &Path, exe: &Path, manifest: &Path, asset: &str, expected_version: &str) -> Result<String> {
     verify_checksum(staged, manifest, asset)?;
+    #[cfg(unix)]
     std::fs::set_permissions(staged, Permissions::from_mode(0o755)).context("making the new binary executable")?;
 
     let out = verify_runs(staged)?;
@@ -130,9 +139,11 @@ fn install_verified(staged: &Path, exe: &Path, manifest: &Path, asset: &str, exp
 
     // Preserve the existing binary's mode so an update never broadens it (e.g. 0700 → 0755); fall
     // back to 0755 when there's no existing binary to copy the mode from.
+    #[cfg(unix)]
     let mode = std::fs::metadata(exe)
         .map(|m| m.permissions().mode() & 0o777)
         .unwrap_or(0o755);
+    #[cfg(unix)]
     std::fs::set_permissions(staged, Permissions::from_mode(mode)).context("setting the new binary's permissions")?;
 
     // Same-filesystem rename (staged sits in a temp dir beside exe), so this is atomic. The live

--- a/src/hub.rs
+++ b/src/hub.rs
@@ -9,7 +9,7 @@ use hf_hub::{HFClient, HFError, RepoTypeDataset};
 
 /// `<org>/<repo>[/…]` with no scheme and not a path (`/` `.` `~`) → an HF dataset shorthand.
 pub fn is_remote_shorthand(spec: &str) -> bool {
-    !spec.starts_with(['/', '.', '~']) && spec.contains('/')
+    !crate::platform::is_windows_path(spec) && !spec.starts_with(['/', '.', '~']) && spec.contains('/')
 }
 
 /// Parse `hf://datasets/<owner>/<name>[/<prefix…>]` into (owner, name, prefix). Empty prefix = repo
@@ -93,10 +93,19 @@ pub fn has_token() -> bool {
 
 /// HF token from the standard env var, else the `huggingface_hub` cached token file.
 pub fn hf_token() -> Option<String> {
-    let token_file = std::env::var("HOME")
-        .ok()
-        .map(|h| PathBuf::from(h).join(".cache/huggingface/token"));
+    let token_file = std::env::var_os("HF_TOKEN_PATH")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| cache_home().map(|home| home.join("token")));
     token_from(|k| std::env::var(k).ok(), token_file.as_deref())
+}
+
+/// Hugging Face's cache root, retaining the explicit HF_HOME override.
+pub(crate) fn cache_home() -> Option<PathBuf> {
+    std::env::var_os("HF_HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| crate::platform::user_home().map(|home| home.join(".cache/huggingface")))
 }
 
 /// Pure core of [`hf_token`]: env vars (in precedence order) win over the token file; blank

--- a/src/inference/blas.rs
+++ b/src/inference/blas.rs
@@ -612,9 +612,7 @@ fn hf_snapshot(repo: &str) -> Result<PathBuf> {
 /// snapshots cached the pick is arbitrary — fine here: any complete copy of these frozen model
 /// repos is interchangeable.
 fn local_snapshot(repo: &str) -> Option<PathBuf> {
-    let base = std::env::var("HF_HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| PathBuf::from(std::env::var("HOME").unwrap_or_default()).join(".cache/huggingface"));
+    let base = crate::hub::cache_home()?;
     let snaps = base
         .join("hub")
         .join(format!("models--{}", repo.replace('/', "--")))

--- a/src/inference/blas.rs
+++ b/src/inference/blas.rs
@@ -94,7 +94,7 @@ mod seam {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 mod seam {
     use faer::linalg::matmul::matmul;
     use faer::{Accum, MatMut, MatRef, Par};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@
 //! - [`commands`] — what funes does when you run it: orchestration and decisions.
 //! - [`ui`] — how a result reaches the terminal.
 //! - [`agents`] — registering funes with a coding agent (MCP + automation hooks).
+//! - [`platform`] — shared host filesystem conventions, profile discovery, and path classification.
 //!
 //! Where a new function goes: names an HF concept → transport; names Lance → mechanics; answers
 //! *what is this memory, what state is it in* → domain; decides *what to do about it* → command.
@@ -34,6 +35,7 @@ pub mod commands;
 pub mod hub;
 pub mod inference;
 pub mod memory;
+pub mod platform;
 pub mod scan;
 pub mod session_sketch;
 pub mod traces;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,11 +24,9 @@
 //! *what is this memory, what state is it in* → domain; decides *what to do about it* → command.
 //! Commands ask the layers below for state; they never infer it from error shapes.
 
-// funes is unix-only (Linux/macOS): the release targets, install.sh, and the in-place
-// self-update all assume unix semantics. Fail with a clear message on other platforms rather
-// than a confusing missing-symbol error deep in a module.
-#[cfg(not(unix))]
-compile_error!("funes is unix-only (Linux/macOS)");
+// Windows is being validated on MSVC before it is advertised as a supported release.
+#[cfg(not(any(unix, windows)))]
+compile_error!("funes requires Unix or Windows");
 
 pub mod agents;
 pub mod chunk;

--- a/src/main.rs
+++ b/src/main.rs
@@ -322,7 +322,13 @@ impl MemoryOpts {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    match Cli::parse().cmd {
+    let cmd = Cli::parse().cmd;
+    if cfg!(windows) && matches!(&cmd, Cmd::Add { .. } | Cmd::Remove { .. }) {
+        return Err(anyhow!(
+            "Windows integration is still under development; use explicit-path index and manual MCP configuration"
+        ));
+    }
+    match cmd {
         Cmd::Recall {
             query,
             k,

--- a/src/main.rs
+++ b/src/main.rs
@@ -323,9 +323,27 @@ impl MemoryOpts {
 #[tokio::main]
 async fn main() -> Result<()> {
     let cmd = Cli::parse().cmd;
-    if cfg!(windows) && matches!(&cmd, Cmd::Add { .. } | Cmd::Remove { .. }) {
+    if std::env::var_os("FUNES_HOME")
+        .filter(|value| !value.is_empty())
+        .is_none()
+        && funes::platform::user_home().is_none()
+    {
         return Err(anyhow!(
-            "Windows integration is still under development; use explicit-path index and manual MCP configuration"
+            "cannot resolve the user profile; set FUNES_HOME to an explicit state directory"
+        ));
+    }
+    if cfg!(windows)
+        && matches!(
+            &cmd,
+            Cmd::Add {
+                agent: AddAgent::Claude { .. } | AddAgent::Pi { .. } | AddAgent::Hermes { .. }
+            } | Cmd::Remove {
+                agent: RemoveAgent::Claude | RemoveAgent::Pi | RemoveAgent::Hermes
+            }
+        )
+    {
+        return Err(anyhow!(
+            "Windows automation currently supports Codex only; use explicit-path index and manual MCP configuration for other agents"
         ));
     }
     match cmd {

--- a/src/memory/dataset.rs
+++ b/src/memory/dataset.rs
@@ -35,11 +35,12 @@ pub const DIM: i32 = 384;
 /// funes's home directory: `$FUNES_HOME`, else `~/.funes`. Holds the incremental state and the
 /// local memory.
 pub fn funes_dir() -> PathBuf {
-    if let Ok(d) = std::env::var("FUNES_HOME") {
+    if let Some(d) = std::env::var_os("FUNES_HOME").filter(|value| !value.is_empty()) {
         return PathBuf::from(d);
     }
-    let home = std::env::var("HOME").unwrap_or_default();
-    PathBuf::from(home).join(".funes")
+    crate::platform::user_home()
+        .expect("cannot resolve the user profile; set FUNES_HOME to an explicit state directory")
+        .join(".funes")
 }
 
 /// Directory holding the local memory (the `chunks` dataset is at `<dir>/chunks.lance`).

--- a/src/memory/remote.rs
+++ b/src/memory/remote.rs
@@ -37,7 +37,7 @@
 
 use std::collections::{BTreeMap, HashMap};
 use std::io::Write as _;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::{ensure, Context, Result};
@@ -59,6 +59,14 @@ use super::capture_store::{CaptureStore, Captured};
 use super::dataset;
 use super::fetch_store::{FetchStore, FileFetcher};
 use crate::hub;
+
+/// Hub keys use slashes, including when the staged files live on Windows.
+fn repo_path(path: &Path) -> String {
+    path.components()
+        .map(|part| part.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/")
+}
 
 /// Outcome of an [`append`] commit.
 pub(crate) enum Appended {
@@ -159,11 +167,8 @@ pub(crate) async fn first_publish(
         if !entry.file_type().is_file() {
             continue;
         }
-        let rel = entry.path().strip_prefix(staging.path()).unwrap_or(entry.path());
-        ops.push(CommitOperation::add_file(
-            rel.to_string_lossy().into_owned(),
-            entry.path().to_path_buf(),
-        ));
+        let rel = entry.path().strip_prefix(staging.path())?;
+        ops.push(CommitOperation::add_file(repo_path(rel), entry.path().to_path_buf()));
     }
     if ops.is_empty() {
         return Ok(None);
@@ -536,6 +541,15 @@ mod tests {
     use arrow_schema::{DataType, Field, Schema};
     use lance_index::scalar::InvertedIndexParams;
     use lance_index::IndexType;
+
+    #[test]
+    fn upload_keys_use_repo_separators() {
+        let path = PathBuf::from("prefix 中文")
+            .join("chunks.lance")
+            .join("_versions")
+            .join("1.manifest");
+        assert_eq!(repo_path(&path), "prefix 中文/chunks.lance/_versions/1.manifest");
+    }
 
     /// Pins the Lance behavior [`reindex`] relies on: `append()` adds one delta sub-index per
     /// backlog, and `merge(deltas)` folds the deltas back into one without touching the base.

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,0 +1,56 @@
+//! Host filesystem conventions shared by the storage, transport, and integration layers.
+
+use std::path::PathBuf;
+
+/// The user's home directory. Rust uses the Windows profile on Windows and HOME/passwd on Unix.
+/// Empty environment values never turn state or credentials into paths relative to the cwd.
+pub fn user_home() -> Option<PathBuf> {
+    std::env::home_dir().filter(|path| !path.as_os_str().is_empty())
+}
+
+/// Recognize Windows drive and rooted paths even when a memory identifier is read on Unix.
+pub fn is_windows_path(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    path.starts_with('\\') || (bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':')
+}
+
+/// Resolve native executables and npm's Windows command shims while retaining argv escaping.
+/// Rust handles an explicitly named .cmd/.bat with its batch-file escaping rules; callers never
+/// concatenate arguments into `cmd /c` or bypass those rules with raw arguments.
+pub fn command(program: &str) -> std::process::Command {
+    #[cfg(windows)]
+    if std::path::Path::new(program).components().count() == 1 {
+        if let Some(path) = std::env::var_os("PATH") {
+            for dir in std::env::split_paths(&path) {
+                for suffix in [".exe", ".cmd", ".bat"] {
+                    let candidate = dir.join(format!("{program}{suffix}"));
+                    if candidate.is_file() {
+                        return std::process::Command::new(candidate);
+                    }
+                }
+            }
+        }
+    }
+    std::process::Command::new(program)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn windows_paths_are_not_hub_names() {
+        for path in [
+            r"C:\work\memory",
+            "C:/work/memory",
+            "C:memory",
+            r"\\server\share\记忆",
+            r"\memory",
+        ] {
+            assert!(is_windows_path(path), "{path}");
+        }
+        for path in ["acme/memory", "hf://datasets/acme/memory", "/tmp/memory", "./memory"] {
+            assert!(!is_windows_path(path), "{path}");
+        }
+    }
+}

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -56,7 +56,16 @@ impl Trufflehog {
     /// Locate the trufflehog binary; fail-closed if none is found.
     pub fn find() -> Result<Self> {
         Ok(Self {
-            bin: find_in(|k| std::env::var_os(k), |p| p.is_file())?,
+            bin: find_in(
+                |k| {
+                    if k == "HOME" {
+                        crate::platform::user_home().map(PathBuf::into_os_string)
+                    } else {
+                        std::env::var_os(k)
+                    }
+                },
+                |p| p.is_file(),
+            )?,
         })
     }
 }
@@ -188,16 +197,17 @@ fn parse_finding(line: &str) -> Result<(String, Finding)> {
 /// the real environment or filesystem. Errors if none exists — the scan is mandatory, never a
 /// silent pass.
 fn find_in(env: impl Fn(&str) -> Option<OsString>, exists: impl Fn(&Path) -> bool) -> Result<PathBuf> {
+    let executable = format!("trufflehog{}", std::env::consts::EXE_SUFFIX);
     let mut candidates: Vec<PathBuf> = Vec::new();
     if let Some(over) = env("FUNES_TRUFFLEHOG") {
         candidates.push(PathBuf::from(over));
     }
     if let Some(path) = env("PATH") {
-        candidates.extend(std::env::split_paths(&path).map(|d| d.join("trufflehog")));
+        candidates.extend(std::env::split_paths(&path).map(|d| d.join(&executable)));
     }
     if let Some(home) = env("HOME").map(PathBuf::from) {
-        candidates.push(home.join("go/bin/trufflehog"));
-        candidates.push(home.join(".local/bin/trufflehog"));
+        candidates.push(home.join("go/bin").join(&executable));
+        candidates.push(home.join(".local/bin").join(&executable));
     }
     candidates.extend(
         [
@@ -360,10 +370,10 @@ mod tests {
         assert_eq!(find_in(env, |_| true).unwrap(), PathBuf::from("/custom/trufflehog"));
 
         // No override: the first existing PATH entry wins.
-        let env = |k: &str| (k == "PATH").then(|| OsString::from("/aa:/bb"));
+        let env = |k: &str| (k == "PATH").then(|| std::env::join_paths(["/aa", "/bb"]).unwrap());
         assert_eq!(
             find_in(env, |p| p.starts_with("/aa") || p.starts_with("/bb")).unwrap(),
-            PathBuf::from("/aa/trufflehog")
+            PathBuf::from("/aa").join(format!("trufflehog{}", std::env::consts::EXE_SUFFIX))
         );
 
         // Nothing anywhere: fail-closed with an actionable message.

--- a/src/traces/codex.rs
+++ b/src/traces/codex.rs
@@ -284,6 +284,31 @@ mod tests {
     }
 
     #[test]
+    fn windows_rollout_preserves_powershell_calls_and_provenance() {
+        let f = write_jsonl(&[
+            r#"{"type":"session_meta","payload":{"id":"windows-session","cwd":"C:\\Users\\Alice\\My Project"}}"#,
+            r#"{"type":"response_item","payload":{"type":"function_call","name":"exec_command","arguments":"{\"cmd\":\"Get-Content 'C:\\\\My Project\\\\测试.txt'\",\"shell\":\"powershell\"}","call_id":"ps1"}}"#,
+            r#"{"type":"response_item","payload":{"type":"function_call_output","call_id":"ps1","output":"第一行\r\n第二行\r\n"}}"#,
+        ]);
+        let turns = turns_from_jsonl_file(f.path(), "fallback").unwrap();
+        assert_eq!(turns.len(), 2);
+        for turn in &turns {
+            assert_eq!(turn.session_id, "windows-session");
+            assert_eq!(turn.workdir, "C--Users-Alice-My-Project");
+            assert_eq!(turn.harness, "codex");
+            assert_eq!(turn.blocks[0].tool_name.as_deref(), Some("exec_command"));
+            assert_eq!(turn.blocks[0].tool_use_id.as_deref(), Some("ps1"));
+        }
+        assert_eq!(turns[0].blocks[0].block_type, "tool_use");
+        assert_eq!(
+            turns[0].blocks[0].text,
+            r#"{"cmd":"Get-Content 'C:\\My Project\\测试.txt'","shell":"powershell"}"#
+        );
+        assert_eq!(turns[1].blocks[0].block_type, "tool_result");
+        assert_eq!(turns[1].blocks[0].text, "第一行\r\n第二行\r\n");
+    }
+
+    #[test]
     fn custom_tool_call_uses_input_not_arguments() {
         let f = write_jsonl(&[
             r#"{"type":"response_item","timestamp":"t","payload":{"type":"custom_tool_call","name":"apply_patch","input":"*** Begin Patch","call_id":"c2"}}"#,

--- a/src/traces/harness.rs
+++ b/src/traces/harness.rs
@@ -79,19 +79,34 @@ impl Harness {
     /// identifies the harness.
     pub fn from_known_dir(root: &Path) -> Option<Harness> {
         let canon = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
-        let s = canon.to_string_lossy();
-        KNOWN_DIRS.iter().find(|(tail, _)| s.ends_with(tail)).map(|(_, h)| *h)
+        KNOWN_DIRS
+            .iter()
+            .find(|(tail, _)| canon.ends_with(tail))
+            .map(|(_, h)| *h)
     }
 }
 
 /// hermes' session store — a single SQLite file under `$HOME`, not a session dir like the others.
 pub const HERMES_DB: &str = ".hermes/state.db";
 
-fn known_harness_roots_from(home: &Path, pi_agent_dir: Option<&Path>) -> Vec<(PathBuf, Harness)> {
+fn known_harness_roots_from(
+    home: &Path,
+    pi_agent_dir: Option<&Path>,
+    codex_home: Option<&Path>,
+) -> Vec<(PathBuf, Harness)> {
     let mut roots: Vec<(PathBuf, Harness)> = KNOWN_DIRS
         .iter()
         .filter(|(_, h)| *h != Harness::Pi)
-        .map(|(tail, h)| (home.join(tail), *h))
+        .map(|(tail, h)| {
+            let root = if *h == Harness::Codex {
+                codex_home
+                    .map(|path| path.join("sessions"))
+                    .unwrap_or_else(|| home.join(tail))
+            } else {
+                home.join(tail)
+            };
+            (root, *h)
+        })
         .filter(|(dir, _)| dir.is_dir())
         .collect();
 
@@ -113,12 +128,15 @@ fn known_harness_roots_from(home: &Path, pi_agent_dir: Option<&Path>) -> Vec<(Pa
 /// The `(root, harness)` pairs present under `$HOME` — drives a no-arg `funes index`. The JSONL
 /// agents contribute a session dir each; hermes contributes its `state.db` file.
 pub fn known_harness_roots() -> Vec<(PathBuf, Harness)> {
-    let home = match std::env::var_os("HOME") {
-        Some(h) => PathBuf::from(h),
+    let home = match crate::platform::user_home() {
+        Some(h) => h,
         None => return Vec::new(),
     };
     let pi_agent_dir = std::env::var_os("PI_CODING_AGENT_DIR").map(PathBuf::from);
-    known_harness_roots_from(&home, pi_agent_dir.as_deref())
+    let codex_home = std::env::var_os("CODEX_HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from);
+    known_harness_roots_from(&home, pi_agent_dir.as_deref(), codex_home.as_deref())
 }
 
 #[cfg(test)]
@@ -170,7 +188,7 @@ mod tests {
         let custom_sessions = custom.path().join("sessions");
         std::fs::create_dir_all(&custom_sessions).unwrap();
 
-        let roots = known_harness_roots_from(home.path(), Some(custom.path()));
+        let roots = known_harness_roots_from(home.path(), Some(custom.path()), None);
 
         assert!(roots.contains(&(custom_sessions, Harness::Pi)));
         assert!(!roots.contains(&(default_pi, Harness::Pi)));
@@ -182,8 +200,30 @@ mod tests {
         let default_pi = home.path().join(".pi/agent/sessions");
         std::fs::create_dir_all(&default_pi).unwrap();
 
-        let roots = known_harness_roots_from(home.path(), None);
+        let roots = known_harness_roots_from(home.path(), None, None);
 
         assert!(roots.contains(&(default_pi, Harness::Pi)));
+    }
+
+    #[test]
+    fn relocated_codex_home_replaces_default_root() {
+        let home = tempfile::tempdir().unwrap();
+        let custom = home.path().join("Codex 测试");
+        let default_sessions = home.path().join(".codex/sessions");
+        let custom_sessions = custom.join("sessions");
+        std::fs::create_dir_all(&default_sessions).unwrap();
+        std::fs::create_dir_all(&custom_sessions).unwrap();
+        let roots = known_harness_roots_from(home.path(), None, Some(&custom));
+        assert!(roots.contains(&(custom_sessions, Harness::Codex)));
+        assert!(!roots.contains(&(default_sessions, Harness::Codex)));
+    }
+
+    #[test]
+    fn directory_matching_requires_whole_components() {
+        assert_eq!(Harness::from_known_dir(Path::new("/x/not.codex/sessions")), None);
+        #[cfg(windows)]
+        for path in [r"C:\用户 数据\.codex\sessions", r"\\server\share\.codex\sessions"] {
+            assert_eq!(Harness::from_known_dir(Path::new(path)), Some(Harness::Codex));
+        }
     }
 }

--- a/tests/add_claude_plugin.rs
+++ b/tests/add_claude_plugin.rs
@@ -4,6 +4,8 @@
 //! files are written regardless, which is what we assert (registering with `claude` is exercised
 //! manually, not here).
 
+#![cfg(unix)]
+
 use funes::agents::claude;
 use serde_json::Value;
 use std::fs;

--- a/tests/add_codex_hooks.rs
+++ b/tests/add_codex_hooks.rs
@@ -5,12 +5,15 @@
 use funes::agents::codex;
 use serde_json::Value;
 use std::fs;
+#[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 
 #[test]
 fn add_codex_installs_hooks_and_preserves_existing() {
     let home = tempfile::tempdir().unwrap();
     std::env::set_var("HOME", home.path());
+    #[cfg(windows)]
+    std::env::set_var("USERPROFILE", home.path());
     std::env::set_var("PATH", "");
     // Codex's home is asked of Codex, and `CODEX_HOME` answers when it can't be run — so a
     // developer's own variable would send this install into their real Codex home. `FUNES_HOME`
@@ -36,9 +39,10 @@ fn add_codex_installs_hooks_and_preserves_existing() {
 
     // Scripts written and executable.
     let hooks_dir = home.path().join(".codex/hooks");
-    for name in ["funes-index.sh", "funes-push.sh"] {
+    for name in [funes::agents::hooks::INDEX_NAME, funes::agents::hooks::PUSH_NAME] {
         let p = hooks_dir.join(name);
         assert!(p.exists(), "{name} written");
+        #[cfg(unix)]
         assert!(
             fs::metadata(&p).unwrap().permissions().mode() & 0o111 != 0,
             "{name} executable"
@@ -48,17 +52,23 @@ fn add_codex_installs_hooks_and_preserves_existing() {
     let cfg: Value = serde_json::from_str(&fs::read_to_string(&config).unwrap()).unwrap();
     // funes's hooks: Stop (index codex) + SessionEnd/SessionStart (push acme/kb).
     let stop = cfg["hooks"]["Stop"][0]["hooks"][0]["command"].as_str().unwrap();
-    assert!(
-        stop.contains("funes-index.sh") && stop.contains("codex"),
-        "stop: {stop}"
+    assert_eq!(
+        stop,
+        funes::agents::hooks::command(
+            &hooks_dir.join(funes::agents::hooks::INDEX_NAME).display().to_string(),
+            &["codex"]
+        )
     );
     let start = cfg["hooks"]["SessionStart"][0]["hooks"][0]["command"].as_str().unwrap();
-    assert!(
-        start.contains("funes-push.sh") && start.contains("acme/kb"),
-        "start: {start}"
+    assert_eq!(
+        start,
+        funes::agents::hooks::command(
+            &hooks_dir.join(funes::agents::hooks::PUSH_NAME).display().to_string(),
+            &["acme/kb", "codex"]
+        )
     );
     let end = cfg["hooks"]["SessionEnd"][0]["hooks"][0]["command"].as_str().unwrap();
-    assert!(end.contains("funes-push.sh") && end.contains("acme/kb"), "end: {end}");
+    assert_eq!(end, start);
     // The skill Codex lists before loading any tool (now in Codex's own tree, not shared).
     let skill = home.path().join(".codex/skills/funes/SKILL.md");
     assert!(skill.exists(), "skill written");

--- a/tests/add_codex_hooks.rs
+++ b/tests/add_codex_hooks.rs
@@ -38,7 +38,7 @@ fn add_codex_installs_hooks_and_preserves_existing() {
     codex::install(Some("acme/kb".to_string())).unwrap();
 
     // Scripts written and executable.
-    let hooks_dir = home.path().join(".codex/hooks");
+    let hooks_dir = home.path().join(".codex").join("hooks");
     for name in [funes::agents::hooks::INDEX_NAME, funes::agents::hooks::PUSH_NAME] {
         let p = hooks_dir.join(name);
         assert!(p.exists(), "{name} written");

--- a/tests/index_recall.rs
+++ b/tests/index_recall.rs
@@ -26,8 +26,13 @@ fn write_transcript(source: &std::path::Path) -> (String, String) {
 
 #[tokio::test]
 async fn index_then_read_surface() {
-    let db_dir = tempfile::tempdir().unwrap();
-    let source = tempfile::tempdir().unwrap();
+    // Exercise filesystem paths that require quoting in shell-based integrations and retain
+    // non-ASCII characters through Lance's URI handling, on Unix and native Windows alike.
+    let db_dir = tempfile::Builder::new().prefix("funes memory 测试 ").tempdir().unwrap();
+    let source = tempfile::Builder::new()
+        .prefix("funes transcripts 测试 ")
+        .tempdir()
+        .unwrap();
     // db::funes_dir() reads $FUNES_HOME; point the whole read/write surface at the temp dir.
     std::env::set_var("FUNES_HOME", db_dir.path());
     let (session, workdir) = write_transcript(source.path());

--- a/tests/remove.rs
+++ b/tests/remove.rs
@@ -1,6 +1,9 @@
 //! `funes remove` reverses each supported `add` integration while preserving memories and
 //! unrelated agent configuration.
 
+// Other agent integrations remain Unix-only; windows_codex covers native Codex cleanup.
+#![cfg(unix)]
+
 mod support;
 
 use serde_json::Value;

--- a/tests/windows_codex.rs
+++ b/tests/windows_codex.rs
@@ -40,6 +40,33 @@ fn main() {
     let log = root.path().join("calls.txt");
     std::env::set_var("USERPROFILE", &home);
     std::env::remove_var("HOME");
+    std::env::remove_var("FUNES_HOME");
+    assert_eq!(funes::platform::user_home(), Some(home.clone()));
+    assert_eq!(funes::memory::dataset::funes_dir(), home.join(".funes"));
+    let state = root.path().join("custom memory");
+    std::env::set_var("FUNES_HOME", &state);
+    assert_eq!(funes::memory::dataset::funes_dir(), state);
+
+    // Exercise cache fallback with invented token files, never the user's credentials.
+    for key in [
+        "HF_HOME",
+        "HF_TOKEN_PATH",
+        "HF_TOKEN",
+        "HUGGING_FACE_HUB_TOKEN",
+        "HUGGINGFACE_TOKEN",
+    ] {
+        std::env::remove_var(key);
+    }
+    let cache = home.join(".cache/huggingface");
+    fs::create_dir_all(&cache).unwrap();
+    fs::write(cache.join("token"), "profile-fixture").unwrap();
+    assert_eq!(funes::hub::hf_token().as_deref(), Some("profile-fixture"));
+    let cache_override = root.path().join("custom HF cache");
+    fs::create_dir_all(&cache_override).unwrap();
+    fs::write(cache_override.join("token"), "override-fixture").unwrap();
+    std::env::set_var("HF_HOME", &cache_override);
+    assert_eq!(funes::hub::hf_token().as_deref(), Some("override-fixture"));
+
     std::env::set_var("CODEX_HOME", root.path().join("wrong fallback"));
     std::env::set_var("PATH", &bin);
     std::env::set_var("FUNES_TEST_CLI_LOG", &log);

--- a/tests/windows_codex.rs
+++ b/tests/windows_codex.rs
@@ -1,0 +1,87 @@
+//! Native process and configuration regression tests; one test owns its environment variables.
+#![cfg(windows)]
+
+use funes::agents::codex;
+use serde_json::json;
+use std::{fs, process::Command};
+
+#[test]
+fn native_codex_registration_and_independent_cleanup() {
+    let root = tempfile::Builder::new().prefix("funes 用户 & (x) ").tempdir().unwrap();
+    let bin = root.path().join("bin");
+    fs::create_dir(&bin).unwrap();
+    let fixture = bin.join("fixture.rs");
+    fs::write(&fixture, r#"
+use std::{env, fs::OpenOptions, io::Write};
+fn main() {
+    let args: Vec<String> = env::args().skip(1).collect();
+    let mut log = OpenOptions::new().create(true).append(true).open(env::var_os("FUNES_TEST_CLI_LOG").unwrap()).unwrap();
+    writeln!(log, "START\n{}\nEND", args.join("\n")).unwrap();
+    if args.first().map(String::as_str) == Some("doctor") {
+        println!("{}", env::var("FUNES_TEST_REPORT").unwrap());
+    } else if args.first().map(String::as_str) == Some("--version") {
+        println!("codex-cli 0.151.0");
+    } else if args.get(1).map(String::as_str) == Some("remove") && env::var_os("FUNES_TEST_REMOVE_FAIL").is_some() {
+        eprintln!("fixture unregister failure");
+        std::process::exit(1);
+    }
+}
+"#).unwrap();
+    assert!(Command::new("rustc")
+        .arg(&fixture)
+        .args(["--edition", "2021", "-o"])
+        .arg(bin.join("codex.exe"))
+        .status()
+        .unwrap()
+        .success());
+    let home = root.path().join("profile");
+    let codex_home = root.path().join("custom Codex");
+    fs::create_dir_all(&codex_home).unwrap();
+    let log = root.path().join("calls.txt");
+    std::env::set_var("USERPROFILE", &home);
+    std::env::remove_var("HOME");
+    std::env::set_var("CODEX_HOME", root.path().join("wrong fallback"));
+    std::env::set_var("PATH", &bin);
+    std::env::set_var("FUNES_TEST_CLI_LOG", &log);
+    std::env::set_var(
+        "FUNES_TEST_REPORT",
+        json!({"checks":{"config.load":{"details":{"CODEX_HOME":codex_home}}}}).to_string(),
+    );
+    let funes = root.path().join("funes path & (x) %.exe");
+    std::env::set_var("FUNES_BIN", &funes);
+    let hooks = codex_home.join("hooks.json");
+    fs::write(
+        &hooks,
+        r#"{"theme":"dark","hooks":{"PreToolUse":[{"hooks":[{"command":"user-hook"}]}]}}"#,
+    )
+    .unwrap();
+    codex::install(Some("acme/kb".into())).unwrap();
+    let calls = fs::read_to_string(&log).unwrap();
+    assert!(
+        calls.contains(&format!("mcp\nadd\nfunes\n--\n{}\nmcp\nacme/kb", funes.display())),
+        "{calls}"
+    );
+    assert!(codex_home.join("hooks/funes-index.ps1").is_file());
+    let skill = codex_home.join("skills/funes/SKILL.md");
+    assert!(skill.is_file());
+    codex::install(None).unwrap();
+    let config: serde_json::Value = serde_json::from_str(&fs::read_to_string(&hooks).unwrap()).unwrap();
+    assert_eq!(config["theme"], "dark");
+    assert_eq!(config["hooks"]["Stop"].as_array().unwrap().len(), 1);
+    assert!(config["hooks"].get("SessionEnd").is_none());
+    codex::uninstall().unwrap();
+    assert!(!skill.exists());
+    let config: serde_json::Value = serde_json::from_str(&fs::read_to_string(&hooks).unwrap()).unwrap();
+    assert_eq!(config["hooks"]["PreToolUse"][0]["hooks"][0]["command"], "user-hook");
+
+    codex::install(None).unwrap();
+    fs::write(&hooks, "malformed configuration").unwrap();
+    assert!(codex::uninstall().is_err());
+    assert_eq!(fs::read_to_string(&hooks).unwrap(), "malformed configuration");
+    assert!(!skill.exists(), "malformed hooks must not strand the skill");
+    fs::write(&hooks, "{}").unwrap();
+    codex::install(None).unwrap();
+    std::env::set_var("FUNES_TEST_REMOVE_FAIL", "1");
+    assert!(codex::uninstall().is_err());
+    assert!(!skill.exists(), "failed unregister must not strand the skill");
+}


### PR DESCRIPTION
Adds an initial native x86-64 Windows CLI and Codex integration path, addressing the Windows portion of #136. It keeps the existing local-first, append-only memory and pull-based recall design; a desktop UI is outside this PR.

The branch now includes upstream `72c1081`, including Lance 11 and remote-cache repair.

## Changes

- Add a checksum-verifying PowerShell installer, Windows release-build support, and native setup documentation.
- Support Windows profile/cache resolution, drive/UNC paths, native Codex executables and npm `.cmd` launchers.
- Add detached PowerShell indexing/publishing hooks, with redirected stdin, UTF-8 logs, and cleanup that preserves unrelated user commands.
- Normalize staged Hub object keys to `/`, so a successful Windows upload can subsequently be read remotely.
- Reserve the MSVC CLI main-thread stack and test the actual executable: library tests had missed an unoptimized startup stack overflow.

## Validation after syncing upstream

Local environment: Windows 11 build 26200, Rust 1.95.0/MSVC, protoc 28.3, Codex 0.153.4, and trufflehog 3.95.5.

- Formatting, full locked Windows Cargo tests (260 library tests plus main/integration targets), and both all-target Clippy backend variants with `-D warnings` passed.
- Native CLI startup passed without `RUST_MIN_STACK`. Detached-worker tests passed for both hooks, covering argument handling, nonblocking foreground behavior, UTF-8 stdout/stderr, empty stderr lines and exit-code logging.
- Ten authenticated checks passed using synthetic memories: previous Lance 7 remote status/recall, first publication, remote recall, repeat no-op, missing-scanner rejection, incremental publication/retrieval/count, and recall after forced reindexing. Upstream-token-gated Cargo tests are not counted as live remote evidence.
- The optimized package passed PE stack-reserve, ZIP and payload checksums, fresh CLI/MCP retrieval, npm Codex add/repeat/remove, and installed-hook indexing followed by recall. A copied Lance 7 local memory remained byte-for-byte unchanged after status/recall. These checks reused downloaded inference models.

See the [updated acceptance record](https://github.com/wellorbetter/funes/blob/8d984901372fe8ee69407fde5d11b7bbccdf2140/openspec/changes/add-windows-minimum-support/acceptance.md) for details. The earlier [Windows CI](https://github.com/wellorbetter/funes/actions/runs/34675875240), [Linux CI](https://github.com/wellorbetter/funes/actions/runs/34675875238), [release builds](https://github.com/wellorbetter/funes/actions/runs/34675875228), and [bidirectional memory exchange](https://github.com/wellorbetter/funes/actions/runs/34675674228) apply to the pre-sync implementation; they are not presented as CI results for this update. This update was validated locally rather than by manually rerunning Actions.

## Reproduction

With MSVC and protoc configured as described in `docs/windows.md`:

```powershell
cargo fmt --check
cargo clippy --all-targets -- -D warnings
cargo clippy --all-targets --no-default-features --features onnx -- -D warnings
cargo test --locked --profile ci --target x86_64-pc-windows-msvc
powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/test-windows.ps1
cargo build --locked --release --target x86_64-pc-windows-msvc --bin funes
```

Clean Windows 10/11 installation journeys and installation from a real versioned Windows asset remain release-qualification checks. Windows ARM64 and automatic Claude/pi/Hermes integrations are outside this initial tier. No release, private conversation log, or credential is included in this submission.
